### PR TITLE
speed up travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: objective-c
 
 before_script: travis/before_script.sh
 script: travis/script.sh
+
+sudo: false
+git:
+  depth: 1


### PR DESCRIPTION
Use the new container-based environment and set the git shallow clone depth to 1 for travis-ci.
