### PR TITLE
Modifies behavior of some keys when the candidate list is appearing

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -11,5 +11,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Clean
         run: xcodebuild -scheme McBopomofo -configuration Release clean
+      - name: Clean
+        run: xcodebuild -scheme McBopomofoInstaller -configuration Release clean
       - name: Build
-        run: xcodebuild -scheme McBopomofo -configuration Release
+        run: xcodebuild -scheme McBopomofo -configuration Release build
+      - name: Build
+        run: xcodebuild -scheme McBopomofoInstaller -configuration Release build
+

--- a/Source/InputMethodController.mm
+++ b/Source/InputMethodController.mm
@@ -1040,7 +1040,10 @@ public:
             return YES;
         }
         else {
-            [self beep];
+            BOOL updated = [gCurrentCandidateController showPreviousPage];
+            if (!updated) {
+                [self beep];
+            }
             [self updateClientComposingBuffer:_currentCandidateClient];
             return YES;
         }
@@ -1055,7 +1058,10 @@ public:
             return YES;
         }
         else {
-            [self beep];
+            BOOL updated = [gCurrentCandidateController showNextPage];
+            if (!updated) {
+                [self beep];
+            }
             [self updateClientComposingBuffer:_currentCandidateClient];
             return YES;
         }

--- a/Source/InputMethodController.mm
+++ b/Source/InputMethodController.mm
@@ -984,14 +984,14 @@ public:
 
 - (BOOL)handleCandidateEventWithInputText:(NSString *)inputText charCode:(UniChar)charCode keyCode:(NSUInteger)keyCode
 {
-    if (_inputMode == kPlainBopomofoModeIdentifier) {
-        if (charCode == '<') {
-            keyCode = kPageUpKeyCode;
-        }
-        else if (charCode == '>') {
-            keyCode = kPageDownKeyCode;
-        }
-    }
+//    if (_inputMode == kPlainBopomofoModeIdentifier) {
+//        if (charCode == '<') {
+//            keyCode = kPageUpKeyCode;
+//        }
+//        else if (charCode == '>') {
+//            keyCode = kPageDownKeyCode;
+//        }
+//    }
 
     BOOL cancelCandidateKey =
         (charCode == 27) ||
@@ -1138,7 +1138,6 @@ public:
         }
 
         if (_inputMode == kPlainBopomofoModeIdentifier) {
-            // TODO: also commit punctuation.
             string layout = [self currentLayout];
             string customPunctuation = string("_punctuation_") + layout + string(1, (char)charCode);
             string punctuation = string("_punctuation_") + string(1, (char)charCode);

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -e
 
 xcodebuild -scheme McBopomofo -configuration Release clean
-xcodebuild -scheme McBopomofo -configuration Release
+xcodebuild -scheme McBopomofo -configuration Release build
+xcodebuild -scheme McBopomofoInstaller -configuration Release clean
+xcodebuild -scheme McBopomofoInstaller -configuration Release build


### PR DESCRIPTION
This fixes #159 and #61.

* Now the users can use the left/right key to go to the next page of the candidate list when using the vertical window.
* Now the plain BPMF input method selects the first candidate when a user types a punctuation symbol. However, the function to use <> keys to go to another page is disabled.