### PR TITLE
Fixes the bug that I forgot to create the user phrases folder.

### DIFF
--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -51,6 +51,12 @@
 
 "Chinese Conversion" = "Convert to Simplified Chinese";
 
+"User Phrases" = "User Phrases";
+
 "Edit User Phrases" = "Edit User Phrases";
 
 "Reload User Phrases" = "Reload User Phrases";
+
+"Unable to create the user phrase file." = "Unable to create the user phrase file.";
+
+"Please check the permission of at \"%@\"." = "Please check the permission of at \"%@\".";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -51,7 +51,12 @@
 
 "Chinese Conversion" = "輸出簡體中文";
 
+"User Phrases" = "使用者詞彙";
+
 "Edit User Phrases" = "編輯使用者詞彙";
 
 "Reload User Phrases" = "重新載入使用者詞彙";
 
+"Unable to create the user phrase file." = "無法建立使用者詞彙檔案";
+
+"Please check the permission of at \"%@\"." = "請檢查以下路徑的寫入權限 \"%@\"。";


### PR DESCRIPTION
There was a legacy user override model which creates a folder and a
plist file. If a user uses McBopomofo for years, the folder would
exist. However, when the old override model was removed, I forgot
to create the folder for the new user phrase file.

The bug would let the users with new installation of McBopomofo unable
to add user phrases.