### PR TITLE
Use backward-compatible Swift in certain places

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -450,8 +450,8 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
         }
 
         keyLabelStripView.keyLabelFont = keyLabelFont
-        let keyLabels = keyLabels[0..<Int(keyLabelCount)].map { $0.displayedText }
-        keyLabelStripView.keyLabels = keyLabels
+        let actualKeyLabels = keyLabels[0..<Int(keyLabelCount)].map { $0.displayedText }
+        keyLabelStripView.keyLabels = actualKeyLabels
         keyLabelStripView.labelOffsetY = (keyLabelFontSize >= candidateFontSize) ? 0.0 : floor((candidateFontSize - keyLabelFontSize) / 2.0)
 
         let rowHeight = ceil(fontSize * 1.25)
@@ -461,7 +461,7 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
         let textAttr: [NSAttributedString.Key: AnyObject] = [.font: keyLabelFont]
         let boundingBox = NSSize(width: 1600.0, height: 1600.0)
 
-        for label in keyLabels {
+        for label in actualKeyLabels {
             let rect = (label as NSString).boundingRect(with: boundingBox, options: .usesLineFragmentOrigin, attributes: textAttr)
             maxKeyLabelWidth = max(rect.size.width, maxKeyLabelWidth)
         }

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -310,9 +310,9 @@ extension McBopomofoInputMethodController {
         // then we defer the update in the next runloop round -- so that the composing buffer is not
         // meaninglessly flushed, an annoying bug in Terminal.app since Mac OS X 10.5
         if (client as? IMKTextInput)?.bundleIdentifier() == "com.apple.Terminal" && NSStringFromClass(client.self as! AnyClass) != "IPMDServerClientWrapper" {
-            let currentDeferredClient = currentDeferredClient
+            let innerCurrentDeferredClient = currentDeferredClient
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now()) {
-                (currentDeferredClient as? IMKTextInput)?.insertText(buffer, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+                (innerCurrentDeferredClient as? IMKTextInput)?.insertText(buffer, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
             }
         }
         (client as? IMKTextInput)?.insertText(buffer, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -247,8 +247,8 @@ class InputState: NSObject {
             let text = (composingBuffer as NSString).substring(with: markedRange)
             let (exactBegin, _) = (composingBuffer as NSString).characterIndex(from: markedRange.location)
             let (exactEnd, _) = (composingBuffer as NSString).characterIndex(from: markedRange.location + markedRange.length)
-            let readings = readings[exactBegin..<exactEnd]
-            let joined = readings.joined(separator: "-")
+            let selectedReadings = readings[exactBegin..<exactEnd]
+            let joined = selectedReadings.joined(separator: "-")
             return "\(text) \(joined)"
         }
     }

--- a/Source/main.swift
+++ b/Source/main.swift
@@ -30,9 +30,9 @@ private func install() -> Int32 {
         return -1
     }
     let bundleUrl = Bundle.main.bundleURL
-    var inputSource = InputSourceHelper.inputSource(for: bundleID)
+    var maybeInputSource = InputSourceHelper.inputSource(for: bundleID)
 
-    if inputSource == nil {
+    if maybeInputSource == nil {
         NSLog("Registering input source \(bundleID) at \(bundleUrl.absoluteString)");
         // then register
         let status = InputSourceHelper.registerTnputSource(at: bundleUrl)
@@ -42,10 +42,10 @@ private func install() -> Int32 {
             return -1
         }
 
-        inputSource = InputSourceHelper.inputSource(for: bundleID)
+        maybeInputSource = InputSourceHelper.inputSource(for: bundleID)
     }
 
-    guard let inputSource = inputSource else {
+    guard let inputSource = maybeInputSource else {
         NSLog("Fatal error: Cannot find input source \(bundleID) after registration.")
         return -1
     }


### PR DESCRIPTION
Older Swift compiler does not allow declaring certain variables that
have the same names with those outside of their scope, even though the
scoping rules should allow them. This makes the code buildable with
Xcode 12.4 again.