### PR TITLE
Fixes regression in how upper case letters are handled when input state is empty

### DIFF
--- a/.github/workflows/continuous-integration-workflow-xcode-12.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-12.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Test NSStringUtils
         run: swift test
         working-directory: Packages/NSStringUtils
+      - name: Clean McBopomofo for testing
+        run: xcodebuild -scheme McBopomofo -configuration Debug clean
+      - name: Test McBopomofo
+        run: xcodebuild -scheme McBopomofo -configuration Debug test
       - name: Clean McBopomofo
         run: xcodebuild -scheme McBopomofo -configuration Release clean
       - name: Clean McBopomofoInstaller

--- a/.github/workflows/continuous-integration-workflow-xcode-latest.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-latest.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Test NSStringUtils
         run: swift test
         working-directory: Packages/NSStringUtils
+      - name: Clean McBopomofo for testing
+        run: xcodebuild -scheme McBopomofo -configuration Debug clean
+      - name: Test McBopomofo
+        run: xcodebuild -scheme McBopomofo -configuration Debug test
       - name: Clean McBopomofo
         run: xcodebuild -scheme McBopomofo -configuration Release clean
       - name: Clean McBopomofoInstaller

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -266,17 +266,40 @@ class KeyHandlerBopomofoTests: XCTestCase {
         }
     }
 
-    func testLetter() {
-        let input = KeyHandlerInput(inputText: "A", keyCode: 0, charCode: charCode("A"), flags: .shift, isVerticalMode: false)
+    // Regression test for #292.
+    func testUppercaseLetterWhenEmpty() {
+        let input = KeyHandlerInput(inputText: "A", keyCode: KeyCode.enter.rawValue, charCode: charCode("A"), flags: [], isVerticalMode: false)
         var state: InputState = InputState.Empty()
-        handler.handle(input: input, state: state) { newState in
+        let result = handler.handle(input: input, state: state) { newState in
+            state = newState
+        } errorCallback: {
+        }
+        XCTAssertFalse(result)
+    }
+
+    // Regression test for #292.
+    func testUppercaseLetterWhenNotEmpty() {
+        var state: InputState = InputState.Empty()
+        let keys = Array("u6").map {
+            String($0)
+        }
+        for key in keys {
+            let input = KeyHandlerInput(inputText: key, keyCode: 0, charCode: charCode(key), flags: [], isVerticalMode: false)
+            handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+        }
+
+        let letterInput = KeyHandlerInput(inputText: "A", keyCode: 0, charCode: charCode("A"), flags: .shift, isVerticalMode: false)
+        handler.handle(input: letterInput, state: state) { newState in
             state = newState
         } errorCallback: {
         }
 
         XCTAssertTrue(state is InputState.Inputting, "\(state)")
         if let state = state as? InputState.Inputting {
-            XCTAssertEqual(state.composingBuffer, "a")
+            XCTAssertEqual(state.composingBuffer, "一a")
         }
     }
 

--- a/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
@@ -25,15 +25,22 @@ import XCTest
 @testable import McBopomofo
 
 class KeyHandlerPlainBopomofoTests: XCTestCase {
+    var savedKeyboardLayout: Int = 0
     var handler = KeyHandler()
 
     override func setUpWithError() throws {
         LanguageModelManager.loadDataModels()
         handler = KeyHandler()
         handler.inputMode = .plainBopomofo
+
+        savedKeyboardLayout = Preferences.keyboardLayout
+
+        // Punctuation-related tests only work when the layout is Standard.
+        Preferences.keyboardLayout = KeyboardLayout.standard.rawValue
     }
 
     override func tearDownWithError() throws {
+        Preferences.keyboardLayout = savedKeyboardLayout
     }
 
     func testPunctuationTable() {

--- a/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
@@ -43,6 +43,17 @@ class KeyHandlerPlainBopomofoTests: XCTestCase {
         Preferences.keyboardLayout = savedKeyboardLayout
     }
 
+    // Regression test for #292.
+    func testUppercaseLetterWhenEmpty() {
+        let input = KeyHandlerInput(inputText: "A", keyCode: KeyCode.enter.rawValue, charCode: charCode("A"), flags: [], isVerticalMode: false)
+        var state: InputState = InputState.Empty()
+        let result = handler.handle(input: input, state: state) { newState in
+            state = newState
+        } errorCallback: {
+        }
+        XCTAssertFalse(result)
+    }
+
     func testPunctuationTable() {
         let input = KeyHandlerInput(inputText: "`", keyCode: 0, charCode: charCode("`"), flags: .shift, isVerticalMode: false)
         var state: InputState = InputState.Empty()

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -541,7 +541,7 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
         return YES;
     }
 
-    if ((char) charCode >= 'A' && (char) charCode <= 'Z') {
+    if ([state isKindOfClass:[InputStateNotEmpty class]] && (char) charCode >= 'A' && (char) charCode <= 'Z') {
         string letter = string("_letter_") + string(1, (char) charCode);
         if ([self _handlePunctuation:letter state:state usingVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback]) {
             return YES;


### PR DESCRIPTION
This fixes #292. Test-driven development makes it easy to confirm the behavior change and fix.

It also makes sure certain Plain BPMF tests are "hermetic" regarding keyboard layout, since the expectations of some punctuation tests are layout-dependent. I'll file a separate issue for future test improvements.

Also, run `McBopomofoTests` as part of the CI workflow.
