### PR TITLE
Modifies the behavior of sole tone mark

### DIFF
--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -493,10 +493,7 @@ class KeyHandlerBopomofoTests: XCTestCase {
             } errorCallback: {
             }
         }
-        XCTAssertTrue(state is InputState.Inputting, "\(state)")
-        if let state = state as? InputState.Inputting {
-            XCTAssertEqual(state.composingBuffer, "ㄙㄛˋ")
-        }
+        XCTAssertTrue(state is InputState.EmptyIgnoringPreviousState, "\(state)")
     }
 
     func testInputting() {
@@ -1484,7 +1481,7 @@ class KeyHandlerBopomofoTests: XCTestCase {
         } errorCallback: {
         }
 
-        XCTAssertTrue(state is InputState.Empty, "\(state)")
+        XCTAssertTrue(state is InputState.EmptyIgnoringPreviousState, "\(state)")
         Preferences.escToCleanInputBuffer = enabled
     }
 

--- a/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
@@ -45,6 +45,8 @@ class KeyHandlerPlainBopomofoTests: XCTestCase {
 
     // Regression test for #292.
     func testUppercaseLetterWhenEmpty() {
+        let tmp = Preferences.letterBehavior
+        Preferences.letterBehavior = 0
         let input = KeyHandlerInput(inputText: "A", keyCode: KeyCode.enter.rawValue, charCode: charCode("A"), flags: [], isVerticalMode: false)
         var state: InputState = InputState.Empty()
         let result = handler.handle(input: input, state: state) { newState in
@@ -52,6 +54,7 @@ class KeyHandlerPlainBopomofoTests: XCTestCase {
         } errorCallback: {
         }
         XCTAssertFalse(result)
+        Preferences.letterBehavior = tmp
     }
 
     func testPunctuationTable() {

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -471,7 +471,7 @@
             <rect key="frame" x="0.0" y="0.0" width="477" height="175"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
                     <rect key="frame" x="18" y="139" width="137" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="User Phrase Location:" id="Sc6-Rd-pOy">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -517,7 +517,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="liS-L1-RTD"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
                     <rect key="frame" x="20" y="20" width="439" height="28"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="435" id="5et-IU-3aG"/>
@@ -562,6 +562,7 @@
                 <constraint firstItem="VEv-3b-PV4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="z8D-qk-sAN" secondAttribute="trailing" constant="8" symbolic="YES" id="9tO-41-XBh"/>
                 <constraint firstItem="z8D-qk-sAN" firstAttribute="top" secondItem="jIf-hP-5m5" secondAttribute="bottom" constant="17" id="KKk-Ye-xfr"/>
                 <constraint firstItem="VEv-3b-PV4" firstAttribute="centerY" secondItem="dY1-Wz-mrw" secondAttribute="centerY" id="KQJ-fm-UVm"/>
+                <constraint firstAttribute="trailing" secondItem="svr-IJ-6mz" secondAttribute="trailing" constant="20" symbolic="YES" id="MR7-Fg-Auy"/>
                 <constraint firstItem="jIf-hP-5m5" firstAttribute="leading" secondItem="z8D-qk-sAN" secondAttribute="leading" id="Y2f-Ms-Jkv"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jIf-hP-5m5" secondAttribute="trailing" constant="20" symbolic="YES" id="aC6-ep-0LG"/>
                 <constraint firstItem="dY1-Wz-mrw" firstAttribute="leading" secondItem="VEv-3b-PV4" secondAttribute="trailing" constant="8" symbolic="YES" id="ali-13-uRi"/>

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -466,6 +466,13 @@ class BopomofoReadingBuffer {
 
   bool hasToneMarker() const { return syllable_.hasToneMarker(); }
 
+  bool hasToneMarkerOnly() const {
+    return syllable_.hasToneMarker() &&
+          !(syllable_.hasConsonant() || syllable_.hasMiddleVowel() ||
+            syllable_.hasVowel());
+  }
+
+
  protected:
   const BopomofoKeyboardLayout* layout_;
   BPMF syllable_;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -594,7 +594,7 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
         // Bopomofo reading, in odds with the expectation of users from
         // other platforms
 
-        if (!_bpmfReadingBuffer->isEmpty() || _bpmfReadingBuffer->hasToneMarkerOnly()) {
+        if (!_bpmfReadingBuffer->isEmpty()) {
             _bpmfReadingBuffer->clear();
             if (!_builder->length()) {
                 InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];

--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -230,9 +230,8 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
 
     @IBAction func openUserPhrasedFolderAction(_ sender: Any) {
         let path =
-         (Preferences.useCustomUserPhraseLocation ?
+         Preferences.useCustomUserPhraseLocation ?
             Preferences.customUserPhraseLocation :
-            UserPhraseLocationHelper.defaultUserPhraseLocation) ??
             UserPhraseLocationHelper.defaultUserPhraseLocation
         let url = URL(fileURLWithPath: path)
         NSWorkspace.shared.open(url)

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -40,7 +40,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSi-pH-F8f">
-                    <rect key="frame" x="181" y="426" width="99" height="25"/>
+                    <rect key="frame" x="185" y="426" width="95" height="25"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="iXH-DJ-dBb">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -70,7 +70,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6eT-rC-gVz">
-                    <rect key="frame" x="181" y="396" width="236" height="25"/>
+                    <rect key="frame" x="185" y="396" width="232" height="25"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="M0n-R9-S5B">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -444,7 +444,7 @@
             <rect key="frame" x="0.0" y="0.0" width="439" height="177"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
                     <rect key="frame" x="18" y="141" width="111" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="使用者詞彙位置：" id="ulY-l0-tqg">
                         <font key="font" metaFont="system"/>
@@ -485,7 +485,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="KRZ-JC-JCe"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
                     <rect key="frame" x="19" y="20" width="401" height="28"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="397" id="PDr-LU-81S"/>


### PR DESCRIPTION
McBopomofo allows users to input sole tone mark like "ˇ", "ˋ", "ˊ", and "˙ " into the composing buffer when lots of other Zhuyin input methods decide it is an error to input a tone mark with any syllable. It helps users to type tone marks when they want to edit custom phrases but this behavior is annoying.

- When a user wants to type ㄚ(8 in the standard layout), he or she may wrongly type 7(˙) and then the tone mark is just sent to the buffer.
- When a user wants to type 以(u3)， he or she may type 3u since the keys requires two hands and it causes the output become ˇㄧ.

The PR changes the behavior. Now we have error tolerance and allow the users to type ˇㄧ to become 以, but ˇㄅ is still an error input. If a user really want to type a sole tone mark, now a space key after the tone mark is required.
