### PR TITLE
Fixes the flow to fix the nodes at front of the composing buffer. 

### DIFF
--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -367,7 +367,6 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
 
         // then walk the lattice
         NSString *poppedText = [self _popOverflowComposingTextAndWalk];
-        [self fixNodesIfRequired];
 
         // get user override model suggestion
         std::string overrideValue = (_inputMode == InputModePlainBopomofo) ? "" : _userOverrideModel->suggest(_walkedNodes, _builder->cursorIndex(), [[NSDate date] timeIntervalSince1970]);
@@ -378,6 +377,8 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
             double highestScore = FindHighestScore(nodes, kEpsilon);
             _builder->grid().overrideNodeScoreForSelectedCandidate(cursorIndex, overrideValue, static_cast<float>(highestScore));
         }
+
+        [self fixNodesIfRequired];
 
         // then update the text
         _bpmfReadingBuffer->clear();
@@ -1407,7 +1408,7 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
             }
             if (node.node->score() < Formosa::Gramambular::kSelectedCandidateScore) {
                 auto candidate = node.node->currentKeyValue().value;
-                _builder->grid().fixNodeSelectedCandidate(index + 1, candidate);
+                _builder->grid().fixNodeSelectedCandidate(index + node.spanningLength, candidate);
             }
             index += node.spanningLength;
         }

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -583,10 +583,15 @@ static NSString *const kGraphVizOutputfile = @"/tmp/McBopomofo-visualization.dot
 
 - (BOOL)_handleTabState:(InputState *)state shiftIsHold:(BOOL)shiftIsHold stateCallback:(void (^)(InputState *))stateCallback errorCallback:(void (^)(void))errorCallback
 {
+    if (!_builder->length()) {
+        return NO;
+    }
+
     if (![state isKindOfClass:[InputStateInputting class]]) {
         errorCallback();
         return YES;
     }
+
     if (!_bpmfReadingBuffer->isEmpty()) {
         errorCallback();
         return YES;


### PR DESCRIPTION
Fixes the flow to fix the nodes at front of the composing buffer.

In the previous PR I put the code before user override models suggestion. It causes the fixes node to be set to another score. Fixed.

I used a workaround yesterday to fix the nodes at front by code like "fixNode(offset + 1)", but it was buggy, and sometimes causes crashes.

Once we change the order to walk through the tree, we cannot just reset the score of the nodes crossing or ending at a given location, but the nodes in the range of the spanning length.

In a range of 台灣人 may contain nodes like 台灣 and 人, once we only reset the nodes crossing or ends at the end index 3, it won't effect the node 台灣, but if we handle only the index, it won't apply to 人. We have to change the way to find effect nodes to reset both 台灣 and 人. Merely using (index + 1) looks right but it is actually wrong.

Also let the tab key handler to handle empty states correctly.
