### PR TITLE
Cross-platform test improvements

### DIFF
--- a/.github/workflows/continuous-integration-workflow-xcode-12.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-12.yml
@@ -16,19 +16,19 @@ jobs:
         run: cmake -S . -B build
         working-directory: Source/Engine
       - name: Run McBopomofoLMLibTest
-        run: make runTest
+        run: make runMcBopomofoLMLibTest
         working-directory: Source/Engine/build
       - name: Build MandarinTest
         run: cmake -S . -B build
         working-directory: Source/Engine/Mandarin
       - name: Run MandarinTest
-        run: make runTest
+        run: make runMandarinTest
         working-directory: Source/Engine/Mandarin/build
       - name: Build GramambularTest
         run: cmake -S . -B build
         working-directory: Source/Engine/Gramambular
       - name: Run GramambularTest
-        run: make runTest
+        run: make runGramambularTest
         working-directory: Source/Engine/Gramambular/build
       - name: Test McBopomofo App Bundle
         run: xcodebuild -scheme McBopomofo -configuration Debug test

--- a/.github/workflows/continuous-integration-workflow-xcode-latest.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-latest.yml
@@ -16,19 +16,19 @@ jobs:
         run: cmake -S . -B build
         working-directory: Source/Engine
       - name: Run McBopomofoLMLibTest
-        run: make runTest
+        run: make runMcBopomofoLMLibTest
         working-directory: Source/Engine/build
       - name: Build MandarinTest
         run: cmake -S . -B build
         working-directory: Source/Engine/Mandarin
       - name: Run MandarinTest
-        run: make runTest
+        run: make runMandarinTest
         working-directory: Source/Engine/Mandarin/build
       - name: Build GramambularTest
         run: cmake -S . -B build
         working-directory: Source/Engine/Gramambular
       - name: Run GramambularTest
-        run: make runTest
+        run: make runGramambularTest
         working-directory: Source/Engine/Gramambular/build
       - name: Test McBopomofo App Bundle
         run: xcodebuild -scheme McBopomofo -configuration Debug test

--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -41,10 +41,10 @@ include(GoogleTest)
 gtest_discover_tests(McBopomofoLMLibTest)
 
 add_custom_target(
-        runTest
+        runMcBopomofoLMLibTest
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/McBopomofoLMLibTest
 )
-add_dependencies(runTest McBopomofoLMLibTest)
+add_dependencies(runMcBopomofoLMLibTest McBopomofoLMLibTest)
 
 # Benchmark target; to run, manually uncomment the lines below.
 #

--- a/Source/Engine/Gramambular/CMakeLists.txt
+++ b/Source/Engine/Gramambular/CMakeLists.txt
@@ -25,7 +25,7 @@ include(GoogleTest)
 gtest_discover_tests(GramambularTest)
 
 add_custom_target(
-        runTest
+        runGramambularTest
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GramambularTest
 )
-add_dependencies(runTest GramambularTest)
+add_dependencies(runGramambularTest GramambularTest)

--- a/Source/Engine/Mandarin/CMakeLists.txt
+++ b/Source/Engine/Mandarin/CMakeLists.txt
@@ -25,7 +25,7 @@ include(GoogleTest)
 gtest_discover_tests(MandarinTest)
 
 add_custom_target(
-        runTest
+        runMandarinTest
         COMMAND ${CMAKE_CURRENT_BINARY_DIR}/MandarinTest
 )
-add_dependencies(runTest MandarinTest)
+add_dependencies(runMandarinTest MandarinTest)

--- a/Source/Engine/PhraseReplacementMapTest.cpp
+++ b/Source/Engine/PhraseReplacementMapTest.cpp
@@ -33,8 +33,7 @@ namespace McBopomofo {
 TEST(PhraseReplacementMapTest, LenientReading)
 {
     std::string tmp_name
-        = std::string(std::filesystem::temp_directory_path()) + "test.txt";
-
+        = std::string(std::filesystem::temp_directory_path() / "test.txt");
     FILE* f = fopen(tmp_name.c_str(), "w");
     ASSERT_NE(f, nullptr);
 

--- a/Source/Engine/UserPhrasesLMTest.cpp
+++ b/Source/Engine/UserPhrasesLMTest.cpp
@@ -33,7 +33,7 @@ namespace McBopomofo {
 TEST(UserPhreasesLMTest, LenientReading)
 {
     std::string tmp_name
-        = std::string(std::filesystem::temp_directory_path()) + "test.txt";
+        = std::string(std::filesystem::temp_directory_path() / "test.txt");
 
     FILE* f = fopen(tmp_name.c_str(), "w");
     ASSERT_NE(f, nullptr);


### PR DESCRIPTION
Some tests fail when run on Linux, and it turns out that the paths were not concatenated correctly--C++'s `std::filesystem::path` supports `operator/()` for that.

This PR also renames the test target names so that the CMake projects can become another project`s subprojects.
