### PR TITLE
修正一些讀音錯誤的詞

### DIFF
--- a/Source/Data/analysis.py
+++ b/Source/Data/analysis.py
@@ -1,0 +1,128 @@
+with open('data.txt') as f:
+    lines = f.readlines()
+
+data = [ln.strip().split(' ') for ln in lines[1:] if not ln.startswith('_')]
+
+data = [(d[0].split('-'), d[1], float(d[2])) for d in data]
+
+unigram_1char = {}
+value_to_score = {}
+
+unigram_1char_count = 0
+unigram_multichar_count = 0
+
+for (r, v, s) in data:
+    # Skip emojis.
+    if s == -8:
+        continue
+
+    if v in value_to_score:
+        if s > value_to_score[v]:
+            value_to_score[v] = s
+    else:
+        value_to_score[v] = s
+
+    if len(r) > 1:
+        unigram_multichar_count += 1
+        continue
+    unigram_1char_count += 1
+
+    k = r[0]
+    if k in unigram_1char:
+        if s > unigram_1char[k][1]:
+            unigram_1char[k] = (v, s)
+    else:
+        unigram_1char[k] = (v, s)
+
+faulty = []
+indifferents = []
+insufficients = []
+competing_unigrams = []
+
+for (r, v, s) in data:
+    if len(r) < 2:
+        continue
+
+    # Skip all emojis.
+    if s == -8:
+        continue
+
+    comp = []
+    ts = 0
+    bad = False
+    for x in r:
+        if x not in unigram_1char:
+            bad = True
+            break
+
+        uv, us = unigram_1char[x]
+        ts += us
+        comp.append((uv, us))
+
+    if bad:
+        faulty.append((r, v))
+        continue
+
+    if ts >= s:
+        i = (r, v, s, comp, (s - ts))
+
+        k = ''.join([x[0] for x in comp])
+
+        if v == k:
+            indifferents.append(i)
+        else:
+            if k in value_to_score and v != k:
+                if s < value_to_score[k]:
+                    competing_unigrams.append((v, s, k, value_to_score[k]))
+            insufficients.append(i)
+
+insufficients = sorted(insufficients, key=lambda i: i[2], reverse=True)
+competing_unigrams = sorted(
+    competing_unigrams, key=lambda i: i[1] - i[3], reverse=True)
+
+separator = '-' * 72
+print(separator)
+print('%6d unigrams with one character' % unigram_1char_count)
+print('%6d unigrams with multiple characters' % unigram_multichar_count)
+
+print(separator)
+print('summary for unigrams with scores lower than their competing characters:')
+print('%6d unigrams that are indifferent since the characters are the same' %
+      len(indifferents))
+print('%6d unigrams that are not the top candidate (%.1f%% of unigrams)' %
+      (len(insufficients),
+       len(insufficients) / float(unigram_multichar_count) * 100.0))
+print('\nof which:')
+
+insufficients_map = {}
+for x in range(2, 7):
+    insufficients_map[x] = [i for i in insufficients if len(i[0]) == x]
+
+print('  %6d 2-character unigrams' % len(insufficients_map[2]))
+print('  %6d 3-character unigrams' % len(insufficients_map[3]))
+print('  %6d 4-character unigrams' % len(insufficients_map[4]))
+print('  %6d 5-character unigrams' % len(insufficients_map[5]))
+print('  %6d 6-character unigrams' % len(insufficients_map[6]))
+
+print(separator)
+print('top insufficient 2-character unigrams')
+for i in insufficients_map[2][:25]:
+    print(i)
+
+print(separator)
+print('all insufficient 3-character unigrams')
+for i in insufficients_map[3]:
+    print(i)
+
+print(separator)
+print('%d unigrams also compete with unigrams from top composing characters' %
+      len(competing_unigrams))
+print('some samples:')
+for i in competing_unigrams[:25]:
+    print(i)
+
+if faulty:
+    print(separator)
+    print('The following unigrams cannot be typed:')
+    for f in faulty:
+        print(f)


### PR DESCRIPTION
PR 中列舉的詞用到了不存在的讀音，所以無法輸入。

此外為了瞭解 #300 所列「雙字詞分數比不過個別最高分數成員字」問題的普遍程度，PR 中的 analysis.py 同時列出有該問題的雙字詞及三字詞。例如「依舊」雖然在詞庫中，分數怎麼樣也比不過「一」與「就」兩個最高分數的同音字。

有一些雙字詞或許可以靠手動提高詞頻的方式處理（？），但並不是所有有此現象的雙字詞都應該如此處理。例如「它的」跟「他的」比起來，還是「他的」比較常見。

許多問題從修改 user override model 用戶選字記憶機制下手，可能比較實際。
