### PR TITLE
Improve user override model effectiveness

### DIFF
--- a/Source/Engine/AssociatedPhrases.cpp
+++ b/Source/Engine/AssociatedPhrases.cpp
@@ -27,10 +27,10 @@
 
 #include "AssociatedPhrases.h"
 
-#include <sys/mman.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 #include <fstream>
+#include <sys/mman.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include "KeyValueBlobReader.h"
@@ -38,9 +38,9 @@
 namespace McBopomofo {
 
 AssociatedPhrases::AssociatedPhrases()
-: fd(-1)
-, data(0)
-, length(0)
+    : fd(-1)
+    , data(0)
+    , length(0)
 {
 }
 
@@ -51,7 +51,7 @@ AssociatedPhrases::~AssociatedPhrases()
     }
 }
 
-const bool AssociatedPhrases::isLoaded()
+bool AssociatedPhrases::isLoaded()
 {
     if (data) {
         return true;
@@ -59,7 +59,7 @@ const bool AssociatedPhrases::isLoaded()
     return false;
 }
 
-bool AssociatedPhrases::open(const char *path)
+bool AssociatedPhrases::open(const char* path)
 {
     if (data) {
         return false;
@@ -87,8 +87,7 @@ bool AssociatedPhrases::open(const char *path)
 
     KeyValueBlobReader reader(static_cast<char*>(data), length);
     KeyValueBlobReader::KeyValue keyValue;
-    KeyValueBlobReader::State state;
-    while ((state = reader.Next(&keyValue)) == KeyValueBlobReader::State::HAS_PAIR) {
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
         keyRowMap[keyValue.key].emplace_back(keyValue.key, keyValue.value);
     }
     return true;
@@ -113,15 +112,15 @@ const std::vector<std::string> AssociatedPhrases::valuesForKey(const std::string
         const std::vector<Row>& rows = iter->second;
         for (const auto& row : rows) {
             std::string_view value = row.value;
-            v.push_back({value.data(), value.size()});
+            v.push_back({ value.data(), value.size() });
         }
     }
     return v;
 }
 
-const bool AssociatedPhrases::hasValuesForKey(const std::string& key)
+bool AssociatedPhrases::hasValuesForKey(const std::string& key)
 {
     return keyRowMap.find(key) != keyRowMap.end();
 }
 
-};  // namespace McBopomofo
+} // namespace McBopomofo

--- a/Source/Engine/AssociatedPhrases.h
+++ b/Source/Engine/AssociatedPhrases.h
@@ -28,28 +28,31 @@
 #ifndef ASSOCIATEDPHRASES_H
 #define ASSOCIATEDPHRASES_H
 
-#include <string>
-#include <map>
 #include <iostream>
+#include <map>
+#include <string>
 #include <vector>
 
 namespace McBopomofo {
 
-class AssociatedPhrases
-{
+class AssociatedPhrases {
 public:
     AssociatedPhrases();
     ~AssociatedPhrases();
 
-    const bool isLoaded();
-    bool open(const char *path);
+    bool isLoaded();
+    bool open(const char* path);
     void close();
     const std::vector<std::string> valuesForKey(const std::string& key);
-    const bool hasValuesForKey(const std::string& key);
+    bool hasValuesForKey(const std::string& key);
 
 protected:
     struct Row {
-        Row(std::string_view& k, std::string_view& v) : key(k), value(v) {}
+        Row(std::string_view& k, std::string_view& v)
+            : key(k)
+            , value(v)
+        {
+        }
         std::string_view key;
         std::string_view value;
     };
@@ -57,10 +60,10 @@ protected:
     std::map<std::string_view, std::vector<Row>> keyRowMap;
 
     int fd;
-    void *data;
+    void* data;
     size_t length;
 };
 
 }
 
-#endif /* AssociatedPhrases_hpp */
+#endif // ASSOCIATEDPHRASES_H

--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -7,6 +7,8 @@ add_subdirectory(gramambular2)
 
 include_directories("Gramambular")
 add_library(McBopomofoLMLib
+        AssociatedPhrases.h
+        AssociatedPhrases.cpp
         KeyValueBlobReader.cpp
         KeyValueBlobReader.h
         ParselessPhraseDB.cpp
@@ -15,6 +17,8 @@ add_library(McBopomofoLMLib
         ParselessLM.h
         PhraseReplacementMap.h
         PhraseReplacementMap.cpp
+        UserOverrideModel.h
+        UserOverrideModel.cpp
         UserPhrasesLM.h
         UserPhrasesLM.cpp)
 
@@ -37,8 +41,9 @@ add_executable(McBopomofoLMLibTest
         ParselessLMTest.cpp
         ParselessPhraseDBTest.cpp
         PhraseReplacementMapTest.cpp
+        UserOverrideModelTest.cpp
         UserPhrasesLMTest.cpp)
-target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib)
+target_link_libraries(McBopomofoLMLibTest gtest_main McBopomofoLMLib gramambular2_lib)
 include(GoogleTest)
 gtest_discover_tests(McBopomofoLMLibTest)
 

--- a/Source/Engine/Mandarin/Mandarin.cpp
+++ b/Source/Engine/Mandarin/Mandarin.cpp
@@ -31,8 +31,7 @@ namespace Mandarin {
 
 class PinyinParseHelper {
  public:
-  static const bool ConsumePrefix(std::string& target,
-                                  const std::string& prefix) {
+  static bool ConsumePrefix(std::string& target, const std::string& prefix) {
     if (target.length() < prefix.length()) {
       return false;
     }
@@ -601,10 +600,10 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
 const std::string BPMF::composedString() const {
   std::string result;
 #define APPEND(c)                                                         \
-  if (syllable_ & c)                                                     \
+  if (syllable_ & c)                                                      \
   result +=                                                               \
       (*BopomofoCharacterMap::SharedInstance().componentToCharacter.find( \
-           syllable_ & c))                                               \
+           syllable_ & c))                                                \
           .second
   APPEND(ConsonantMask);
   APPEND(MiddleVowelMask);
@@ -613,8 +612,6 @@ const std::string BPMF::composedString() const {
 #undef APPEND
   return result;
 }
-
-
 
 const BopomofoCharacterMap& BopomofoCharacterMap::SharedInstance() {
   static BopomofoCharacterMap* map = new BopomofoCharacterMap();

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -67,9 +67,7 @@ class BopomofoSyllable {
 
   Component consonantComponent() const { return syllable_ & ConsonantMask; }
 
-  Component middleVowelComponent() const {
-    return syllable_ & MiddleVowelMask;
-  }
+  Component middleVowelComponent() const { return syllable_ & MiddleVowelMask; }
 
   Component vowelComponent() const { return syllable_ & VowelMask; }
 
@@ -113,8 +111,8 @@ class BopomofoSyllable {
 
   const BopomofoSyllable operator+(const BopomofoSyllable& another) const {
     Component newSyllable = syllable_;
-#define OP_SOVER(mask) \
-  if (another.syllable_ & mask) { \
+#define OP_SOVER(mask)                                                \
+  if (another.syllable_ & mask) {                                     \
     newSyllable = (newSyllable & ~mask) | (another.syllable_ & mask); \
   }
     OP_SOVER(ConsonantMask);
@@ -126,8 +124,8 @@ class BopomofoSyllable {
   }
 
   BopomofoSyllable& operator+=(const BopomofoSyllable& another) {
-#define OPE_SOVER(mask) \
-  if (another.syllable_ & mask) { \
+#define OPE_SOVER(mask)                                           \
+  if (another.syllable_ & mask) {                                 \
     syllable_ = (syllable_ & ~mask) | (another.syllable_ & mask); \
   }
     OPE_SOVER(ConsonantMask);
@@ -183,7 +181,7 @@ class BopomofoKeyboardLayout {
 
   BopomofoKeyboardLayout(const BopomofoKeyToComponentMap& ktcm,
                          const std::string& name)
-      : m_keyToComponent(ktcm), m_name(name) {
+      : m_name(name), m_keyToComponent(ktcm) {
     for (BopomofoKeyToComponentMap::const_iterator miter =
              m_keyToComponent.begin();
          miter != m_keyToComponent.end(); ++miter)
@@ -382,6 +380,8 @@ class BopomofoReadingBuffer {
     }
   }
 
+  const BopomofoKeyboardLayout* keyboardLayout() const { return layout_; }
+
   bool isValidKey(char k) const {
     if (!pinyin_mode_) {
       return layout_ ? (layout_->keyToComponents(k)).size() > 0 : false;
@@ -468,10 +468,9 @@ class BopomofoReadingBuffer {
 
   bool hasToneMarkerOnly() const {
     return syllable_.hasToneMarker() &&
-          !(syllable_.hasConsonant() || syllable_.hasMiddleVowel() ||
-            syllable_.hasVowel());
+           !(syllable_.hasConsonant() || syllable_.hasMiddleVowel() ||
+             syllable_.hasVowel());
   }
-
 
  protected:
   const BopomofoKeyboardLayout* layout_;

--- a/Source/Engine/UserOverrideModel.h
+++ b/Source/Engine/UserOverrideModel.h
@@ -36,25 +36,42 @@ class UserOverrideModel {
 public:
     UserOverrideModel(size_t capacity, double decayConstant);
 
-    void observe(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-        size_t cursorIndex,
-        const std::string& candidate,
+    struct Suggestion {
+        Suggestion() = default;
+        Suggestion(std::string c, bool f)
+            : candidate(std::move(c))
+            , forceHighScoreOverride(f)
+        {
+        }
+        std::string candidate;
+        bool forceHighScoreOverride = false;
+
+        [[nodiscard]] bool empty() const
+        {
+            return candidate.empty();
+        }
+    };
+
+    void observe(
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& walkBeforeUserOverride,
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& walkAfterUserOverride,
+        size_t cursor,
         double timestamp);
 
-    std::string suggest(const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& walkedNodes,
-        size_t cursorIndex,
+    Suggestion suggest(
+        const Formosa::Gramambular2::ReadingGrid::WalkResult& currentWalk,
+        size_t cursor,
         double timestamp);
+
+    void observe(const std::string& key, const std::string& candidate, double timestamp, bool forceHighScoreOverride = false);
+
+    Suggestion suggest(const std::string& key, double timestamp);
 
 private:
     struct Override {
-        size_t count;
-        double timestamp;
-
-        Override()
-            : count(0)
-            , timestamp(0.0)
-        {
-        }
+        size_t count = 0;
+        double timestamp = 0;
+        bool forceHighScoreOverride = false;
     };
 
     struct Observation {
@@ -65,7 +82,7 @@ private:
             : count(0)
         {
         }
-        void update(const std::string& candidate, double timestamp);
+        void update(const std::string& candidate, double timestamp, bool forceHighScoreOverride);
     };
 
     typedef std::pair<std::string, Observation> KeyObservationPair;
@@ -76,6 +93,6 @@ private:
     std::map<std::string, std::list<KeyObservationPair>::iterator> m_lruMap;
 };
 
-}; // namespace McBopomofo
+} // namespace McBopomofo
 
 #endif

--- a/Source/Engine/UserOverrideModelTest.cpp
+++ b/Source/Engine/UserOverrideModelTest.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "UserOverrideModel.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+namespace {
+    constexpr double kFakeNow = 1657772432;
+    constexpr int kCapacity = 5;
+    constexpr double kHalflife = 5400.0; // 1.5 hr.
+} // namespace
+
+TEST(UserOverrideModelTest, BasicOperation)
+{
+    UserOverrideModel uom(kCapacity, kHalflife);
+    std::string key = "abc";
+    std::string candidate = "v";
+    uom.observe(key, candidate, kFakeNow);
+
+    auto v = uom.suggest(key, kFakeNow);
+    ASSERT_EQ(v.candidate, candidate);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 1);
+    ASSERT_EQ(v.candidate, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 5);
+    ASSERT_EQ(v.candidate, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 10);
+    ASSERT_EQ(v.candidate, candidate);
+    v = uom.suggest(key, kFakeNow + kHalflife * 20);
+    ASSERT_EQ(v.candidate, candidate);
+
+    // The suggestion is no longer valid after ~30 hours.
+    v = uom.suggest(key, kFakeNow + kHalflife * 21);
+    ASSERT_TRUE(v.empty());
+}
+
+TEST(UserOverrideModelTest, FreshVsFrequent)
+{
+    UserOverrideModel uom(kCapacity, kHalflife);
+    std::string key = "abc";
+    std::string olderValue = "older";
+    std::string newerValue = "newer";
+
+    uom.observe(key, olderValue, kFakeNow);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 1);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 2);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 3);
+    uom.observe(key, olderValue, kFakeNow + kHalflife * 4);
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 5);
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 5.25);
+
+    // Even if newerValue is more recent, olderValue is used more frequently,
+    // and so initially olderValue is still suggested.
+    auto v = uom.suggest(key, kFakeNow + kHalflife * 7);
+    ASSERT_EQ(v.candidate, olderValue);
+    v = uom.suggest(key, kFakeNow + kHalflife * 20);
+    ASSERT_EQ(v.candidate, olderValue);
+    v = uom.suggest(key, kFakeNow + kHalflife * 22);
+    ASSERT_EQ(v.candidate, olderValue);
+
+    // At this point, even if olderValue hasn't expired yet, but the
+    // less-frequently observed newerValue is fresher.
+    uom.observe(key, newerValue, kFakeNow + kHalflife * 23);
+    v = uom.suggest(key, kFakeNow + kHalflife * 23.5);
+    ASSERT_EQ(v.candidate, newerValue);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 25);
+    ASSERT_EQ(v.candidate, newerValue);
+
+    v = uom.suggest(key, kFakeNow + kHalflife * 45);
+    ASSERT_TRUE(v.empty());
+}
+
+TEST(UserOverrideModelTest, LRUBehavior)
+{
+    UserOverrideModel uom(2, kHalflife);
+    uom.observe("abc", "x", kFakeNow);
+    uom.observe("def", "y", kFakeNow + kHalflife);
+    uom.observe("ghi", "z", kFakeNow + kHalflife * 2);
+
+    auto v = uom.suggest("ghi", kFakeNow + kHalflife * 3);
+    ASSERT_EQ(v.candidate, "z");
+
+    v = uom.suggest("def", kFakeNow + kHalflife * 4);
+    ASSERT_EQ(v.candidate, "y");
+
+    // abc evicted.
+    v = uom.suggest("abc", kFakeNow + kHalflife * 5);
+    ASSERT_TRUE(v.empty());
+
+    uom.observe("jkl", "p", kFakeNow + kHalflife * 6);
+
+    v = uom.suggest("ghi", kFakeNow + kHalflife * 7);
+    ASSERT_EQ(v.candidate, "z");
+
+    // def evicted.
+    v = uom.suggest("def", kFakeNow + kHalflife * 7);
+    ASSERT_TRUE(v.empty());
+}
+
+} // namespace McBopomofo

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -154,12 +154,21 @@ class ReadingGrid {
 
   struct WalkResult {
     std::vector<NodePtr> nodes;
+    size_t totalReadings;
     size_t vertices;
     size_t edges;
     uint64_t elapsedMicroseconds;
 
-    std::vector<std::string> valuesAsStrings();
-    std::vector<std::string> readingsAsStrings();
+    // Convenient method for finding the node at the cursor. Returns
+    // nodes.cend() if the value of cursor argument doesn't make sense. An
+    // optional ourCursorPastNode argument can be used to obtain the cursor
+    // position that is right past the node at cursor, and will be only be set
+    // if it's not nullptr and the returned iterator is not nodes.cend().
+    std::vector<NodePtr>::const_iterator findNodeAt(
+        size_t cursor, size_t* outCursorPastNode = nullptr) const;
+
+    std::vector<std::string> valuesAsStrings() const;
+    std::vector<std::string> readingsAsStrings() const;
   };
 
   WalkResult walk();

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -207,11 +207,13 @@ TEST(ReadingGridTest, Span) {
   ASSERT_EQ(span.maxLength(), 0);
   ASSERT_EQ(span.nodeOf(1), nullptr);
 
+#ifndef NDEBUG
   auto n10 = std::make_shared<ReadingGrid::Node>("", 10, lm.getUnigrams(""));
   ASSERT_DEATH({ (void)span.add(n10); }, "Assertion");
   ASSERT_DEATH({ (void)span.nodeOf(0); }, "Assertion");
   ASSERT_DEATH({ (void)span.nodeOf(ReadingGrid::kMaximumSpanLength + 1); },
                "Assertion");
+#endif
 }
 
 TEST(ReadingGridTest, ScoreRankedLanguageModel) {


### PR DESCRIPTION
根據 #328 的分析，發現詞庫中不少雙字詞，分數小於最高分同音單字詞，例如「依舊」的分數比不過「一」與「就」加起來。這其中有些或許可以從改善資料下手，但另一個長久以來的問題是：用戶選字記憶機制，並沒有正確把雙字詞的選字結果記起來。這中間問題很多，簡單說是跟 UserOverrideModel 怎麼決定選字事件，以及在建議雙字詞 override 時，沒有給足夠高的分數造成的。

這個 PR 做了不少重構，讓 UserOverrideModel 可以對 walked nodes 作比較精細的處理。

Demo 請參考 fcitx5-mcbopomofo [PR#63](https://github.com/openvanilla/fcitx5-mcbopomofo/pull/63)。

Also sync with the engine code with fcitx5-mcbopomofo. Some source files are formatted or updated to address clang-tidy issues.

Fixes #300