### PR TITLE
test: verify covering ambiguity (first discussed in #300)

### DIFF
--- a/Source/Data/term_score_verification/playground.ipynb
+++ b/Source/Data/term_score_verification/playground.ipynb
@@ -1,0 +1,735 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from functools import lru_cache\n",
+    "from itertools import combinations\n",
+    "\n",
+    "import pandas as pd\n",
+    "from tqdm.auto import tqdm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@lru_cache(maxsize=None)\n",
+    "def get_prefix(v, s):\n",
+    "    return (\"-\".join(s[:v[0]]),)\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def get_suffix(v, s):\n",
+    "    return (\"-\".join(s[v[-1]:]),)\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def get_infix(v, s, j):\n",
+    "    return \"-\".join(s[v[j]:v[j+1]])\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def map_intervals_to_syllable_segments(vs, s):\n",
+    "    return [\n",
+    "        get_prefix(v, s)\n",
+    "            + tuple(get_infix(v, s, j) for j in range(len(v)-1))\n",
+    "            + get_suffix(v, s)\n",
+    "        for v in vs\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def get_top1_script_and_logprob(hyphenated_syllable_str):\n",
+    "    test_df = zh_Hant_df[zh_Hant_df[\"transcript\"] == hyphenated_syllable_str]\n",
+    "    if 0 == test_df.size:\n",
+    "        return \"<unk>\", -float(\"inf\")\n",
+    "    top1_df = test_df.loc[test_df.logprob.idxmax()]\n",
+    "    return top1_df.script, top1_df.logprob\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def get_argmax_script_seg_and_logprob_sum(hyphenated_syllable_str_tpl):\n",
+    "    pairs = list(zip(*map(get_top1_script_and_logprob, hyphenated_syllable_str_tpl)))\n",
+    "    return \"\".join(pairs[0]), sum(pairs[1])\n",
+    "\n",
+    "\n",
+    "@lru_cache(maxsize=None)\n",
+    "def get_best_alt_t_seg(hyphenated_syllable):\n",
+    "    partitions = []\n",
+    "    s = hyphenated_syllable.split(\"-\")\n",
+    "    max_len = len(s)\n",
+    "\n",
+    "    s_tpl = tuple(s)\n",
+    "    for i in range(1, max_len):\n",
+    "        intervals = tuple(combinations(range(1, max_len), i))\n",
+    "        alt_t_segs = map_intervals_to_syllable_segments(intervals, s_tpl)\n",
+    "\n",
+    "        for alt_t_seg in alt_t_segs:\n",
+    "            alt_s, alt_l = get_argmax_script_seg_and_logprob_sum(alt_t_seg)\n",
+    "            if alt_l > -float(\"inf\"):\n",
+    "                partitions += [(alt_t_seg, alt_s, alt_l)]\n",
+    "    if not partitions:\n",
+    "        return [(None,), \"<unk>\", -float(\"inf\")]\n",
+    "    return sorted(partitions, key=lambda x: x[2], reverse=True)[0]\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>logprob</th>\n",
+       "      <th>syllable_count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>152150.000000</td>\n",
+       "      <td>152150.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>-6.521430</td>\n",
+       "      <td>2.547217</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>1.056862</td>\n",
+       "      <td>0.977678</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>-99.000000</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>-7.275731</td>\n",
+       "      <td>2.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>-6.641368</td>\n",
+       "      <td>2.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>-5.942398</td>\n",
+       "      <td>3.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>-1.619924</td>\n",
+       "      <td>6.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             logprob  syllable_count\n",
+       "count  152150.000000   152150.000000\n",
+       "mean       -6.521430        2.547217\n",
+       "std         1.056862        0.977678\n",
+       "min       -99.000000        1.000000\n",
+       "25%        -7.275731        2.000000\n",
+       "50%        -6.641368        2.000000\n",
+       "75%        -5.942398        3.000000\n",
+       "max        -1.619924        6.000000"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>transcript</th>\n",
+       "      <th>script</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>152150</td>\n",
+       "      <td>152150</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>unique</th>\n",
+       "      <td>126666</td>\n",
+       "      <td>147327</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>top</th>\n",
+       "      <td>ㄧˋ</td>\n",
+       "      <td>一個個</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>freq</th>\n",
+       "      <td>132</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       transcript  script\n",
+       "count      152150  152150\n",
+       "unique     126666  147327\n",
+       "top            ㄧˋ     一個個\n",
+       "freq          132       6"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df = pd.read_table(\n",
+    "    \"../data.txt\",\n",
+    "    sep=\" \",\n",
+    "    header=None,\n",
+    "    names=(\"transcript\", \"script\", \"logprob\"),\n",
+    "    dtype=str,\n",
+    "    skiprows=400,\n",
+    "    quoting=3\n",
+    ")\n",
+    "df = df.assign(syllable_count=df.transcript.str.split(\"-\").apply(len))\n",
+    "zh_Hant_df = df[df.logprob != \"-8\"]\n",
+    "zh_Hant_df = zh_Hant_df.assign(logprob=pd.to_numeric(zh_Hant_df.logprob))\n",
+    "display(zh_Hant_df.describe())\n",
+    "display(zh_Hant_df.describe(include=[\"O\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def verify(syl_cnt):\n",
+    "    polysyllabic_zh_Hant_df = zh_Hant_df[zh_Hant_df.syllable_count == syl_cnt]\n",
+    "    logprob_sorted_polysyllabic_zh_Hant_df = polysyllabic_zh_Hant_df.sort_values(\"logprob\", ascending=False)\n",
+    "    logprob_sorted_polysyllabic_top1_zh_Hant_df = logprob_sorted_polysyllabic_zh_Hant_df.drop_duplicates(\"transcript\")\n",
+    "\n",
+    "    shadowed_records = []\n",
+    "    for x in tqdm(\n",
+    "        logprob_sorted_polysyllabic_top1_zh_Hant_df.itertuples(),\n",
+    "        total=len(logprob_sorted_polysyllabic_top1_zh_Hant_df.index)\n",
+    "    ):\n",
+    "        t, s, l = x.transcript, x.script, x.logprob\n",
+    "        best_alt_t_seg, best_alt_s, best_alt_l = get_best_alt_t_seg(t)\n",
+    "        if best_alt_s != s and best_alt_l > l:\n",
+    "            shadowed_records.append((t, s, l, best_alt_t_seg, best_alt_s, best_alt_l))\n",
+    "    return shadowed_records\n",
+    "\n",
+    "\n",
+    "def display_helper(syl_cnt, shadowed_records, top_n=5):\n",
+    "    display(\n",
+    "        pd.DataFrame(\n",
+    "            list(\n",
+    "                sorted(\n",
+    "                    shadowed_records, key=lambda x: x[2], reverse=True\n",
+    "                )\n",
+    "            )[:top_n],\n",
+    "            columns=[\n",
+    "                \"transcript\",\n",
+    "                \"script\",\n",
+    "                \"logprb\",\n",
+    "                \"alt_transcript_seg\",\n",
+    "                \"alt_script\",\n",
+    "                \"alt_logprob\",\n",
+    "            ]\n",
+    "        ).style.set_caption(\n",
+    "            f\"{len(shadowed_records):_} shadowed {syl_cnt}-syllable scripts by their parts; top-{top_n}:\"\n",
+    "        )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f4c8f6254c3b448a9b61c3d32979c217",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1118 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_8ef88\">\n",
+       "  <caption>0 shadowed 6-syllable scripts by their parts; top-5:</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_8ef88_level0_col0\" class=\"col_heading level0 col0\" >transcript</th>\n",
+       "      <th id=\"T_8ef88_level0_col1\" class=\"col_heading level0 col1\" >script</th>\n",
+       "      <th id=\"T_8ef88_level0_col2\" class=\"col_heading level0 col2\" >logprb</th>\n",
+       "      <th id=\"T_8ef88_level0_col3\" class=\"col_heading level0 col3\" >alt_transcript_seg</th>\n",
+       "      <th id=\"T_8ef88_level0_col4\" class=\"col_heading level0 col4\" >alt_script</th>\n",
+       "      <th id=\"T_8ef88_level0_col5\" class=\"col_heading level0 col5\" >alt_logprob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x11dd0a0d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "syl_cnt = 6\n",
+    "shadowed_records_6 = verify(syl_cnt)\n",
+    "display_helper(syl_cnt, shadowed_records_6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "84b108447d034fd8a651413e6229eb82",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2072 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_8a201\">\n",
+       "  <caption>0 shadowed 5-syllable scripts by their parts; top-5:</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_8a201_level0_col0\" class=\"col_heading level0 col0\" >transcript</th>\n",
+       "      <th id=\"T_8a201_level0_col1\" class=\"col_heading level0 col1\" >script</th>\n",
+       "      <th id=\"T_8a201_level0_col2\" class=\"col_heading level0 col2\" >logprb</th>\n",
+       "      <th id=\"T_8a201_level0_col3\" class=\"col_heading level0 col3\" >alt_transcript_seg</th>\n",
+       "      <th id=\"T_8a201_level0_col4\" class=\"col_heading level0 col4\" >alt_script</th>\n",
+       "      <th id=\"T_8a201_level0_col5\" class=\"col_heading level0 col5\" >alt_logprob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x11dadabb0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "syl_cnt = 5\n",
+    "shadowed_records_5 = verify(syl_cnt)\n",
+    "display_helper(syl_cnt, shadowed_records_5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8cc09260e67546d4ba3242374ea9b05b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/26118 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_9bccf\">\n",
+       "  <caption>5 shadowed 4-syllable scripts by their parts; top-5:</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_9bccf_level0_col0\" class=\"col_heading level0 col0\" >transcript</th>\n",
+       "      <th id=\"T_9bccf_level0_col1\" class=\"col_heading level0 col1\" >script</th>\n",
+       "      <th id=\"T_9bccf_level0_col2\" class=\"col_heading level0 col2\" >logprb</th>\n",
+       "      <th id=\"T_9bccf_level0_col3\" class=\"col_heading level0 col3\" >alt_transcript_seg</th>\n",
+       "      <th id=\"T_9bccf_level0_col4\" class=\"col_heading level0 col4\" >alt_script</th>\n",
+       "      <th id=\"T_9bccf_level0_col5\" class=\"col_heading level0 col5\" >alt_logprob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bccf_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_9bccf_row0_col0\" class=\"data row0 col0\" >ㄧ-ㄒㄧㄠˇ-ㄕˊ-ㄏㄡˋ</td>\n",
+       "      <td id=\"T_9bccf_row0_col1\" class=\"data row0 col1\" >一小時後</td>\n",
+       "      <td id=\"T_9bccf_row0_col2\" class=\"data row0 col2\" >-6.673671</td>\n",
+       "      <td id=\"T_9bccf_row0_col3\" class=\"data row0 col3\" >('ㄧ', 'ㄒㄧㄠˇ-ㄕˊ-ㄏㄡˋ')</td>\n",
+       "      <td id=\"T_9bccf_row0_col4\" class=\"data row0 col4\" >一小時候</td>\n",
+       "      <td id=\"T_9bccf_row0_col5\" class=\"data row0 col5\" >-6.540373</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bccf_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_9bccf_row1_col0\" class=\"data row1 col0\" >ㄧㄢˊ-ㄐㄧㄡˋ-ㄙㄨㄛˇ-ㄌㄧˇ</td>\n",
+       "      <td id=\"T_9bccf_row1_col1\" class=\"data row1 col1\" >研究所裡</td>\n",
+       "      <td id=\"T_9bccf_row1_col2\" class=\"data row1 col2\" >-6.974701</td>\n",
+       "      <td id=\"T_9bccf_row1_col3\" class=\"data row1 col3\" >('ㄧㄢˊ-ㄐㄧㄡˋ-ㄙㄨㄛˇ', 'ㄌㄧˇ')</td>\n",
+       "      <td id=\"T_9bccf_row1_col4\" class=\"data row1 col4\" >研究所理</td>\n",
+       "      <td id=\"T_9bccf_row1_col5\" class=\"data row1 col5\" >-6.958653</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bccf_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_9bccf_row2_col0\" class=\"data row2 col0\" >ㄊㄞˊ-ㄅㄟˇ-ㄕˋ-ㄕㄤ</td>\n",
+       "      <td id=\"T_9bccf_row2_col1\" class=\"data row2 col1\" >台北士商</td>\n",
+       "      <td id=\"T_9bccf_row2_col2\" class=\"data row2 col2\" >-6.974701</td>\n",
+       "      <td id=\"T_9bccf_row2_col3\" class=\"data row2 col3\" >('ㄊㄞˊ-ㄅㄟˇ-ㄕˋ', 'ㄕㄤ')</td>\n",
+       "      <td id=\"T_9bccf_row2_col4\" class=\"data row2 col4\" >台北市商</td>\n",
+       "      <td id=\"T_9bccf_row2_col5\" class=\"data row2 col5\" >-6.869624</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bccf_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_9bccf_row3_col0\" class=\"data row3 col0\" >ㄅㄨˋ-ㄅㄨˋ-ㄒㄧㄠˇ-ㄒㄧㄣ</td>\n",
+       "      <td id=\"T_9bccf_row3_col1\" class=\"data row3 col1\" >步步小心</td>\n",
+       "      <td id=\"T_9bccf_row3_col2\" class=\"data row3 col2\" >-7.275731</td>\n",
+       "      <td id=\"T_9bccf_row3_col3\" class=\"data row3 col3\" >('ㄅㄨˋ', 'ㄅㄨˋ-ㄒㄧㄠˇ-ㄒㄧㄣ')</td>\n",
+       "      <td id=\"T_9bccf_row3_col4\" class=\"data row3 col4\" >不不小心</td>\n",
+       "      <td id=\"T_9bccf_row3_col5\" class=\"data row3 col5\" >-7.033613</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9bccf_level0_row4\" class=\"row_heading level0 row4\" >4</th>\n",
+       "      <td id=\"T_9bccf_row4_col0\" class=\"data row4 col0\" >ㄐㄧㄠˇ-ㄊㄚˋ-ㄔㄜ-ㄉㄠˋ</td>\n",
+       "      <td id=\"T_9bccf_row4_col1\" class=\"data row4 col1\" >腳踏車道</td>\n",
+       "      <td id=\"T_9bccf_row4_col2\" class=\"data row4 col2\" >-7.275731</td>\n",
+       "      <td id=\"T_9bccf_row4_col3\" class=\"data row4 col3\" >('ㄐㄧㄠˇ-ㄊㄚˋ-ㄔㄜ', 'ㄉㄠˋ')</td>\n",
+       "      <td id=\"T_9bccf_row4_col4\" class=\"data row4 col4\" >腳踏車到</td>\n",
+       "      <td id=\"T_9bccf_row4_col5\" class=\"data row4 col5\" >-7.265441</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x11f8b9f10>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "syl_cnt = 4\n",
+    "shadowed_records_4 = verify(syl_cnt)\n",
+    "display_helper(syl_cnt, shadowed_records_4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d1ac664e587e4959949f0d7994b2abff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/32890 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_55106\">\n",
+       "  <caption>765 shadowed 3-syllable scripts by their parts; top-5:</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_55106_level0_col0\" class=\"col_heading level0 col0\" >transcript</th>\n",
+       "      <th id=\"T_55106_level0_col1\" class=\"col_heading level0 col1\" >script</th>\n",
+       "      <th id=\"T_55106_level0_col2\" class=\"col_heading level0 col2\" >logprb</th>\n",
+       "      <th id=\"T_55106_level0_col3\" class=\"col_heading level0 col3\" >alt_transcript_seg</th>\n",
+       "      <th id=\"T_55106_level0_col4\" class=\"col_heading level0 col4\" >alt_script</th>\n",
+       "      <th id=\"T_55106_level0_col5\" class=\"col_heading level0 col5\" >alt_logprob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_55106_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_55106_row0_col0\" class=\"data row0 col0\" >ㄅㄨˋ-ㄈㄣˋ-ㄉㄜ˙</td>\n",
+       "      <td id=\"T_55106_row0_col1\" class=\"data row0 col1\" >部份的</td>\n",
+       "      <td id=\"T_55106_row0_col2\" class=\"data row0 col2\" >-5.261156</td>\n",
+       "      <td id=\"T_55106_row0_col3\" class=\"data row0 col3\" >('ㄅㄨˋ-ㄈㄣˋ', 'ㄉㄜ˙')</td>\n",
+       "      <td id=\"T_55106_row0_col4\" class=\"data row0 col4\" >部分的</td>\n",
+       "      <td id=\"T_55106_row0_col5\" class=\"data row0 col5\" >-5.074531</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_55106_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_55106_row1_col0\" class=\"data row1 col0\" >ㄗㄞˋ-ㄇㄟˊ-ㄧㄡˇ</td>\n",
+       "      <td id=\"T_55106_row1_col1\" class=\"data row1 col1\" >再沒有</td>\n",
+       "      <td id=\"T_55106_row1_col2\" class=\"data row1 col2\" >-5.475036</td>\n",
+       "      <td id=\"T_55106_row1_col3\" class=\"data row1 col3\" >('ㄗㄞˋ', 'ㄇㄟˊ-ㄧㄡˇ')</td>\n",
+       "      <td id=\"T_55106_row1_col4\" class=\"data row1 col4\" >在沒有</td>\n",
+       "      <td id=\"T_55106_row1_col5\" class=\"data row1 col5\" >-5.069755</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_55106_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_55106_row2_col0\" class=\"data row2 col0\" >ㄓㄨㄥ-ㄍㄨㄛˊ-ㄕˋ</td>\n",
+       "      <td id=\"T_55106_row2_col1\" class=\"data row2 col1\" >中國式</td>\n",
+       "      <td id=\"T_55106_row2_col2\" class=\"data row2 col2\" >-5.627127</td>\n",
+       "      <td id=\"T_55106_row2_col3\" class=\"data row2 col3\" >('ㄓㄨㄥ-ㄍㄨㄛˊ', 'ㄕˋ')</td>\n",
+       "      <td id=\"T_55106_row2_col4\" class=\"data row2 col4\" >中國是</td>\n",
+       "      <td id=\"T_55106_row2_col5\" class=\"data row2 col5\" >-5.383699</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_55106_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_55106_row3_col0\" class=\"data row3 col0\" >ㄔㄤˊ-ㄔㄤˊ-ㄉㄜ˙</td>\n",
+       "      <td id=\"T_55106_row3_col1\" class=\"data row3 col1\" >長長的</td>\n",
+       "      <td id=\"T_55106_row3_col2\" class=\"data row3 col2\" >-5.738278</td>\n",
+       "      <td id=\"T_55106_row3_col3\" class=\"data row3 col3\" >('ㄔㄤˊ-ㄔㄤˊ', 'ㄉㄜ˙')</td>\n",
+       "      <td id=\"T_55106_row3_col4\" class=\"data row3 col4\" >常常的</td>\n",
+       "      <td id=\"T_55106_row3_col5\" class=\"data row3 col5\" >-5.623324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_55106_level0_row4\" class=\"row_heading level0 row4\" >4</th>\n",
+       "      <td id=\"T_55106_row4_col0\" class=\"data row4 col0\" >ㄧ-ㄐㄧㄡˋ-ㄕˋ</td>\n",
+       "      <td id=\"T_55106_row4_col1\" class=\"data row4 col1\" >依舊是</td>\n",
+       "      <td id=\"T_55106_row4_col2\" class=\"data row4 col2\" >-5.776066</td>\n",
+       "      <td id=\"T_55106_row4_col3\" class=\"data row4 col3\" >('ㄧ', 'ㄐㄧㄡˋ-ㄕˋ')</td>\n",
+       "      <td id=\"T_55106_row4_col4\" class=\"data row4 col4\" >一就是</td>\n",
+       "      <td id=\"T_55106_row4_col5\" class=\"data row4 col5\" >-5.221533</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x11f8bb220>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "syl_cnt = 3\n",
+    "shadowed_records_3 = verify(syl_cnt)\n",
+    "display_helper(syl_cnt, shadowed_records_3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd93dac35c05464c803e4e3c503c2df1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/63123 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style type=\"text/css\">\n",
+       "</style>\n",
+       "<table id=\"T_9873f\">\n",
+       "  <caption>15_214 shadowed 2-syllable scripts by their parts; top-5:</caption>\n",
+       "  <thead>\n",
+       "    <tr>\n",
+       "      <th class=\"blank level0\" >&nbsp;</th>\n",
+       "      <th id=\"T_9873f_level0_col0\" class=\"col_heading level0 col0\" >transcript</th>\n",
+       "      <th id=\"T_9873f_level0_col1\" class=\"col_heading level0 col1\" >script</th>\n",
+       "      <th id=\"T_9873f_level0_col2\" class=\"col_heading level0 col2\" >logprb</th>\n",
+       "      <th id=\"T_9873f_level0_col3\" class=\"col_heading level0 col3\" >alt_transcript_seg</th>\n",
+       "      <th id=\"T_9873f_level0_col4\" class=\"col_heading level0 col4\" >alt_script</th>\n",
+       "      <th id=\"T_9873f_level0_col5\" class=\"col_heading level0 col5\" >alt_logprob</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9873f_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_9873f_row0_col0\" class=\"data row0 col0\" >ㄧ-ㄗㄞˋ</td>\n",
+       "      <td id=\"T_9873f_row0_col1\" class=\"data row0 col1\" >一再</td>\n",
+       "      <td id=\"T_9873f_row0_col2\" class=\"data row0 col2\" >-4.576535</td>\n",
+       "      <td id=\"T_9873f_row0_col3\" class=\"data row0 col3\" >('ㄧ', 'ㄗㄞˋ')</td>\n",
+       "      <td id=\"T_9873f_row0_col4\" class=\"data row0 col4\" >一在</td>\n",
+       "      <td id=\"T_9873f_row0_col5\" class=\"data row0 col5\" >-4.316461</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9873f_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_9873f_row1_col0\" class=\"data row1 col0\" >ㄕˋ-ㄕˋ</td>\n",
+       "      <td id=\"T_9873f_row1_col1\" class=\"data row1 col1\" >試試</td>\n",
+       "      <td id=\"T_9873f_row1_col2\" class=\"data row1 col2\" >-4.589256</td>\n",
+       "      <td id=\"T_9873f_row1_col3\" class=\"data row1 col3\" >('ㄕˋ', 'ㄕˋ')</td>\n",
+       "      <td id=\"T_9873f_row1_col4\" class=\"data row1 col4\" >是是</td>\n",
+       "      <td id=\"T_9873f_row1_col5\" class=\"data row1 col5\" >-4.078380</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9873f_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_9873f_row2_col0\" class=\"data row2 col0\" >ㄓㄨㄥ-ㄕˋ</td>\n",
+       "      <td id=\"T_9873f_row2_col1\" class=\"data row2 col1\" >中市</td>\n",
+       "      <td id=\"T_9873f_row2_col2\" class=\"data row2 col2\" >-4.614894</td>\n",
+       "      <td id=\"T_9873f_row2_col3\" class=\"data row2 col3\" >('ㄓㄨㄥ', 'ㄕˋ')</td>\n",
+       "      <td id=\"T_9873f_row2_col4\" class=\"data row2 col4\" >中是</td>\n",
+       "      <td id=\"T_9873f_row2_col5\" class=\"data row2 col5\" >-4.539011</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9873f_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_9873f_row3_col0\" class=\"data row3 col0\" >ㄍㄜˋ-ㄕˋ</td>\n",
+       "      <td id=\"T_9873f_row3_col1\" class=\"data row3 col1\" >各式</td>\n",
+       "      <td id=\"T_9873f_row3_col2\" class=\"data row3 col2\" >-4.676816</td>\n",
+       "      <td id=\"T_9873f_row3_col3\" class=\"data row3 col3\" >('ㄍㄜˋ', 'ㄕˋ')</td>\n",
+       "      <td id=\"T_9873f_row3_col4\" class=\"data row3 col4\" >個是</td>\n",
+       "      <td id=\"T_9873f_row3_col5\" class=\"data row3 col5\" >-4.441402</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th id=\"T_9873f_level0_row4\" class=\"row_heading level0 row4\" >4</th>\n",
+       "      <td id=\"T_9873f_row4_col0\" class=\"data row4 col0\" >ㄓㄨㄥ-ㄅㄨˋ</td>\n",
+       "      <td id=\"T_9873f_row4_col1\" class=\"data row4 col1\" >中部</td>\n",
+       "      <td id=\"T_9873f_row4_col2\" class=\"data row4 col2\" >-4.786606</td>\n",
+       "      <td id=\"T_9873f_row4_col3\" class=\"data row4 col3\" >('ㄓㄨㄥ', 'ㄅㄨˋ')</td>\n",
+       "      <td id=\"T_9873f_row4_col4\" class=\"data row4 col4\" >中不</td>\n",
+       "      <td id=\"T_9873f_row4_col5\" class=\"data row4 col5\" >-4.677396</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n"
+      ],
+      "text/plain": [
+       "<pandas.io.formats.style.Styler at 0x109767bb0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "syl_cnt = 2\n",
+    "shadowed_records_2 = verify(syl_cnt)\n",
+    "display_helper(syl_cnt, shadowed_records_2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.13 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "7a792fcb311f9eb9f3c1b942a8c87ada8484712b89b670347c16a1088e0a1f69"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Source/Data/term_score_verification/requirements.txt
+++ b/Source/Data/term_score_verification/requirements.txt
@@ -1,0 +1,4 @@
+ipywidgets
+jupyterlab
+pandas
+tqdm


### PR DESCRIPTION
related: #300 #328 #329

The notebook playground.ipynb uses a brute-force way to find covering ambiguities.

Literature often defines two categories of word/syllable segmentation ambiguities:
1. covering/combination/combinatorial: e.g., syllable /A-B/ competes with syllables /A/ & /B/
2. conflicting/overlapping: e.g., syllable /A-B/ competes with syllable /B-C/

(I prefer covering and conflicting because combinat-ion/-orial and overlapping are near-synonyms.)

If we change the brute-force partition function to a real dynamic programming function, the verification should run much faster.

Please kindly note that the perspective is slightly different than #329.