### PR TITLE
Allow keeping the reading upon composition error

### DIFF
--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -38,6 +38,7 @@ private let kChooseCandidateUsingSpaceKey = "ChooseCandidateUsingSpaceKey"
 private let kChineseConversionEnabledKey = "ChineseConversionEnabled"
 private let kHalfWidthPunctuationEnabledKey = "HalfWidthPunctuationEnable"
 private let kEscToCleanInputBufferKey = "EscToCleanInputBuffer"
+private let kKeepReadingUponCompositionError = "KeepReadingUponCompositionError"
 
 private let kCandidateTextFontName = "CandidateTextFontName"
 private let kCandidateKeyLabelFontName = "CandidateKeyLabelFontName"
@@ -196,6 +197,7 @@ class Preferences: NSObject {
          kChineseConversionEnabledKey,
          kHalfWidthPunctuationEnabledKey,
          kEscToCleanInputBufferKey,
+         kKeepReadingUponCompositionError,
          kCandidateTextFontName,
          kCandidateKeyLabelFontName,
          kCandidateKeys,
@@ -258,6 +260,9 @@ class Preferences: NSObject {
 
     @UserDefault(key: kEscToCleanInputBufferKey, defaultValue: false)
     @objc static var escToCleanInputBuffer: Bool
+
+    @UserDefault(key: kKeepReadingUponCompositionError, defaultValue: false)
+    @objc static var keepReadingUponCompositionError: Bool
 
     // MARK: Optional settings
 


### PR DESCRIPTION
Fixes #331

To enable the option:

  defaults write org.openvanilla.inputmethod.McBopomofo KeepReadingUponCompositionError -bool true

To revert back to the default behavior:

  defaults delete org.openvanilla.inputmethod.McBopomofo KeepReadingUponCompositionError