### PR TITLE
Format Objective-C++ code

### DIFF
--- a/Source/.clang-format
+++ b/Source/.clang-format
@@ -1,0 +1,192 @@
+---
+Language:        ObjC
+# BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: WebKit
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Left
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -55,7 +55,7 @@ extern InputMode InputModePlainBopomofo;
 - (nullable InputState *)buildAssociatePhraseStateWithKey:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
 
 @property (strong, nonatomic) InputMode inputMode;
-@property (weak, nonatomic) id <KeyHandlerDelegate> delegate;
+@property (weak, nonatomic) id<KeyHandlerDelegate> delegate;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -22,17 +22,17 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #import "KeyHandler.h"
-#import "reading_grid.h"
 #import "LanguageModelManager+Privates.h"
 #import "Mandarin.h"
 #import "McBopomofo-Swift.h"
 #import "McBopomofoLM.h"
 #import "UserOverrideModel.h"
+#import "reading_grid.h"
 
 #import <codecvt>
 #import <locale>
-#import <unordered_map>
 #import <string>
+#import <unordered_map>
 #import <utility>
 
 @import CandidateUI;
@@ -41,14 +41,16 @@
 InputMode InputModeBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Bopomofo";
 InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.PlainBopomofo";
 
-static std::u32string ToU32(const std::string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.from_bytes(s);
+static std::u32string ToU32(const std::string& s)
+{
+    std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
+    return conv.from_bytes(s);
 }
 
-static std::string ToU8(const std::u32string& s) {
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
-  return conv.to_bytes(s);
+static std::string ToU8(const std::u32string& s)
+{
+    std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
+    return conv.to_bytes(s);
 }
 
 @implementation KeyHandler {
@@ -203,7 +205,7 @@ static std::string ToU8(const std::u32string& s) {
 {
     _bpmfReadingBuffer->clear();
     _grid->clear();
-    _latestWalk = Formosa::Gramambular2::ReadingGrid::WalkResult{};
+    _latestWalk = Formosa::Gramambular2::ReadingGrid::WalkResult {};
 }
 
 - (std::string)_currentLayout
@@ -293,7 +295,6 @@ static std::string ToU8(const std::u32string& s) {
         stateCallback(state);
     }
 
-
     BOOL keyConsumedByReading = NO;
     BOOL skipBpmfHandling = [input isReservedKey] || [input isControlHold];
 
@@ -347,10 +348,7 @@ static std::string ToU8(const std::u32string& s) {
         if (_inputMode != InputModePlainBopomofo) {
             McBopomofo::UserOverrideModel::Suggestion suggestion = _userOverrideModel->suggest(_latestWalk, [self _actualCandidateCursorIndex], [[NSDate date] timeIntervalSince1970]);
             if (!suggestion.empty()) {
-                Formosa::Gramambular2::ReadingGrid::Node::OverrideType type =
-                    suggestion.forceHighScoreOverride ?
-                    Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore :
-                    Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram;
+                Formosa::Gramambular2::ReadingGrid::Node::OverrideType type = suggestion.forceHighScoreOverride ? Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore : Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram;
                 _grid->overrideCandidate([self _actualCandidateCursorIndex], suggestion.candidate, type);
                 [self _walk];
             }
@@ -530,8 +528,7 @@ static std::string ToU8(const std::u32string& s) {
             if ([self _handlePunctuation:letter state:state usingVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback]) {
                 return YES;
             }
-        }
-        else {
+        } else {
             if ([state isKindOfClass:[InputStateNotEmpty class]]) {
                 [self clear];
                 InputStateEmpty *empty = [[InputStateEmpty alloc] init];
@@ -575,7 +572,6 @@ static std::string ToU8(const std::u32string& s) {
         return YES;
     }
 
-
     auto nodeIter = _latestWalk.findNodeAt([self _actualCandidateCursorIndex]);
     if (nodeIter == _latestWalk.nodes.cend()) {
         // Shouldn't happen.
@@ -593,7 +589,7 @@ static std::string ToU8(const std::u32string& s) {
         // In other words, if a user type two BPMF readings, but the score of seeing
         // them as two unigrams is higher than a phrase with two characters, the
         // user can just use the longer phrase by typing the tab key.
-        InputStateCandidate* candidate = candidates[0];
+        InputStateCandidate *candidate = candidates[0];
         if (currentNode->reading() == candidate.reading.UTF8String && currentNode->value() == candidate.value.UTF8String) {
             // If the first candidate is the value of the current node, we use next
             // one.
@@ -604,7 +600,7 @@ static std::string ToU8(const std::u32string& s) {
             }
         }
     } else {
-        for (InputStateCandidate* candidate : candidates) {
+        for (InputStateCandidate *candidate : candidates) {
             if (currentNode->reading() == candidate.reading.UTF8String && currentNode->value() == candidate.value.UTF8String) {
                 if (shiftIsHold) {
                     currentIndex == 0 ? currentIndex = candidates.count - 1 : currentIndex--;
@@ -621,7 +617,7 @@ static std::string ToU8(const std::u32string& s) {
         currentIndex = 0;
     }
 
-    InputStateCandidate* candidate = candidates[currentIndex];
+    InputStateCandidate *candidate = candidates[currentIndex];
     [self fixNodeWithReading:candidate.reading value:candidate.value useMoveCursorAfterSelectionSetting:NO];
     InputStateInputting *inputting = (InputStateInputting *)[self buildInputtingState];
     stateCallback(inputting);
@@ -809,8 +805,7 @@ static std::string ToU8(const std::u32string& s) {
 
     if (_bpmfReadingBuffer->hasToneMarkerOnly()) {
         _bpmfReadingBuffer->clear();
-    }
-    else if (_bpmfReadingBuffer->isEmpty()) {
+    } else if (_bpmfReadingBuffer->isEmpty()) {
         if (_grid->cursor()) {
             _grid->deleteReadingBeforeCursor();
             [self _walk];
@@ -1249,11 +1244,11 @@ static std::string ToU8(const std::u32string& s) {
     // the cursor is at does not agree with the actual codepoint count of the
     // node's value, we'll need to move the cursor at the end of the node to
     // avoid confusions.
-    size_t runningCursor = 0;  // spanning-length-based, like the builder cursor
+    size_t runningCursor = 0; // spanning-length-based, like the builder cursor
 
     std::string composed;
     size_t builderCursor = _grid->cursor();
-    size_t composedCursor = 0;  // UTF-8 (so "byte") cursor per fcitx5 requirement.
+    size_t composedCursor = 0; // UTF-8 (so "byte") cursor per fcitx5 requirement.
     NSString *tooltip = @"";
 
     for (const auto& node : _latestWalk.nodes) {
@@ -1304,7 +1299,7 @@ static std::string ToU8(const std::u32string& s) {
     }
 
     std::string headStr = composed.substr(0, composedCursor);
-    std::string tailStr =composed.substr(composedCursor, composed.length() - composedCursor);
+    std::string tailStr = composed.substr(composedCursor, composed.length() - composedCursor);
 
     NSString *head = [NSString stringWithUTF8String:headStr.c_str()];
     NSString *reading = [NSString stringWithUTF8String:_bpmfReadingBuffer->composedString().c_str()];

--- a/Source/LanguageModelManager+Privates.h
+++ b/Source/LanguageModelManager+Privates.h
@@ -22,8 +22,8 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 #import "LanguageModelManager.h"
-#import "UserOverrideModel.h"
 #import "McBopomofoLM.h"
+#import "UserOverrideModel.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/LanguageModelManager.h
+++ b/Source/LanguageModelManager.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
 #import "KeyHandler.h"
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -43,14 +43,14 @@ static NSString *const kTemplateExtension = @".txt";
 
 @implementation LanguageModelManager
 
-static void LTLoadLanguageModelFile(NSString *filenameWithoutExtension, McBopomofo::McBopomofoLM &lm)
+static void LTLoadLanguageModelFile(NSString *filenameWithoutExtension, McBopomofo::McBopomofoLM& lm)
 {
     Class cls = NSClassFromString(@"McBopomofoInputMethodController");
     NSString *dataPath = [[NSBundle bundleForClass:cls] pathForResource:filenameWithoutExtension ofType:@"txt"];
     lm.loadLanguageModel([dataPath UTF8String]);
 }
 
-static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM &lm)
+static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
 {
     Class cls = NSClassFromString(@"McBopomofoInputMethodController");
     NSString *dataPath = [[NSBundle bundleForClass:cls] pathForResource:@"associated-phrases" ofType:@"txt"];


### PR DESCRIPTION
A custom .clang-format is introduced to minimize diff. It is evident
that the Objective-C++ code has been pretty much following the WebKit
style throughout the years.