### PR TITLE
Clear Bopomofo reading upon force-commit

### DIFF
--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -147,9 +147,10 @@ class McBopomofoInputMethodController: IMKInputController {
 
     // MARK: - IMKServerInput protocol methods
 
-    override func commitComposition(_ sender: Any!) {
-        keyHandler.clear()
-        self.handle(state: .Empty(), client: sender)
+    override func commitComposition(_ client: Any!) {
+        keyHandler.handleForceCommit(stateCallback: { newState in
+            self.handle(state: newState, client: client)
+        })
     }
 
     override func recognizedEvents(_ sender: Any!) -> Int {

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -51,6 +51,9 @@ extern InputMode InputModePlainBopomofo;
 - (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value useMoveCursorAfterSelectionSetting:(BOOL)flag NS_SWIFT_NAME(fixNode(reading:value:useMoveCursorAfterSelectionSetting:));
 - (void)clear;
 
+- (void)handleForceCommitWithStateCallback:(void (^)(InputState *))stateCallback
+    NS_SWIFT_NAME(handleForceCommit(stateCallback:));
+
 - (InputState *)buildInputtingState;
 - (nullable InputState *)buildAssociatePhraseStateWithKey:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -208,6 +208,17 @@ static std::string ToU8(const std::u32string& s)
     _latestWalk = Formosa::Gramambular2::ReadingGrid::WalkResult {};
 }
 
+- (void)handleForceCommitWithStateCallback:(void (^)(InputState *))stateCallback
+{
+    // Upon force-commit, clear the BPMF reading, then "steal" the composing buffer text from the built inputting state.
+    _bpmfReadingBuffer->clear();
+    InputStateInputting *inputting = (InputStateInputting *)[self buildInputtingState];
+    [self clear];
+
+    InputStateCommitting *committing = [[InputStateCommitting alloc] initWithPoppedText:inputting.composingBuffer];
+    stateCallback(committing);
+}
+
 - (std::string)_currentLayout
 {
     NSString *keyboardLayoutName = Preferences.keyboardLayoutName;


### PR DESCRIPTION
Fixes #336. Note that this addresses the case of force-commit, most likely due to user deactivation (the case of #336).

There are other scenarios where an IME session is deactivated without force-commit, and different apps handle those scenarios differently. I didn't intend to change how the input method controller interacts with those scenarios.


