### PR TITLE
Stop calling setMarkedText upon (de)activation

### DIFF
--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -210,6 +210,11 @@ static std::string ToU8(const std::u32string& s)
 
 - (void)handleForceCommitWithStateCallback:(void (^)(InputState *))stateCallback
 {
+    if (_bpmfReadingBuffer->isEmpty() && _grid->length() == 0) {
+        // No-op if both are empty.
+        return;
+    }
+
     // Upon force-commit, clear the BPMF reading, then "steal" the composing buffer text from the built inputting state.
     _bpmfReadingBuffer->clear();
     InputStateInputting *inputting = (InputStateInputting *)[self buildInputtingState];


### PR DESCRIPTION
Fixes #346

Certain apps don't handle -setMarkedText:selectedRange:replacementRange: consistently upon IMK session (de)activation. It's an effectively no-op anyway, and so this simplifies the (de)activation call.

Also updates the state machine transitions so that entering the deactivated state will cause the state machine to transit to the empty state. This is to guarantee that the state machine is always in the empty state upon IMK session activation.