### PR TITLE
Implements a Big5 code input mode

### DIFF
--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -305,6 +305,8 @@ extension McBopomofoInputMethodController {
             handle(state: newState, previous: previous, client: client)
         } else if let newState = newState as? InputState.AssociatedPhrases {
             handle(state: newState, previous: previous, client: client)
+        } else if let newState = newState as? InputState.Big5 {
+            handle(state: newState, previous: previous, client: client)
         }
     }
 
@@ -443,6 +445,20 @@ extension McBopomofoInputMethodController {
         }
         client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         show(candidateWindowWith: state, client: client)
+    }
+
+    private func handle(state: InputState.Big5, previous: InputState, client: Any?) {
+        gCurrentCandidateController?.visible = false
+        hideTooltip()
+
+        guard let client = client as? IMKTextInput else {
+            return
+        }
+
+        if let previous = previous as? InputState.NotEmpty {
+            commit(text: previous.composingBuffer, client: client)
+        }
+        client.setMarkedText(state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 }
 

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -111,6 +111,24 @@ class InputState: NSObject {
 
     // MARK: -
 
+    @objc(InputStateBig5)
+    class Big5: InputState {
+        @objc private(set) var code: String
+        @objc init(code: String) {
+            self.code = code
+        }
+
+        override var description: String {
+            "<InputState.Big5, code:\(code)>"
+        }
+
+        @objc public var composingBuffer: String {
+            return "[內碼] \(code)"
+        }
+    }
+
+    // MARK: -
+
     /// Represents that the composing buffer is not empty.
     @objc (InputStateNotEmpty)
     class NotEmpty: InputState {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -237,6 +237,11 @@ static std::string ToU8(const std::u32string& s)
     UniChar charCode = input.charCode;
     McBopomofoEmacsKey emacsKey = input.emacsKey;
 
+    // MARK: Handle Big5 Input
+    if ([state isKindOfClass:[InputStateBig5 class]]) {
+        return [self _handleBig5State:state input:input stateCallback:stateCallback errorCallback:errorCallback];
+    }
+
     // if the inputText is empty, it's a function key combination, we ignore it
     if (!input.inputText.length) {
         return NO;
@@ -299,11 +304,6 @@ static std::string ToU8(const std::u32string& s)
         }
         state = [[InputStateEmpty alloc] init];
         stateCallback(state);
-    }
-
-    // MARK: Handle Big5 Input
-    if ([state isKindOfClass:[InputStateBig5 class]]) {
-        return [self _handleBig5State:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
 
     // MARK: Handle Marking


### PR DESCRIPTION
I know some traditional Bopomofo users who are familiar with Big5 code input method (內碼輸入法) since the DOS era. They use traditional Bopomofo to input Hanzi but Big5 code for punctuations and symbols. Using big5 code has already become a muscle memory. The feature is for such users.

To enter Big5 code mode, just enter ctrl key and `. Type esc to leave the mode.