### PR TITLE
Migrate off of codecvt

### DIFF
--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		6AD7CBC815FE555000691B5B /* data-plain-bpmf.txt in Resources */ = {isa = PBXBuildFile; fileRef = 6AD7CBC715FE555000691B5B /* data-plain-bpmf.txt */; };
 		6AE210B215FC63CC003659FE /* PlainBopomofo.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 6AE210B015FC63CC003659FE /* PlainBopomofo.tiff */; };
 		6AE210B315FC63CC003659FE /* PlainBopomofo@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 6AE210B115FC63CC003659FE /* PlainBopomofo@2x.tiff */; };
+		6AE215112A2849BB005A6A02 /* UTF8Helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */; };
 		6AFF97F2253B299E007F1C49 /* NonModalAlertWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */; };
 		D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41355D7278D7409005E5CBD /* LanguageModelManager.mm */; };
 		D41355DB278E6D17005E5CBD /* McBopomofoLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */; };
@@ -145,6 +146,8 @@
 		6AD7CBC715FE555000691B5B /* data-plain-bpmf.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "data-plain-bpmf.txt"; sourceTree = "<group>"; };
 		6AE210B015FC63CC003659FE /* PlainBopomofo.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = PlainBopomofo.tiff; sourceTree = "<group>"; };
 		6AE210B115FC63CC003659FE /* PlainBopomofo@2x.tiff */ = {isa = PBXFileReference; lastKnownFileType = image.tiff; path = "PlainBopomofo@2x.tiff"; sourceTree = "<group>"; };
+		6AE2150F2A2849BB005A6A02 /* UTF8Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UTF8Helper.h; sourceTree = "<group>"; };
+		6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UTF8Helper.cpp; sourceTree = "<group>"; };
 		6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NonModalAlertWindowController.xib; sourceTree = "<group>"; };
 		D41355D6278D7409005E5CBD /* LanguageModelManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LanguageModelManager.h; sourceTree = "<group>"; };
 		D41355D7278D7409005E5CBD /* LanguageModelManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageModelManager.mm; sourceTree = "<group>"; };
@@ -268,6 +271,8 @@
 				D41355D7278D7409005E5CBD /* LanguageModelManager.mm */,
 				D4E569DA27A34CC100AC2CEF /* KeyHandler.h */,
 				D4E569DB27A34CC100AC2CEF /* KeyHandler.mm */,
+				6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */,
+				6AE2150F2A2849BB005A6A02 /* UTF8Helper.h */,
 				D456576D279E4F7B00DF6BC9 /* KeyHandlerInput.swift */,
 				D461B791279DAC010070E734 /* InputState.swift */,
 				D427F76B278CA1BA004A2160 /* AppDelegate.swift */,
@@ -658,6 +663,7 @@
 				6A0D4F4515FC0EB100ABF4B3 /* Mandarin.cpp in Sources */,
 				6ACC3D452793701600F1B140 /* ParselessLM.cpp in Sources */,
 				D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */,
+				6AE215112A2849BB005A6A02 /* UTF8Helper.cpp in Sources */,
 				6ACC3D3F27914F2400F1B140 /* KeyValueBlobReader.cpp in Sources */,
 				D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */,
 			);

--- a/Source/UTF8Helper.cpp
+++ b/Source/UTF8Helper.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "UTF8Helper.h"
+
+namespace McBopomofo {
+
+// Adapted from https://github.com/lua/lua/blob/master/lutf8lib.c
+
+constexpr char32_t kMaxUnicode = 0x10FFFF;
+static inline bool IsContinuationByte(char32_t c) { return (c & 0xC0) == 0x80; }
+
+// Decodes one UTF-8 code point and advances the string iterator past the code
+// point. Returns false if i is already at the end, or if the iterated UTF-8
+// sequence is not valid.
+static inline bool DecodeUTF8(std::string::const_iterator& i,
+                              const std::string::const_iterator& end) {
+  static const char32_t limits[] = {~(char32_t)0, 0x80,     0x800,
+                                    0x10000,      0x200000, 0x4000000};
+  if (i == end) {
+    return false;
+  }
+
+  char32_t c = static_cast<unsigned char>(*i);
+  // Consumes the continuation bytes if c is not ASCII.
+  if (c >= 0x80) {
+    char32_t res = 0;
+    size_t count = 0;  // to count number of continuation bytes
+
+    std::string::const_iterator next = i;
+    for (; c & 0x40; c <<= 1) {
+      ++next;
+      if (next == end) {
+        // Sequence terminates prematurely. Bail.
+        return false;
+      }
+
+      ++count;
+      char32_t cc = static_cast<unsigned char>(*next);
+      if (!IsContinuationByte(cc)) {
+        return false;
+      }
+      // Add lower 6 bits from the continuous byte.
+      res = (res << 6) | (cc & 0x3F);
+    }
+    // Add first byte. Recall c has already been left-shifted (count * 1) times,
+    // and so we need to left-shift another (count * 5) bits so the net effect
+    // is left-shifting (count * 6) bits.
+    res |= ((char32_t)(c & 0x7F) << (count * 5));
+
+    bool invalid = count > 5 || res > kMaxUnicode || res < limits[count] ||
+                   (0xd800 <= res && res <= 0xdfff);
+    if (invalid) {
+      return false;
+    }
+    for (size_t j = 0; j < count && i != end; j++) {
+      ++i;
+    }
+  }
+
+  // Sequence terminates prematurely.
+  if (i == end) {
+    return false;
+  }
+
+  ++i;
+  return true;
+}
+
+size_t CodePointCount(const std::string& s) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return c;
+}
+
+std::string SubstringToCodePoints(const std::string& s, size_t cp) {
+  size_t c = 0;
+  std::string::const_iterator i = s.cbegin();
+  std::string::const_iterator end = s.cend();
+  while (i != end && c < cp) {
+    bool r = DecodeUTF8(i, end);
+    if (!r) {
+      break;
+    }
+    ++c;
+  }
+
+  return {s.cbegin(), i};
+}
+
+}  // namespace McBopomofo

--- a/Source/UTF8Helper.h
+++ b/Source/UTF8Helper.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_UTF8HELPER_H_
+#define SRC_UTF8HELPER_H_
+
+#include <string>
+
+namespace McBopomofo {
+
+// Count the number of code points of a string encoded in UTF-8. If it
+// encounters an invalid UTF-8 sequence, the returned value is the number of
+// code points up to before that invalid sequence.
+size_t CodePointCount(const std::string& s);
+
+// Clamp the string by the cp code points. If the string is shorter, the result
+// is a copy of s. If s contains some invalid UTF-8 sequence, the returned value
+// will be the string clamped up to before that invalid sequence.
+std::string SubstringToCodePoints(const std::string& s, size_t cp);
+
+}  // namespace McBopomofo
+
+#endif  // SRC_UTF8HELPER_H_


### PR DESCRIPTION
It's deprecated in C++17, and clang now hands out warnings. KeyHandler relly just needs a simple substring function, and so this reimplements it using the UTF-8 iteration code from Lua.