### PR TITLE
Fix missing phonetics for 鈾

### DIFF
--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -10210,6 +10210,7 @@
 扰 ㄧㄡˋ you4 u.4 big5
 牰 ㄧㄡˋ you4 u.4 big5
 迶 ㄧㄡˋ you4 u.4 big5
+鈾 ㄧㄡˋ you4 u.4 big5
 由 ㄧㄡˊ you2 u.6 big5
 游 ㄧㄡˊ you2 u.6 big5
 遊 ㄧㄡˊ you2 u.6 big5


### PR DESCRIPTION
Ref: https://www.moedict.tw/%E9%88%BE

after the patch:

```
$ ag 鈾 
Source/Data/associated-phrases.txt
34038:鈾 礦

Source/Data/BPMFBase.txt
10213:鈾 ㄧㄡˋ you4 u.4 big5
10222:鈾 ㄧㄡˊ you2 u.6 big5

Source/Data/phrase.occ
8293:鈾 19
32161:鈾礦      1

Source/Data/BPMFMappings.txt
55657:鈾礦 ㄧㄡˋ ㄎㄨㄤˋ
```