### PR TITLE
System service to add to user phrases list /「加入小麥注音使用者詞彙」系統服務

### DIFF
--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		6AE210B315FC63CC003659FE /* PlainBopomofo@2x.tiff in Resources */ = {isa = PBXBuildFile; fileRef = 6AE210B115FC63CC003659FE /* PlainBopomofo@2x.tiff */; };
 		6AE215112A2849BB005A6A02 /* UTF8Helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */; };
 		6AFF97F2253B299E007F1C49 /* NonModalAlertWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */; };
+		B058C5272AC9DF51002EDD66 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */; };
 		D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41355D7278D7409005E5CBD /* LanguageModelManager.mm */; };
 		D41355DB278E6D17005E5CBD /* McBopomofoLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */; };
 		D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355DC278EA3ED005E5CBD /* UserPhrasesLM.cpp */; };
@@ -149,6 +150,7 @@
 		6AE2150F2A2849BB005A6A02 /* UTF8Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UTF8Helper.h; sourceTree = "<group>"; };
 		6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UTF8Helper.cpp; sourceTree = "<group>"; };
 		6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NonModalAlertWindowController.xib; sourceTree = "<group>"; };
+		B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
 		D41355D6278D7409005E5CBD /* LanguageModelManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LanguageModelManager.h; sourceTree = "<group>"; };
 		D41355D7278D7409005E5CBD /* LanguageModelManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageModelManager.mm; sourceTree = "<group>"; };
 		D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = McBopomofoLM.cpp; sourceTree = "<group>"; };
@@ -279,6 +281,7 @@
 				D44FB74427915555003C80A6 /* Preferences.swift */,
 				D47F7DCF278C0897002F9DD7 /* NonModalAlertWindowController.swift */,
 				D47F7DCD278BFB57002F9DD7 /* PreferencesWindowController.swift */,
+				B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */,
 				D47B92BF27972AC800458394 /* main.swift */,
 				6A0D4EF615FC0DA600ABF4B3 /* McBopomofo-Prefix.pch */,
 				D427A9BF25ED28CC005D43E0 /* McBopomofo-Bridging-Header.h */,
@@ -665,6 +668,7 @@
 				D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */,
 				6AE215112A2849BB005A6A02 /* UTF8Helper.cpp in Sources */,
 				6ACC3D3F27914F2400F1B140 /* KeyValueBlobReader.cpp in Sources */,
+				B058C5272AC9DF51002EDD66 /* ServiceProvider.swift in Sources */,
 				D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		6AE215112A2849BB005A6A02 /* UTF8Helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */; };
 		6AFF97F2253B299E007F1C49 /* NonModalAlertWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */; };
 		B058C5272AC9DF51002EDD66 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */; };
+		B0781B352ACA2655003D9F75 /* ServicesMenu.strings in Resources */ = {isa = PBXBuildFile; fileRef = B0781B372ACA2655003D9F75 /* ServicesMenu.strings */; };
 		D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41355D7278D7409005E5CBD /* LanguageModelManager.mm */; };
 		D41355DB278E6D17005E5CBD /* McBopomofoLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */; };
 		D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355DC278EA3ED005E5CBD /* UserPhrasesLM.cpp */; };
@@ -151,6 +152,8 @@
 		6AE215102A2849BB005A6A02 /* UTF8Helper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UTF8Helper.cpp; sourceTree = "<group>"; };
 		6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NonModalAlertWindowController.xib; sourceTree = "<group>"; };
 		B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
+		B0781B362ACA2655003D9F75 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ServicesMenu.strings; sourceTree = "<group>"; };
+		B0781B382ACA2659003D9F75 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ServicesMenu.strings"; sourceTree = "<group>"; };
 		D41355D6278D7409005E5CBD /* LanguageModelManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LanguageModelManager.h; sourceTree = "<group>"; };
 		D41355D7278D7409005E5CBD /* LanguageModelManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageModelManager.mm; sourceTree = "<group>"; };
 		D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = McBopomofoLM.cpp; sourceTree = "<group>"; };
@@ -346,6 +349,7 @@
 				6A0D4EF515FC0DA600ABF4B3 /* McBopomofo-Info.plist */,
 				D4E33D8D27A838F0006DB1CF /* InfoPlist.strings */,
 				D4E33D8827A838CF006DB1CF /* Localizable.strings */,
+				B0781B372ACA2655003D9F75 /* ServicesMenu.strings */,
 				6A187E2816004C5900466B2E /* MainMenu.xib */,
 				6A0D4F4E15FC0EE100ABF4B3 /* preferences.xib */,
 			);
@@ -579,6 +583,7 @@
 				6A0D4F0815FC0DA600ABF4B3 /* Bopomofo.tiff in Resources */,
 				6A0D4F0915FC0DA600ABF4B3 /* Bopomofo@2x.tiff in Resources */,
 				6A6ED16D2797650A0012872E /* template-exclude-phrases-plain-bpmf.txt in Resources */,
+				B0781B352ACA2655003D9F75 /* ServicesMenu.strings in Resources */,
 				6A0D4F5315FC0EE100ABF4B3 /* preferences.xib in Resources */,
 				6A2E40F6253A69DA00D1AE1D /* Images.xcassets in Resources */,
 				D4E33D8F27A838F0006DB1CF /* InfoPlist.strings in Resources */,
@@ -809,6 +814,15 @@
 			name = MainMenu.xib;
 			path = Source/Installer;
 			sourceTree = SOURCE_ROOT;
+		};
+		B0781B372ACA2655003D9F75 /* ServicesMenu.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B0781B362ACA2655003D9F75 /* en */,
+				B0781B382ACA2659003D9F75 /* zh-Hant */,
+			);
+			name = ServicesMenu.strings;
+			sourceTree = "<group>";
 		};
 		D4E33D8827A838CF006DB1CF /* Localizable.strings */ = {
 			isa = PBXVariantGroup;

--- a/Source/AppDelegate.swift
+++ b/Source/AppDelegate.swift
@@ -153,8 +153,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NonModalAlertWindowControlle
     private var updateNextStepURL: URL?
     private var fsStreamHelper: FSEventStreamHelper?
 
-    func updateUserPhases() {
-        NSLog("updateUserPhases called \(LanguageModelManager.dataFolderPath)")
+    func updateUserPhrases() {
+        NSLog("updateUserPhrases called \(LanguageModelManager.dataFolderPath)")
         LanguageModelManager.loadUserPhrases()
         LanguageModelManager.loadUserPhraseReplacement()
 
@@ -167,7 +167,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NonModalAlertWindowControlle
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         LanguageModelManager.setupDataModelValueConverter()
-        updateUserPhases()
+        updateUserPhrases()
 
         if UserDefaults.standard.object(forKey: kCheckUpdateAutomatically) == nil {
             UserDefaults.standard.set(true, forKey: kCheckUpdateAutomatically)
@@ -175,8 +175,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NonModalAlertWindowControlle
         }
 
         NotificationCenter.default.addObserver(forName: .userPhraseLocationDidChange, object: nil, queue: OperationQueue.main) { notification in
-            self.updateUserPhases()
+            self.updateUserPhrases()
         }
+
+        NSApp.servicesProvider = ServiceProvider()
 
         checkForUpdate()
     }
@@ -269,5 +271,40 @@ extension AppDelegate: FSEventStreamHelperDelegate {
             LanguageModelManager.loadUserPhrases()
             LanguageModelManager.loadUserPhraseReplacement()
         }
+    }
+}
+
+extension AppDelegate {
+    private func open(userFileAt path: String) {
+        func checkIfUserFilesExist() -> Bool {
+            if !LanguageModelManager.checkIfUserLanguageModelFilesExist() {
+                let content = String(format: NSLocalizedString("Please check the permission of the path at \"%@\".", comment: ""), LanguageModelManager.dataFolderPath)
+                NonModalAlertWindowController.shared.show(title: NSLocalizedString("Unable to create the user phrase file.", comment: ""), content: content, confirmButtonTitle: NSLocalizedString("OK", comment: ""), cancelButtonTitle: nil, cancelAsDefault: false, delegate: nil)
+                return false
+            }
+            return true
+        }
+
+        if !checkIfUserFilesExist() {
+            return
+        }
+        let url = URL(fileURLWithPath: path)
+        NSWorkspace.shared.open(url)
+    }
+
+    @objc func openUserPhrases(_ sender: Any?) {
+        open(userFileAt: LanguageModelManager.userPhrasesDataPathMcBopomofo)
+    }
+
+    @objc func openExcludedPhrasesPlainBopomofo(_ sender: Any?) {
+        open(userFileAt: LanguageModelManager.excludedPhrasesDataPathPlainBopomofo)
+    }
+
+    @objc func openExcludedPhrasesMcBopomofo(_ sender: Any?) {
+        open(userFileAt: LanguageModelManager.excludedPhrasesDataPathMcBopomofo)
+    }
+
+    @objc func openPhraseReplacementMcBopomofo(_ sender: Any?) {
+        open(userFileAt: LanguageModelManager.phraseReplacementDataPathMcBopomofo)
     }
 }

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -135,6 +135,11 @@ bool McBopomofoLM::hasUnigrams(const std::string& key)
     return getUnigrams(key).size() > 0;
 }
 
+std::vector<std::string_view> McBopomofoLM::getPronounciations(const std::string_view& value)
+{
+    return m_languageModel.getPronounciations(value);
+}
+
 void McBopomofoLM::setPhraseReplacementEnabled(bool enabled)
 {
     m_phraseReplacementEnabled = enabled;

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -24,6 +24,7 @@
 #include "McBopomofoLM.h"
 #include <algorithm>
 #include <iterator>
+#include <float.h>
 
 namespace McBopomofo {
 
@@ -135,9 +136,24 @@ bool McBopomofoLM::hasUnigrams(const std::string& key)
     return getUnigrams(key).size() > 0;
 }
 
-std::vector<std::string_view> McBopomofoLM::getPronounciations(const std::string_view& value)
+std::string McBopomofoLM::getReading(const std::string_view& value)
 {
-    return m_languageModel.getPronounciations(value);
+    std::vector<std::string> records = m_languageModel.getReadings(value);
+    
+    double highScore = -DBL_MAX;
+    std::string highScoringValue;
+    for (std::string record : records) {
+        std::vector<std::string_view> parts = split(record, ' ');
+        if (parts.size() == 3) {
+            double score = std::stod(std::string(parts[2]));
+            if (score > highScore) {
+                highScoringValue = std::string(parts[0]);
+                highScore = score;
+            }
+        }
+    }
+    
+    return highScoringValue;
 }
 
 void McBopomofoLM::setPhraseReplacementEnabled(bool enabled)
@@ -204,6 +220,17 @@ const std::vector<std::string> McBopomofoLM::associatedPhrasesForKey(const std::
 bool McBopomofoLM::hasAssociatedPhrasesForKey(const std::string& key)
 {
     return m_associatedPhrases.hasValuesForKey(key);
+}
+
+std::vector<std::string_view> McBopomofoLM::split(const std::string_view& str, char delim) {
+    std::vector<std::string_view> strings;
+    size_t start;
+    size_t end = 0;
+    while ((start = str.find_first_not_of(delim, end)) != std::string_view::npos) {
+        end = str.find(delim, start);
+        strings.push_back(std::string_view(str.substr(start, end - start)));
+    }
+    return strings;
 }
 
 } // namespace McBopomofo

--- a/Source/Engine/McBopomofoLM.h
+++ b/Source/Engine/McBopomofoLM.h
@@ -105,11 +105,11 @@ public:
     const std::vector<std::string> associatedPhrasesForKey(const std::string& key);
     bool hasAssociatedPhrasesForKey(const std::string& key);
 
-    /// Returns a list of pronounciations that match a given value.
-    /// @param value A string representing the text to look up pronounciation candidates for. For example,
+    /// Returns a list of readings that match a given value.
+    /// @param value A string representing the text to look up reading candidates for. For example,
     ///     if you pass "說", it returns a list of records that include ㄕㄨㄛ, ㄕㄨㄟˋ, and ㄩㄝˋ.
-    /// @return An unsorted list of string records of the form "<key> <value> <score>" separated by spaces.
-    std::vector<std::string_view> getPronounciations(const std::string_view& value);
+    /// @return Best reading found for the string, or an empty string if no matches are found.
+    std::string getReading(const std::string_view& value);
 
 protected:
     /// Filters and converts the input unigrams and return a new list of unigrams.
@@ -122,6 +122,12 @@ protected:
     std::vector<Formosa::Gramambular2::LanguageModel::Unigram> filterAndTransformUnigrams(const std::vector<Formosa::Gramambular2::LanguageModel::Unigram> unigrams,
         const std::unordered_set<std::string>& excludedValues,
         std::unordered_set<std::string>& insertedValues);
+
+    /// Splits a string into parts
+    /// @param str The string to split.
+    /// @param delim Delimiter character in the string to split on.
+    /// @return vector of split-up strings
+    std::vector<std::string_view> split(const std::string_view& str, char delim);
 
     ParselessLM m_languageModel;
     UserPhrasesLM m_userPhrases;

--- a/Source/Engine/McBopomofoLM.h
+++ b/Source/Engine/McBopomofoLM.h
@@ -105,6 +105,12 @@ public:
     const std::vector<std::string> associatedPhrasesForKey(const std::string& key);
     bool hasAssociatedPhrasesForKey(const std::string& key);
 
+    /// Returns a list of pronounciations that match a given value.
+    /// @param value A string representing the text to look up pronounciation candidates for. For example,
+    ///     if you pass "說", it returns a list of records that include ㄕㄨㄛ, ㄕㄨㄟˋ, and ㄩㄝˋ.
+    /// @return An unsorted list of string records of the form "<key> <value> <score>" separated by spaces.
+    std::vector<std::string_view> getPronounciations(const std::string_view& value);
+
 protected:
     /// Filters and converts the input unigrams and return a new list of unigrams.
     ///

--- a/Source/Engine/ParselessLM.cpp
+++ b/Source/Engine/ParselessLM.cpp
@@ -144,3 +144,12 @@ bool McBopomofo::ParselessLM::hasUnigrams(const std::string& key)
 
     return db_->findFirstMatchingLine(key + " ") != nullptr;
 }
+
+std::vector<std::string_view> McBopomofo::ParselessLM::getPronounciations(const std::string_view& value)
+{
+    if (db_ == nullptr) {
+        return std::vector<std::string_view>();
+    }
+    
+    return db_->reverseFindRows(value);
+}

--- a/Source/Engine/ParselessLM.cpp
+++ b/Source/Engine/ParselessLM.cpp
@@ -145,10 +145,10 @@ bool McBopomofo::ParselessLM::hasUnigrams(const std::string& key)
     return db_->findFirstMatchingLine(key + " ") != nullptr;
 }
 
-std::vector<std::string_view> McBopomofo::ParselessLM::getPronounciations(const std::string_view& value)
+std::vector<std::string> McBopomofo::ParselessLM::getReadings(const std::string_view& value)
 {
     if (db_ == nullptr) {
-        return std::vector<std::string_view>();
+        return std::vector<std::string>();
     }
     
     return db_->reverseFindRows(value);

--- a/Source/Engine/ParselessLM.h
+++ b/Source/Engine/ParselessLM.h
@@ -45,6 +45,9 @@ public:
         const std::string& key) override;
     bool hasUnigrams(const std::string& key) override;
 
+    std::vector<std::string_view> getPronounciations(
+        const std::string_view& value);
+
 private:
     int fd_ = -1;
     void* data_ = nullptr;

--- a/Source/Engine/ParselessLM.h
+++ b/Source/Engine/ParselessLM.h
@@ -45,8 +45,7 @@ public:
         const std::string& key) override;
     bool hasUnigrams(const std::string& key) override;
 
-    std::vector<std::string_view> getPronounciations(
-        const std::string_view& value);
+    std::vector<std::string> getReadings(const std::string_view& value);
 
 private:
     int fd_ = -1;

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -163,4 +163,44 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
     return nullptr;
 }
 
+std::vector<std::string_view> ParselessPhraseDB::reverseFindRows(
+    const std::string_view& value)
+{
+    std::vector<std::string_view> rows;
+
+    const char* recordBegin = begin_;
+
+    while (recordBegin < end_) {
+        const char* ptr = recordBegin;
+        
+        // skip over the key to find the field separator
+        while (ptr < end_ && *ptr != ' ') {
+            ++ptr;
+        }
+        // skip over the field separator. there should be just one, but loop just in case.
+        while (ptr < end_ && *ptr == ' ') {
+            ++ptr;
+        }
+        
+        // now walk to the end of this record
+        const char* recordEnd = ptr;
+        while (recordEnd < end_ && *recordEnd != '\n') {
+            ++recordEnd;
+        }
+        
+        if (ptr + value.length() < end_ && memcmp(ptr, value.data(), value.length()) == 0) {
+            // prefix match, add entire record to return value
+            rows.emplace_back(recordBegin, recordEnd - recordBegin);
+        }
+        
+        // skip over the record separator. there should be just one, but loop just in case.
+        recordBegin = recordEnd;
+        while (recordBegin < end_ && *recordBegin == '\n') {
+            ++recordBegin;
+        }
+    }
+
+    return rows;
+}
+
 }; // namespace McBopomofo

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -163,10 +163,10 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
     return nullptr;
 }
 
-std::vector<std::string_view> ParselessPhraseDB::reverseFindRows(
+std::vector<std::string> ParselessPhraseDB::reverseFindRows(
     const std::string_view& value)
 {
-    std::vector<std::string_view> rows;
+    std::vector<std::string> rows;
 
     const char* recordBegin = begin_;
 

--- a/Source/Engine/ParselessPhraseDB.h
+++ b/Source/Engine/ParselessPhraseDB.h
@@ -53,7 +53,7 @@ public:
     // Find the rows that (prefix-)match the value, useful for returning all the
     // ways a phrase or character can be pronounced. Note that this is a potentially-
     // slow linear search that cannot take advantage of the pre-sorting.
-    std::vector<std::string_view> reverseFindRows(const std::string_view& value);
+    std::vector<std::string> reverseFindRows(const std::string_view& value);
 
 private:
     const char* begin_;

--- a/Source/Engine/ParselessPhraseDB.h
+++ b/Source/Engine/ParselessPhraseDB.h
@@ -50,6 +50,11 @@ public:
 
     const char* findFirstMatchingLine(const std::string_view& key);
 
+    // Find the rows that (prefix-)match the value, useful for returning all the
+    // ways a phrase or character can be pronounced. Note that this is a potentially-
+    // slow linear search that cannot take advantage of the pre-sorting.
+    std::vector<std::string_view> reverseFindRows(const std::string_view& value);
+
 private:
     const char* begin_;
     const char* end_;

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -233,37 +233,20 @@ class McBopomofoInputMethodController: IMKInputController {
         (NSApp.delegate as? AppDelegate)?.checkForUpdate(forced: true)
     }
 
-    private func open(userFileAt path: String) {
-        func checkIfUserFilesExist() -> Bool {
-            if !LanguageModelManager.checkIfUserLanguageModelFilesExist() {
-                let content = String(format: NSLocalizedString("Please check the permission of the path at \"%@\".", comment: ""), LanguageModelManager.dataFolderPath)
-                NonModalAlertWindowController.shared.show(title: NSLocalizedString("Unable to create the user phrase file.", comment: ""), content: content, confirmButtonTitle: NSLocalizedString("OK", comment: ""), cancelButtonTitle: nil, cancelAsDefault: false, delegate: nil)
-                return false
-            }
-            return true
-        }
-
-        if !checkIfUserFilesExist() {
-            return
-        }
-        let url = URL(fileURLWithPath: path)
-        NSWorkspace.shared.open(url)
-    }
-
     @objc func openUserPhrases(_ sender: Any?) {
-        open(userFileAt: LanguageModelManager.userPhrasesDataPathMcBopomofo)
+        (NSApp.delegate as? AppDelegate)?.openUserPhrases(sender)
     }
 
     @objc func openExcludedPhrasesPlainBopomofo(_ sender: Any?) {
-        open(userFileAt: LanguageModelManager.excludedPhrasesDataPathPlainBopomofo)
+        (NSApp.delegate as? AppDelegate)?.openExcludedPhrasesPlainBopomofo(sender)
     }
 
     @objc func openExcludedPhrasesMcBopomofo(_ sender: Any?) {
-        open(userFileAt: LanguageModelManager.excludedPhrasesDataPathMcBopomofo)
+        (NSApp.delegate as? AppDelegate)?.openExcludedPhrasesMcBopomofo(sender)
     }
 
     @objc func openPhraseReplacementMcBopomofo(_ sender: Any?) {
-        open(userFileAt: LanguageModelManager.phraseReplacementDataPathMcBopomofo)
+        (NSApp.delegate as? AppDelegate)?.openPhraseReplacementMcBopomofo(sender)
     }
 
     @objc func reloadUserPhrases(_ sender: Any?) {

--- a/Source/LanguageModelManager.h
+++ b/Source/LanguageModelManager.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)checkIfUserPhraseExist:(NSString *)userPhrase key:(NSString *)key NS_SWIFT_NAME(checkIfExist(userPhrase:key:));
 + (BOOL)writeUserPhrase:(NSString *)userPhrase;
 
++ (nullable NSString *)pronounciationFor:(NSString *)phrase;
+
 @property (class, readonly, nonatomic) NSString *dataFolderPath;
 @property (class, readonly, nonatomic) NSString *userPhrasesDataPathMcBopomofo;
 @property (class, readonly, nonatomic) NSString *excludedPhrasesDataPathMcBopomofo;

--- a/Source/LanguageModelManager.h
+++ b/Source/LanguageModelManager.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)checkIfUserPhraseExist:(NSString *)userPhrase key:(NSString *)key NS_SWIFT_NAME(checkIfExist(userPhrase:key:));
 + (BOOL)writeUserPhrase:(NSString *)userPhrase;
 
-+ (nullable NSString *)pronounciationFor:(NSString *)phrase;
++ (nullable NSString *)readingFor:(NSString *)phrase;
 
 @property (class, readonly, nonatomic) NSString *dataFolderPath;
 @property (class, readonly, nonatomic) NSString *userPhrasesDataPathMcBopomofo;

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -305,28 +305,13 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     gLanguageModelMcBopomofo.setPhraseReplacementEnabled(phraseReplacementEnabled);
 }
 
-+ (nullable NSString *)pronounciationFor:(NSString *)phrase {
++ (nullable NSString *)readingFor:(NSString *)phrase {
     if (!gLanguageModelMcBopomofo.isDataModelLoaded()) {
         [self loadDataModel:InputModeBopomofo];
     }
-
-    std::vector<std::string_view> records = gLanguageModelMcBopomofo.getPronounciations(phrase.UTF8String);
-
-    double highScore = -DBL_MAX;
-    NSString *highScoringValue = nil;
-    for (std::string_view record : records) {
-        NSString *string = [NSString stringWithCString:std::string(record).c_str() encoding:NSUTF8StringEncoding];
-        NSArray<NSString *> *parts = [string componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        if (parts.count == 3) {
-            double score = parts[2].doubleValue;
-            if (score > highScore) {
-                highScoringValue = parts[0];
-                highScore = parts[2].doubleValue;
-            }
-        }
-    }
-
-    return highScoringValue;
+    
+    std::string reading = gLanguageModelMcBopomofo.getReading(phrase.UTF8String);
+    return !reading.empty() ? [NSString stringWithCString:reading.c_str() encoding:NSUTF8StringEncoding] : nil;
 }
 
 @end

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -305,4 +305,28 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     gLanguageModelMcBopomofo.setPhraseReplacementEnabled(phraseReplacementEnabled);
 }
 
++ (nullable NSString *)pronounciationFor:(NSString *)phrase {
+    if (!gLanguageModelMcBopomofo.isDataModelLoaded()) {
+        [self loadDataModel:InputModeBopomofo];
+    }
+
+    std::vector<std::string_view> records = gLanguageModelMcBopomofo.getPronounciations(phrase.UTF8String);
+
+    double highScore = -DBL_MAX;
+    NSString *highScoringValue = nil;
+    for (std::string_view record : records) {
+        NSString *string = [NSString stringWithCString:std::string(record).c_str() encoding:NSUTF8StringEncoding];
+        NSArray<NSString *> *parts = [string componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        if (parts.count == 3) {
+            double score = parts[2].doubleValue;
+            if (score > highScore) {
+                highScoringValue = parts[0];
+                highScore = parts[2].doubleValue;
+            }
+        }
+    }
+
+    return highScoringValue;
+}
+
 @end

--- a/Source/McBopomofo-Info.plist
+++ b/Source/McBopomofo-Info.plist
@@ -128,5 +128,23 @@
 	</array>
 	<key>tsInputMethodIconFileKey</key>
 	<string>Bopomofo.tiff</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMessage</key>
+			<string>addUserPhrase</string>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Add to ${PRODUCT_NAME} User Phrases</string>
+			</dict>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>NSRequiredContext</key>
+			<dict/>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Source/McBopomofo-Info.plist
+++ b/Source/McBopomofo-Info.plist
@@ -136,7 +136,7 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Add to ${PRODUCT_NAME} User Phrases</string>
+				<string>Add to McBopomofo User Phrases</string>
 			</dict>
 			<key>NSSendTypes</key>
 			<array>

--- a/Source/ServiceProvider.swift
+++ b/Source/ServiceProvider.swift
@@ -44,7 +44,7 @@ class ServiceProvider: NSObject {
             var drop = 0
             while drop < substringCount {
                 let candidate = String(substring.dropLast(drop))
-                if let match = LanguageModelManager.pronounciation(for: candidate) {
+                if let match = LanguageModelManager.reading(for: candidate) {
                     // append the match and skip over the matched portion
                     matches.append(match)
                     matchFrom = firstWord.index(matchFrom, offsetBy: substringCount - drop)
@@ -60,8 +60,8 @@ class ServiceProvider: NSObject {
             }
         }
         
-        let pronounciation = matches.joined(separator: "-")
-        LanguageModelManager.writeUserPhrase("\(firstWord) \(pronounciation)")
+        let reading = matches.joined(separator: "-")
+        LanguageModelManager.writeUserPhrase("\(firstWord) \(reading)")
         (NSApp.delegate as? AppDelegate)?.openUserPhrases(self)
     }
 }

--- a/Source/ServiceProvider.swift
+++ b/Source/ServiceProvider.swift
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+import AppKit
+
+class ServiceProvider: NSObject {
+    @objc func addUserPhrase(_ pasteboard: NSPasteboard, userData: String?, error: NSErrorPointer) {
+        guard let string = pasteboard.string(forType: .string),
+              let firstWord = string.components(separatedBy: .whitespacesAndNewlines).first
+        else {
+            return
+        }
+        
+        var matches: [String] = []
+        
+        // greedily find the longest possible matches
+        var matchFrom = firstWord.startIndex
+        while matchFrom < firstWord.endIndex {
+            let substring = firstWord.suffix(from: matchFrom)
+            let substringCount = substring.count
+            
+            // if an exact match fails, try dropping successive characters from the end to see
+            // if we can find shorter matches
+            var drop = 0
+            while drop < substringCount {
+                let candidate = String(substring.dropLast(drop))
+                if let match = LanguageModelManager.pronounciation(for: candidate) {
+                    // append the match and skip over the matched portion
+                    matches.append(match)
+                    matchFrom = firstWord.index(matchFrom, offsetBy: substringCount - drop)
+                    break
+                }
+                drop += 1
+            }
+            
+            if drop >= substringCount {
+                // didn't match anything?!
+                matches.append("？")
+                matchFrom = firstWord.index(matchFrom, offsetBy: 1)
+            }
+        }
+        
+        let pronounciation = matches.joined(separator: "-")
+        LanguageModelManager.writeUserPhrase("\(firstWord) \(pronounciation)")
+        (NSApp.delegate as? AppDelegate)?.openUserPhrases(self)
+    }
+}

--- a/Source/en.lproj/ServicesMenu.strings
+++ b/Source/en.lproj/ServicesMenu.strings
@@ -1,0 +1,1 @@
+"Add to McBopomofo User Phrases" = "Add to McBopomofo User Phrases";

--- a/Source/zh-Hant.lproj/ServicesMenu.strings
+++ b/Source/zh-Hant.lproj/ServicesMenu.strings
@@ -1,0 +1,1 @@
+"Add to McBopomofo User Phrases" = "加入小麥注音使用者詞彙";


### PR DESCRIPTION
### 使用方法：

1. 選擇某常用詞句
2. ⌘-點擊，選取「服務」→「加入小麥注音使用者詞彙」選項
3. 在編輯器裡檢視自動填入的注音

<img width="484" alt="截圖 2023-10-01 下午3 57 22" src="https://github.com/openvanilla/McBopomofo/assets/140762048/25597327-b7e4-4b59-ba49-4461b47ec562">

### 注意：

開發時，系統可能需要強迫重讀新的服務才能使用：

```
    /System/Library/CoreServices/pbs -update
    /System/Library/CoreServices/pbs -flush
```

### 技術細節：

ParselessPhraseDB:
- search database for lines that match the "value" (phrase) field of the record
- 在內建詞庫裡搜尋符合一個詞的項目。這跟輸入法從注音找詞的用法相反。

McBopomofoLM, ParselessLM:
- pass the found records up
- 上傳找到的項目

LanguageModelManager:
- go through the records and find the highest-scoring match for a phrase, and return the "key" (pronounciation)
- 在符合的項目裡依分數排序，回覆最高分的注音。

AppDelegate, InputMethodController:
- move `openUserPhrases()` and others to AppDelegate for reuse, because InputMethodController is created by the system and there doesn't appear to be an easy way to get to it.
- 把 `openUserPhrases()` 等移到 AppDelegate 重用。InputMethodController 似乎沒有簡易取得物件的方式。

ServiceProvider:
- greedily match the longest possible substrings of the supplied string
- write the new entry to the user phrases list
- open the user phrases in an editor for the user to verify
- 在資料庫裡找詞，以最長的字串優先。
- 把新詞和注音寫入使用者詞彙。
- 啟動編輯器讓使用者檢查注音是否正確。

### 附註：

C++ 多年沒用，有點生疏了。有什麼錯誤請多包涵、指教。