### PR TITLE
Bring in clang-tidy fixes done in fcitx5-mcbopomofo

### DIFF
--- a/Source/Engine/AssociatedPhrases.cpp
+++ b/Source/Engine/AssociatedPhrases.cpp
@@ -53,10 +53,7 @@ AssociatedPhrases::~AssociatedPhrases()
 
 bool AssociatedPhrases::isLoaded()
 {
-    if (data) {
-        return true;
-    }
-    return false;
+    return data != nullptr;
 }
 
 bool AssociatedPhrases::open(const char* path)

--- a/Source/Engine/Mandarin/Mandarin.cpp
+++ b/Source/Engine/Mandarin/Mandarin.cpp
@@ -58,7 +58,7 @@ class BopomofoCharacterMap {
 };
 
 const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
-  if (!str.length()) {
+  if (str.length() == 0) {
     return BPMF();
   }
 
@@ -73,9 +73,11 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   // lookup consonants and consume them
   bool independentConsonant = false;
 
+  // disable this check for if-else/switch blocks below
+  // NOLINTBEGIN(bugprone-branch-clone)
+
   // the y exceptions fist
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "yuan")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::AN;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ying")) {
@@ -101,7 +103,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // try the first character
-  char c = pinyin.length() ? pinyin[0] : 0;
+  char c = pinyin.length() != 0 ? pinyin[0] : '\0';
   switch (c) {
     case 'b':
       firstComponent = BPMF::B;
@@ -160,7 +162,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
       pinyin = pinyin.substr(1);
       break;
 
-    // special hanlding for w and y
+    // special handling for w and y
     case 'w':
       secondComponent = BPMF::U;
       pinyin = pinyin.substr(1);
@@ -174,8 +176,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then we try ZH, CH, SH, R, Z, C, S (in that order)
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "zh")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "zh")) {
     firstComponent = BPMF::ZH;
     independentConsonant = true;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ch")) {
@@ -200,8 +201,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
 
   // consume exceptions first: (ien, in), (iou, iu), (uen, un), (veng, iong),
   // (ven, vn), (uei, ui), ung but longer sequence takes precedence
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "veng")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "veng")) {
     secondComponent = BPMF::UE;
     thirdComponent = BPMF::ENG;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "iong")) {
@@ -269,8 +269,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // then consume the middle component...
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "i")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "i")) {
     secondComponent = independentConsonant ? 0 : BPMF::I;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "u")) {
     if (firstComponent == BPMF::J || firstComponent == BPMF::Q ||
@@ -284,8 +283,7 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
   }
 
   // the vowels, longer sequence takes precedence
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "ang")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "ang")) {
     thirdComponent = BPMF::ANG;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "eng")) {
     thirdComponent = BPMF::ENG;
@@ -316,10 +314,10 @@ const BPMF BPMF::FromHanyuPinyin(const std::string& str) {
       thirdComponent = BPMF::ER;
     }
   }
+  // NOLINTEND(bugprone-branch-clone)
 
   // at last!
-  if (0) {
-  } else if (PinyinParseHelper::ConsumePrefix(pinyin, "1")) {
+  if (PinyinParseHelper::ConsumePrefix(pinyin, "1")) {
     toneComponent = BPMF::Tone1;
   } else if (PinyinParseHelper::ConsumePrefix(pinyin, "2")) {
     toneComponent = BPMF::Tone2;
@@ -379,43 +377,63 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       break;
     case J:
       consonant = "j";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case Q:
       consonant = "q";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case X:
       consonant = "x";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case ZH:
       consonant = "zh";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case CH:
       consonant = "ch";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case SH:
       consonant = "sh";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case R:
       consonant = "r";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case Z:
       consonant = "z";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case C:
       consonant = "c";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
     case S:
       consonant = "s";
-      if (hasNoMVCOrVC) middle = "i";
+      if (hasNoMVCOrVC) {
+        middle = "i";
+      }
       break;
   }
 
@@ -447,6 +465,7 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       break;
   }
 
+  // NOLINTBEGIN(bugprone-branch-clone)
   switch (vc) {
     case A:
       vowel = "a";
@@ -488,6 +507,7 @@ const std::string BPMF::HanyuPinyinString(bool includesTone,
       vowel = "er";
       break;
   }
+  // NOLINTEND(bugprone-branch-clone)
 
   // combination rules
 
@@ -561,12 +581,15 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
     // the Bopomofo character map or to split the input by codepoints. This
     // suffices for now.
 
+    // disable for check for code points below
+    // NOLINTBEGIN(readability-magic-numbers)
+
     // Illegal.
     if (!(*iter & 0x80)) {
       break;
     }
 
-    size_t utf8_length = -1;
+    std::string::difference_type utf8_length = -1;
 
     // These are the code points for the tone markers.
     if ((*iter & (0x80 | 0x40)) && !(*iter & 0x20)) {
@@ -577,6 +600,7 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
       // Illegal.
       break;
     }
+    // NOLINTEND(readability-magic-numbers)
 
     if (iter + (utf8_length - 1) == str.end()) {
       break;
@@ -589,9 +613,8 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
         charToComp.find(component);
     if (result == charToComp.end()) {
       break;
-    } else {
-      syllable += BPMF((*result).second);
     }
+    syllable += BPMF((*result).second);
     iter += utf8_length;
   }
   return syllable;
@@ -600,10 +623,10 @@ const BPMF BPMF::FromComposedString(const std::string& str) {
 const std::string BPMF::composedString() const {
   std::string result;
 #define APPEND(c)                                                         \
-  if (syllable_ & c)                                                      \
+  if (syllable_ & (c))                                                    \
   result +=                                                               \
       (*BopomofoCharacterMap::SharedInstance().componentToCharacter.find( \
-           syllable_ & c))                                                \
+           syllable_ & (c)))                                              \
           .second
   APPEND(ConsonantMask);
   APPEND(MiddleVowelMask);
@@ -663,10 +686,13 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
 
   for (std::map<std::string, BPMF::Component>::iterator iter =
            characterToComponent.begin();
-       iter != characterToComponent.end(); ++iter)
+       iter != characterToComponent.end(); ++iter) {
     componentToCharacter[(*iter).second] = (*iter).first;
+  }
 }
 
+// we don't need parentheses for these macros
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define ASSIGNKEY1(m, vec, k, val) \
   m[k] = (vec.clear(), vec.push_back((BPMF::Component)val), vec)
 #define ASSIGNKEY2(m, vec, k, val1, val2)                    \
@@ -676,6 +702,7 @@ BopomofoCharacterMap::BopomofoCharacterMap() {
   m[k] = (vec.clear(), vec.push_back((BPMF::Component)val1), \
           vec.push_back((BPMF::Component)val2),              \
           vec.push_back((BPMF::Component)val3), vec)
+// NOLINTEND(bugprone-macro-parentheses)
 
 static BopomofoKeyboardLayout* CreateStandardLayout() {
   std::vector<BPMF::Component> vec;

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -24,6 +24,7 @@
 #ifndef MANDARIN_H_
 #define MANDARIN_H_
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <string>

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -134,7 +134,7 @@ bool McBopomofoLM::hasUnigrams(const std::string& key)
         return m_userPhrases.hasUnigrams(key) || m_languageModel.hasUnigrams(key);
     }
 
-    return getUnigrams(key).size() > 0;
+    return !getUnigrams(key).empty();
 }
 
 std::string McBopomofoLM::getReading(const std::string& value)
@@ -156,7 +156,7 @@ void McBopomofoLM::setPhraseReplacementEnabled(bool enabled)
     m_phraseReplacementEnabled = enabled;
 }
 
-bool McBopomofoLM::phraseReplacementEnabled()
+bool McBopomofoLM::phraseReplacementEnabled() const
 {
     return m_phraseReplacementEnabled;
 }
@@ -166,7 +166,7 @@ void McBopomofoLM::setExternalConverterEnabled(bool enabled)
     m_externalConverterEnabled = enabled;
 }
 
-bool McBopomofoLM::externalConverterEnabled()
+bool McBopomofoLM::externalConverterEnabled() const
 {
     return m_externalConverterEnabled;
 }
@@ -191,7 +191,7 @@ std::vector<Formosa::Gramambular2::LanguageModel::Unigram> McBopomofoLM::filterA
         std::string value = originalValue;
         if (m_phraseReplacementEnabled) {
             std::string replacement = m_phraseReplacement.valueForKey(value);
-            if (replacement != "") {
+            if (!replacement.empty()) {
                 value = replacement;
             }
         }

--- a/Source/Engine/McBopomofoLM.h
+++ b/Source/Engine/McBopomofoLM.h
@@ -55,7 +55,7 @@ namespace McBopomofo {
 ///
 /// The controller can ask the model to load the primary input method language
 /// model while launching and to load the user phrases anytime if the custom
-/// files are modified. It does not keep the reference of the data pathes but
+/// files are modified. It does not keep the reference of the data paths but
 /// you have to pass the paths when you ask it to do loading.
 class McBopomofoLM : public Formosa::Gramambular2::LanguageModel {
 public:
@@ -64,7 +64,7 @@ public:
 
     /// Asks to load the primary language model at the given path.
     /// @param languageModelPath The path of the language model.
-    void loadLanguageModel(const char* languageModelPath);
+    void loadLanguageModel(const char* languageModelDataPath);
     /// If the data model is already loaded.
     bool isDataModelLoaded();
 
@@ -77,7 +77,7 @@ public:
     /// Asks to load the user phrases and excluded phrases at the given path.
     /// @param userPhrasesPath The path of user phrases.
     /// @param excludedPhrasesPath The path of excluded phrases.
-    void loadUserPhrases(const char* userPhrasesPath, const char* excludedPhrasesPath);
+    void loadUserPhrases(const char* userPhrasesDataPath, const char* excludedPhrasesDataPath);
     /// Asks to load th phrase replacement table at the given path.
     /// @param phraseReplacementPath The path of the phrase replacement table.
     void loadPhraseReplacementMap(const char* phraseReplacementPath);
@@ -93,12 +93,12 @@ public:
     /// Enables or disables phrase replacement.
     void setPhraseReplacementEnabled(bool enabled);
     /// If phrase replacement is enabled or not.
-    bool phraseReplacementEnabled();
+    bool phraseReplacementEnabled() const;
 
     /// Enables or disables the external converter.
     void setExternalConverterEnabled(bool enabled);
     /// If the external converted is enabled or not.
-    bool externalConverterEnabled();
+    bool externalConverterEnabled() const;
     /// Sets a lambda to let the values of unigrams could be converted by it.
     void setExternalConverter(std::function<std::string(std::string)> externalConverter);
 

--- a/Source/Engine/ParselessLM.cpp
+++ b/Source/Engine/ParselessLM.cpp
@@ -35,10 +35,7 @@ McBopomofo::ParselessLM::~ParselessLM() { close(); }
 
 bool McBopomofo::ParselessLM::isLoaded()
 {
-    if (data_) {
-        return true;
-    }
-    return false;
+    return data_ != nullptr;
 }
 
 bool McBopomofo::ParselessLM::open(const std::string_view& path)
@@ -70,7 +67,7 @@ bool McBopomofo::ParselessLM::open(const std::string_view& path)
     }
 
     db_ = std::unique_ptr<ParselessPhraseDB>(new ParselessPhraseDB(
-        static_cast<char*>(data_), length_, /*validate_pragme=*/
+        static_cast<char*>(data_), length_, /*validate_pragma=*/
         true));
     return true;
 }
@@ -99,7 +96,7 @@ McBopomofo::ParselessLM::getUnigrams(const std::string& key)
         double score = 0;
 
         // Move ahead until we encounter the first space. This is the key.
-        auto it = row.begin();
+        const auto* it = row.begin();
         while (it != row.end() && *it != ' ') {
             ++it;
         }
@@ -113,7 +110,7 @@ McBopomofo::ParselessLM::getUnigrams(const std::string& key)
 
         if (it != row.end()) {
             // Now it is the start of the value portion.
-            auto value_begin = it;
+            const auto* value_begin = it;
 
             // Move ahead until we encounter the second space. This is the
             // value.

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -42,13 +42,6 @@ ParselessPhraseDB::ParselessPhraseDB(
         std::string_view header(buf, SORTED_PRAGMA_HEADER.length());
         assert(header == SORTED_PRAGMA_HEADER);
 
-        uint32_t x = 5381;
-        for (const auto& i : header) {
-            x = x * 33 + i;
-        }
-
-        assert(x == uint32_t { 3012373384 });
-
         begin_ += header.length();
     }
 }

--- a/Source/Engine/PhraseReplacementMap.cpp
+++ b/Source/Engine/PhraseReplacementMap.cpp
@@ -54,8 +54,7 @@ bool PhraseReplacementMap::open(const char* path)
 
     KeyValueBlobReader reader(static_cast<char*>(data), length);
     KeyValueBlobReader::KeyValue keyValue;
-    KeyValueBlobReader::State state;
-    while ((state = reader.Next(&keyValue)) == KeyValueBlobReader::State::HAS_PAIR) {
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
         keyValueMap[keyValue.key] = keyValue.value;
     }
     return true;

--- a/Source/Engine/UserOverrideModel.cpp
+++ b/Source/Engine/UserOverrideModel.cpp
@@ -54,6 +54,7 @@ UserOverrideModel::UserOverrideModel(size_t capacity, double decayConstant)
     : m_capacity(capacity)
 {
     assert(m_capacity > 0);
+    // NOLINTNEXTLINE(readability-magic-numbers)
     m_decayExponent = log(0.5) / decayConstant;
 }
 

--- a/Source/Engine/UserPhrasesLM.cpp
+++ b/Source/Engine/UserPhrasesLM.cpp
@@ -49,10 +49,7 @@ UserPhrasesLM::~UserPhrasesLM()
 
 bool UserPhrasesLM::isLoaded()
 {
-    if (data) {
-        return true;
-    }
-    return false;
+    return data != nullptr;
 }
 
 bool UserPhrasesLM::open(const char* path)
@@ -83,8 +80,7 @@ bool UserPhrasesLM::open(const char* path)
 
     KeyValueBlobReader reader(static_cast<char*>(data), length);
     KeyValueBlobReader::KeyValue keyValue;
-    KeyValueBlobReader::State state;
-    while ((state = reader.Next(&keyValue)) == KeyValueBlobReader::State::HAS_PAIR) {
+    while (reader.Next(&keyValue) == KeyValueBlobReader::State::HAS_PAIR) {
         // We invert the key and value, since in user phrases, "key" is the phrase value, and "value" is the BPMF reading.
         keyRowMap[keyValue.value].emplace_back(keyValue.value, keyValue.key);
     }

--- a/Source/Engine/UserPhrasesLMTest.cpp
+++ b/Source/Engine/UserPhrasesLMTest.cpp
@@ -30,7 +30,7 @@
 
 namespace McBopomofo {
 
-TEST(UserPhreasesLMTest, LenientReading)
+TEST(UserPhrasesLMTest, LenientReading)
 {
     std::string tmp_name
         = std::string(std::filesystem::temp_directory_path() / "test.txt");

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -26,6 +26,7 @@
 
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/Source/UTF8Helper.cpp
+++ b/Source/UTF8Helper.cpp
@@ -24,6 +24,7 @@
 #include "UTF8Helper.h"
 
 namespace McBopomofo {
+// NOLINTBEGIN(readability-magic-numbers)
 
 // Adapted from https://github.com/lua/lua/blob/master/lutf8lib.c
 
@@ -117,4 +118,5 @@ std::string SubstringToCodePoints(const std::string& s, size_t cp) {
   return {s.cbegin(), i};
 }
 
+// NOLINTEND(readability-magic-numbers)
 }  // namespace McBopomofo


### PR DESCRIPTION
Cf. https://github.com/openvanilla/fcitx5-mcbopomofo/pull/83 and its related PRs.

This ensures that the engine code in the Mac version and that in fcitx5-mcbopomofo are in sync.
