### PR TITLE
Add user default to allow candidate selection using numeric keypad

### DIFF
--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -266,7 +266,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
-    if ([input isNumericPad]) {
+    if (!Preferences.selectCandidateWithNumericKeypad && [input isNumericPad]) {
         if (![input isLeft] && ![input isRight] && ![input isDown] && ![input isUp] && charCode != 32 && isprint(charCode)) {
             [self clear];
             InputStateEmpty *emptyState = [[InputStateEmpty alloc] init];

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -266,7 +266,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
-    if (!Preferences.selectCandidateWithNumericKeypad && [input isNumericPad]) {
+    if ([input isNumericPad] && !Preferences.selectCandidateWithNumericKeypad) {
         if (![input isLeft] && ![input isRight] && ![input isDown] && ![input isUp] && charCode != 32 && isprint(charCode)) {
             [self clear];
             InputStateEmpty *emptyState = [[InputStateEmpty alloc] init];

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -62,6 +62,8 @@ private let kDefaultAssociatedPhrasesKeys = "!@#$%^&*("
 private let kAddPhraseHookEnabledKey = "AddPhraseHookEnabled"
 private let kAddPhraseHookPath = "AddPhraseHookPath"
 
+private let kSelectCandidateWithNumericKeypad = "SelectCandidateWithNumericKeypad"
+
 // MARK: Property wrappers
 
 @propertyWrapper
@@ -453,4 +455,10 @@ extension Preferences {
 
     @UserDefaultWithFunction(key: kAddPhraseHookPath, defaultValueFunction: defaultAddPhraseHookPath)
     @objc static var addPhraseHookPath: String
+}
+
+extension Preferences {
+    
+    @UserDefault(key: kSelectCandidateWithNumericKeypad, defaultValue: false)
+    @objc static var selectCandidateWithNumericKeypad: Bool
 }


### PR DESCRIPTION
- default off, enable with "defaults write org.openvanilla.inputmethod.McBopomofo SelectCandidateWithNumericKeypad -bool YES"
- does not include Settings UI. I think it'd be a separate discussion as to whether UI is warranted.

fixes https://github.com/openvanilla/McBopomofo/issues/345