### PR TITLE
Ensure default font size selected in Preferences

### DIFF
--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -68,6 +68,28 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
         window?.title = NSLocalizedString("Basic", comment: "")
         use(view: basicSettingsView)
 
+        // When the `CandidateListTextSize` is not yet populated, the pop up
+        // button adds an empty item and selects that empty item. This code
+        // correctly sets the default text size, and removes the empty item
+        // at the end.
+        let selectedSizeTitle = fontSizePopUpButton.selectedItem?.title ?? ""
+        if selectedSizeTitle.isEmpty {
+            let intFontSizeStr = String.init(format: "%d", Int(Preferences.candidateListTextSize))
+            for item in fontSizePopUpButton.itemArray {
+                if item.title == intFontSizeStr {
+                    fontSizePopUpButton.select(item)
+                    break
+                }
+            }
+
+            let items = fontSizePopUpButton.itemArray
+            if let lastItem = items.last {
+                if lastItem.title.isEmpty {
+                    fontSizePopUpButton.removeItem(at: items.count - 1)
+                }
+            }
+        }
+
         let list = TISCreateInputSourceList(nil, true).takeRetainedValue() as! [TISInputSource]
         var usKeyboardLayoutItem: NSMenuItem? = nil
         var chosenItem: NSMenuItem? = nil


### PR DESCRIPTION
This bug may have existed for a long time. In short the pop up button does not select the default candidate font size (16 pt) when McBopomofo is first installed. Since the user defaults are not yet populated, the pop up button cannot find a value to select, and so an empty item is added and selected instead. This commit fixes the issue.

<img width="419" alt="1" src="https://github.com/openvanilla/McBopomofo/assets/25210/43a5b035-f5e7-4908-9036-b60c0736175f">

<img width="414" alt="2" src="https://github.com/openvanilla/McBopomofo/assets/25210/d096f57a-fbe4-46a1-9e63-f4e457fff91d">
