### PR TITLE
Show custom size in Candidate Text Size setting

### DIFF
--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -74,14 +74,41 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
         // at the end.
         let selectedSizeTitle = fontSizePopUpButton.selectedItem?.title ?? ""
         if selectedSizeTitle.isEmpty {
-            let intFontSizeStr = String.init(format: "%d", Int(Preferences.candidateListTextSize))
+            let intFontSize = Int(Preferences.candidateListTextSize)
+            let intFontSizeStr = String.init(format: "%d", intFontSize)
+
+            var selected = false
             for item in fontSizePopUpButton.itemArray {
                 if item.title == intFontSizeStr {
                     fontSizePopUpButton.select(item)
+                    selected = true
                     break
                 }
             }
 
+            // If not selecetd, Preferences.candidateListTextSize is not set to
+            // one of the options provided in the pop up button. Let's list the
+            // option for the user.
+            if !selected {
+                var insertIndex = 0
+
+                // Place the item in the right place. We take advantage of the
+                // fact that Int("") returns nil, and so if the custom font size
+                // is larger than the largest item in the list (say 96), this
+                // code guarantees to place the custom font size item right below
+                // that largest item and before the empty item (which will then
+                // be removed by the code below).
+                for (index, item) in fontSizePopUpButton.itemArray.enumerated() {
+                    if intFontSize < (Int(item.title) ?? Int.max) {
+                        insertIndex = index
+                        break
+                    }
+                }
+                fontSizePopUpButton.insertItem(withTitle: intFontSizeStr, at: insertIndex)
+                fontSizePopUpButton.selectItem(at: insertIndex)
+            }
+
+            // Remove the last item if it's empty
             let items = fontSizePopUpButton.itemArray
             if let lastItem = items.last {
                 if lastItem.title.isEmpty {


### PR DESCRIPTION
Before this treatment, if a user uses a custom candidate text size, the pop up button will revert to the first item (the smallest font size) in the list since we now remove the empty item at the bottom. If the user doesn't touch the pop up button, the custom font size remains intact. It's still a less ideal UI, though.

This commit makes sure that the custom font size is inserted into the pop up button and is selected.

Using `defaults write org.openvanilla.inputmethod.McBopomofo CandidateListTextSize -int 38` to set the custom font size to 38pt, this is before:

<img width="259" alt="1" src="https://github.com/openvanilla/McBopomofo/assets/25210/b76e47cc-70b7-4db2-a6b6-a05484ad1b39">

After:

<img width="208" alt="2" src="https://github.com/openvanilla/McBopomofo/assets/25210/0e02e44a-7959-48a5-8db2-adde0ccaa313">


