### PR TITLE
Honor the NSScroller.Style.overlay scrollbar style

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -327,13 +327,6 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             }
 
             keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
-
-            // fix a subtle OS X "bug" that, since we force the scroller to appear,
-            // scrolling sometimes shows a temporarily "broken" scroll bar
-            // (but quickly disappears)
-            if scrollView.hasVerticalScroller {
-                scrollView.verticalScroller?.setNeedsDisplay()
-            }
         }
     }
 
@@ -450,8 +443,10 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             scrollView.hasVerticalScroller = true
             let verticalScroller = scrollView.verticalScroller
             verticalScroller?.controlSize = controlSize
-            verticalScroller?.scrollerStyle = .legacy
-            scrollerWidth = NSScroller.scrollerWidth(for: controlSize, scrollerStyle: .legacy)
+            verticalScroller?.scrollerStyle = NSScroller.preferredScrollerStyle
+            if NSScroller.preferredScrollerStyle == .legacy {
+                scrollerWidth = NSScroller.scrollerWidth(for: controlSize, scrollerStyle: NSScroller.preferredScrollerStyle)
+            }
         }
 
         keyLabelStripView.keyLabelFont = keyLabelFont


### PR DESCRIPTION
@shuang886 Thanks again for your PR #383. After that, I wonder if we should start honor the `.overlay` scrollbar style. May I ask for your opinion for this one?

Here's the problem with our currently forced use of `.legacy`:

<img width="117" alt="current-ondemand" src="https://github.com/openvanilla/McBopomofo/assets/25210/b00d006c-34ba-439b-9875-a428d79d8967">

This is when "System Preferences > Appearance > Show scroll bars" is set to "Auto" (the default) or "When scrolling".

If the user sets to "Always" then things look fine:

<img width="136" alt="current-always" src="https://github.com/openvanilla/McBopomofo/assets/25210/462871b4-196e-460a-9cd4-5f687852d6d6">

In comparison, the retired candidate UI avoided laying the highlight on the scrollbar:

<img width="118" alt="legacy" src="https://github.com/openvanilla/McBopomofo/assets/25210/8b2504a5-94fd-45ff-b666-a84cf15d3768">

Now, one (not very rigorous) reason we wanted to always show the scrollbar was that we thought it gave a visual hint of "there's more", but I now think that the short appear-then-fade scrollbar when the table view has more than a pageful of content should suffice. macOS's built-in input methods also doesn't explicitly indicate "there's more" other than going along with the scrollbar convention.

After this commit, here's what the candidate sheet looks like (after the appear-and-fade of the scrollbar):

<img width="122" alt="after-ondemand" src="https://github.com/openvanilla/McBopomofo/assets/25210/9fdff3c4-d52d-439b-90c3-5b98f17dcbbb">

When the apperance setting is set to Always, the look remains the same:

<img width="115" alt="after-always" src="https://github.com/openvanilla/McBopomofo/assets/25210/8651e3be-a955-4059-a771-299012fe110f">