### PR TITLE
Fixes a boundary condition regarding integer conversion, and some fine-tunes

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -265,6 +265,12 @@ public class VerticalCandidateController: CandidateController {
         if selected == UInt.max || visibleRowIndexes.contains(Int(selected)) == false {
             keyLabelStripView.highlightedIndex = -1
             keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
+            scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
+                self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
+                self.tableView.deselectAll(self)
+                self.scrollTimer?.invalidate()
+                self.scrollTimer = nil
+            }
         } else {
             scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
                 self.tableView.reloadData()

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -184,7 +184,7 @@ public class VerticalCandidateController: CandidateController {
     }
 
     public override func reloadData() {
-        maxCandidateAttrStringWidth = ceil(candidateFont.pointSize * 2.0 + candidateTextPadding)
+        maxCandidateAttrStringWidth = ceil(candidateFont.pointSize * 1.0 + candidateTextPadding)
         tableView.reloadData()
         layoutCandidateView()
         if delegate?.candidateCountForController(self) ?? 0 > 0 {
@@ -470,9 +470,7 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             let verticalScroller = scrollView.verticalScroller
             verticalScroller?.controlSize = controlSize
             verticalScroller?.scrollerStyle = NSScroller.preferredScrollerStyle
-            if NSScroller.preferredScrollerStyle == .legacy {
-                scrollerWidth = NSScroller.scrollerWidth(for: controlSize, scrollerStyle: NSScroller.preferredScrollerStyle)
-            }
+            scrollerWidth = NSScroller.scrollerWidth(for: controlSize, scrollerStyle: NSScroller.preferredScrollerStyle)
         }
 
         keyLabelStripView.keyLabelFont = keyLabelFont

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -272,8 +272,8 @@ public class VerticalCandidateController: CandidateController {
 
         scrollTimer?.invalidate()
         if selected == UInt.max || visibleRowIndexes.contains(Int(selected)) == false {
-            selectedCandidateIndex = UInt(visibleRowIndexes.lowerBound)
-            tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
+            keyLabelStripView.highlightedIndex = -1
+            keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
         } else {
             scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
                 self.tableView.reloadData()

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -27,7 +27,7 @@ fileprivate class VerticalKeyLabelStripView: NSView {
     var keyLabelFont: NSFont = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
     var labelOffsetY: CGFloat = 0
     var keyLabels: [String] = []
-    var highlightedIndex: UInt = UInt.max
+    var highlightedIndex: Int = -1
 
     override var isFlipped: Bool {
         true
@@ -333,7 +333,7 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             }
 
             if newHilightIndex != keyLabelStripView.highlightedIndex && newHilightIndex >= 0 {
-                keyLabelStripView.highlightedIndex = UInt(newHilightIndex)
+                keyLabelStripView.highlightedIndex = newHilightIndex
                 keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
             }
 
@@ -348,9 +348,9 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             let firstVisibleRow = tableView.row(at: scrollView.documentVisibleRect.origin)
             // firstVisibleRow cannot be larger than selectedRow.
             if selectedRow >= firstVisibleRow {
-                keyLabelStripView.highlightedIndex = UInt(selectedRow - firstVisibleRow)
+                keyLabelStripView.highlightedIndex = selectedRow - firstVisibleRow
             } else {
-                keyLabelStripView.highlightedIndex = UInt.max
+                keyLabelStripView.highlightedIndex = -1
             }
 
             keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -68,15 +68,6 @@ fileprivate class VerticalKeyLabelStripView: NSView {
     }
 }
 
-fileprivate class VerticalCandidateTableView: NSTableView {
-    override func adjustScroll(_ newVisible: NSRect) -> NSRect {
-        var scrollRect = newVisible
-        let rowHeightPlusSpacing = rowHeight + intercellSpacing.height
-        scrollRect.origin.y = (scrollRect.origin.y / rowHeightPlusSpacing) * rowHeightPlusSpacing
-        return scrollRect
-    }
-}
-
 private let kCandidateTextPadding: CGFloat = 24.0
 private let kCandidateTextLeftMargin: CGFloat = 8.0
 private let kCandidateTextPaddingWithMandatedTableViewPadding: CGFloat = 18.0

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -458,8 +458,6 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
         let keyLabelFontSize = ceil(keyLabelFont.pointSize)
         let fontSize = max(candidateFontSize, keyLabelFontSize)
 
-        let controlSize: NSControl.ControlSize = fontSize > 36.0 ? .regular : .small
-
         var keyLabelCount = UInt(keyLabels.count)
         var scrollerWidth: CGFloat = 0.0
         if count <= keyLabelCount {
@@ -467,10 +465,7 @@ extension VerticalCandidateController: NSTableViewDataSource, NSTableViewDelegat
             scrollView.hasVerticalScroller = false
         } else {
             scrollView.hasVerticalScroller = true
-            let verticalScroller = scrollView.verticalScroller
-            verticalScroller?.controlSize = controlSize
-            verticalScroller?.scrollerStyle = NSScroller.preferredScrollerStyle
-            scrollerWidth = NSScroller.scrollerWidth(for: controlSize, scrollerStyle: NSScroller.preferredScrollerStyle)
+            scrollerWidth = NSScroller.scrollerWidth(for: .regular, scrollerStyle: NSScroller.preferredScrollerStyle)
         }
 
         keyLabelStripView.keyLabelFont = keyLabelFont

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -267,13 +267,11 @@ public class VerticalCandidateController: CandidateController {
             keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
             scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
                 self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
-                self.tableView.deselectAll(self)
                 self.scrollTimer?.invalidate()
                 self.scrollTimer = nil
             }
         } else {
             scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
-                self.tableView.reloadData()
                 self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
                 self.scrollTimer?.invalidate()
                 self.scrollTimer = nil

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -271,7 +271,7 @@ public class VerticalCandidateController: CandidateController {
         let selected = selectedCandidateIndex
 
         scrollTimer?.invalidate()
-        if visibleRowIndexes.contains(Int(selected)) == false {
+        if selected == UInt.max || visibleRowIndexes.contains(Int(selected)) == false {
             selectedCandidateIndex = UInt(visibleRowIndexes.lowerBound)
             tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
         } else {

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -175,7 +175,7 @@ public class VerticalCandidateController: CandidateController {
     }
 
     public override func reloadData() {
-        maxCandidateAttrStringWidth = ceil(candidateFont.pointSize * 1.0 + candidateTextPadding)
+        maxCandidateAttrStringWidth = ceil(candidateFont.pointSize + candidateTextPadding)
         tableView.reloadData()
         layoutCandidateView()
         if delegate?.candidateCountForController(self) ?? 0 > 0 {
@@ -261,21 +261,16 @@ public class VerticalCandidateController: CandidateController {
         let visibleRowIndexes = tableView.rows(in: visibleRect)
         let selected = selectedCandidateIndex
 
-        scrollTimer?.invalidate()
         if selected == UInt.max || visibleRowIndexes.contains(Int(selected)) == false {
             keyLabelStripView.highlightedIndex = -1
             keyLabelStripView.setNeedsDisplay(keyLabelStripView.frame)
-            scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
-                self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
-                self.scrollTimer?.invalidate()
-                self.scrollTimer = nil
-            }
-        } else {
-            scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
-                self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
-                self.scrollTimer?.invalidate()
-                self.scrollTimer = nil
-            }
+        }
+
+        scrollTimer?.invalidate()
+        scrollTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { timer in
+            self.tableView.scrollRowToVisible(visibleRowIndexes.lowerBound)
+            self.scrollTimer?.invalidate()
+            self.scrollTimer = nil
         }
     }
 }


### PR DESCRIPTION
* Fix one crasher caused by `Int(UInt.max)`
* The key label strip view used to use `UInt` for the `highlightedIndex` property, but one place still checks against `-1`.
* Small fine-tunes regarding the padding and scroller width
