### PR TITLE
Use template images in the Preference pane

### DIFF
--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -269,27 +269,28 @@ extension McBopomofoInputMethodController {
         let previous = state
         state = newState
 
-        if let newState = newState as? InputState.Deactivated {
+        switch newState {
+        case let newState as InputState.Deactivated:
             handle(state: newState, previous: previous, client: client)
-            // Force transition to Empty, so that when activateServer is
-            // invoked again, the controller is already in the Empty state.
             state = .Empty()
-        } else if let newState = newState as? InputState.Empty {
+        case let newState as InputState.Empty:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.EmptyIgnoringPreviousState {
+        case let newState as InputState.EmptyIgnoringPreviousState:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.Committing {
+        case let newState as InputState.Committing:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.Inputting {
+        case let newState as InputState.Inputting:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.Marking {
+        case let newState as InputState.Marking:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.ChoosingCandidate {
+        case let newState as InputState.ChoosingCandidate:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.AssociatedPhrases {
+        case let newState as InputState.AssociatedPhrases:
             handle(state: newState, previous: previous, client: client)
-        } else if let newState = newState as? InputState.Big5 {
+        case let newState as InputState.Big5:
             handle(state: newState, previous: previous, client: client)
+        default:
+            break
         }
     }
 

--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -185,7 +185,7 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
                     return newImage
                 }
 
-                var resizedImage = resize(image)
+                let resizedImage = resize(image)
                 // On newer version of macOS, the icons became black and white
                 // so we make them template images so it could look better
                 // on dark mode.

--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -185,7 +185,14 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
                     return newImage
                 }
 
-                menuItem.image = resize(image)
+                var resizedImage = resize(image)
+                // On newer version of macOS, the icons became black and white
+                // so we make them template images so it could look better
+                // on dark mode.
+                if #available(macOS 10.16, *) {
+                    resizedImage.isTemplate = true
+                }
+                menuItem.image = resizedImage
             }
 
             if sourceID == "com.apple.keylayout.US" {


### PR DESCRIPTION
We use the icons for various keyboard layouts in the Preference pane. They used to be colorful, but they became entirely black someday and now they look bad in dark mode. This PR set the images to template images so they can be white when dark mode is on.

Also use a switch case in the input controller class to replace lot of the if/else cases.