### PR TITLE
Introduces associated phrases in the smart bopomofo mode

### DIFF
--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		D485D3C02796CE3200657FF3 /* VersionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D485D3BF2796CE3200657FF3 /* VersionUpdateTests.swift */; };
 		D4A13D5A27A59F0B003BE359 /* InputMethodController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A13D5927A59D5C003BE359 /* InputMethodController.swift */; };
 		D4A8E43627A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A8E43527A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift */; };
+		D4C2A9872B4309D700113711 /* UTF8HelperTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C2A9862B4309D700113711 /* UTF8HelperTest.mm */; };
 		D4C9CAB127AAC9690058DFEA /* NSStringUtils in Frameworks */ = {isa = PBXBuildFile; productRef = D4C9CAB027AAC9690058DFEA /* NSStringUtils */; };
 		D4CB1A5B2B389B78006EA984 /* DictionaryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CB1A5A2B3891FB006EA984 /* DictionaryService.swift */; };
 		D4E33D8A27A838CF006DB1CF /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D4E33D8827A838CF006DB1CF /* Localizable.strings */; };
@@ -200,6 +201,8 @@
 		D495583A27A5C6C4006ADE1C /* LanguageModelManager+Privates.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LanguageModelManager+Privates.h"; sourceTree = "<group>"; };
 		D4A13D5927A59D5C003BE359 /* InputMethodController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMethodController.swift; sourceTree = "<group>"; };
 		D4A8E43527A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHandlerPlainBopomofoTests.swift; sourceTree = "<group>"; };
+		D4C2A9852B4309D600113711 /* McBopomofoTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "McBopomofoTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		D4C2A9862B4309D700113711 /* UTF8HelperTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = UTF8HelperTest.mm; sourceTree = "<group>"; };
 		D4C9CAAF27AAC8EC0058DFEA /* NSStringUtils */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = NSStringUtils; path = Packages/NSStringUtils; sourceTree = "<group>"; };
 		D4CB1A5A2B3891FB006EA984 /* DictionaryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryService.swift; sourceTree = "<group>"; };
 		D4E33D8927A838CF006DB1CF /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -454,6 +457,8 @@
 				D449AD5E2B393C00000C5812 /* InputMacroTests.swift */,
 				D449AD602B39506D000C5812 /* ServiceProviderTests.swift */,
 				D4EE67572B39685F00F062DE /* DictionaryServiceTests.swift */,
+				D4C2A9862B4309D700113711 /* UTF8HelperTest.mm */,
+				D4C2A9852B4309D600113711 /* McBopomofoTests-Bridging-Header.h */,
 			);
 			path = McBopomofoTests;
 			sourceTree = "<group>";
@@ -563,7 +568,7 @@
 					};
 					D485D3B52796A8A000657FF3 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 1500;
 						TestTargetID = 6A0D4EA115FC0D2D00ABF4B3;
 					};
 				};
@@ -717,6 +722,7 @@
 			files = (
 				D4A8E43627A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift in Sources */,
 				D449AD5F2B393C00000C5812 /* InputMacroTests.swift in Sources */,
+				D4C2A9872B4309D700113711 /* UTF8HelperTest.mm in Sources */,
 				D47D73A427A5D43900255A50 /* KeyHandlerBopomofoTests.swift in Sources */,
 				D485D3B92796A8A000657FF3 /* PreferencesTests.swift in Sources */,
 				D449AD612B39506D000C5812 /* ServiceProviderTests.swift in Sources */,
@@ -1272,6 +1278,7 @@
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "McBopomofoTests/McBopomofoTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/McBopomofo.app/Contents/MacOS/McBopomofo";
@@ -1317,6 +1324,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OBJC_BRIDGING_HEADER = "McBopomofoTests/McBopomofoTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/McBopomofo.app/Contents/MacOS/McBopomofo";

--- a/McBopomofoTests/DictionaryServiceTests.swift
+++ b/McBopomofoTests/DictionaryServiceTests.swift
@@ -15,7 +15,7 @@ final class DictionaryServiceTests: XCTestCase {
         for index in 0..<count {
             var callbackCalled = false
             let choosing = InputState.ChoosingCandidate(composingBuffer: "hi", cursorIndex: 0, candidates: [InputState.Candidate(reading: "", value: "", displayText: "")], useVerticalMode: false)
-            let selecting =  InputState.SelectingDictionaryService(previousState: choosing, selectedString: "你", selectedIndex: 0)
+            let selecting =  InputState.SelectingDictionary(previousState: choosing, selectedString: "你", selectedIndex: 0)
             let result = DictionaryServices.shared.lookUp(phrase: "你", withServiceAtIndex: index, state: selecting) { _ in
                 callbackCalled = true
             }

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -1605,7 +1605,7 @@ class KeyHandlerBopomofoTests: XCTestCase {
         } errorCallback: {
         }
 
-        XCTAssert(state is InputState.SelectingDictionaryService)
+        XCTAssert(state is InputState.SelectingDictionary)
 
         input = KeyHandlerInput(inputText: "?", keyCode: 0, charCode: 0, flags: [], isVerticalMode: false)
         handler.handle(input: input, state: state) { newState in
@@ -1640,7 +1640,7 @@ class KeyHandlerBopomofoTests: XCTestCase {
         } errorCallback: {
         }
 
-        XCTAssert(state is InputState.SelectingDictionaryService)
+        XCTAssert(state is InputState.SelectingDictionary)
 
         input = KeyHandlerInput(inputText: " ", keyCode: 0, charCode: 27, flags: [], isVerticalMode: false)
         handler.handle(input: input, state: state) { newState in

--- a/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerPlainBopomofoTests.swift
@@ -281,8 +281,8 @@ class KeyHandlerPlainBopomofoTests: XCTestCase {
             }
         }
 
-        XCTAssertTrue(state is InputState.AssociatedPhrases, "\(state)")
-        if let state = state as? InputState.AssociatedPhrases {
+        XCTAssertTrue(state is InputState.AssociatedPhrasesPlain, "\(state)")
+        if let state = state as? InputState.AssociatedPhrasesPlain {
             XCTAssertTrue(state.candidates.contains("嗚"))
         }
         Preferences.associatedPhrasesEnabled = enabled

--- a/McBopomofoTests/McBopomofoTests-Bridging-Header.h
+++ b/McBopomofoTests/McBopomofoTests-Bridging-Header.h
@@ -1,0 +1,4 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+

--- a/McBopomofoTests/UTF8HelperTest.mm
+++ b/McBopomofoTests/UTF8HelperTest.mm
@@ -1,0 +1,35 @@
+#import <XCTest/XCTest.h>
+#import "UTF8Helper.h"
+
+@interface UTF8HelperTest : XCTestCase
+
+@end
+
+@implementation UTF8HelperTest
+
+
+- (void)testGetCodePoint1 {
+    std::string s = "一二三四";
+    std::string r = McBopomofo::GetCodePoint(s, 2);
+    XCTAssertTrue(r == "三");
+}
+
+- (void)testGetCodePoint2 {
+    std::string s = "ABCD";
+    std::string r = McBopomofo::GetCodePoint(s, 2);
+    XCTAssertTrue(r == "C");
+}
+
+- (void)testGetCodePoint3 {
+    std::string s = "11🌳1";
+    std::string r = McBopomofo::GetCodePoint(s, 2);
+    XCTAssertTrue(r == "🌳");
+}
+
+- (void)testGetCodePoint4 {
+    std::string s = "🌳🌳1🌳";
+    std::string r = McBopomofo::GetCodePoint(s, 2);
+    XCTAssertTrue(r == "1");
+}
+
+@end

--- a/Packages/CandidateUI/Sources/CandidateUI/HorizontalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/HorizontalCandidateController.swift
@@ -148,11 +148,8 @@ fileprivate class HorizontalCandidateView: NSView {
         }
 
         if let toolTip = toolTip {
-            lightGray.setFill()
-            NSBezierPath.fill(NSMakeRect(0, 0, bounds.width, tooltipSize.height))
             let tooltipFrame = NSRect(x: 0, y: 0, width: tooltipSize.width, height: tooltipSize.height)
             (toolTip as NSString).draw(in: tooltipFrame, withAttributes: keyLabelAttrDict)
-            NSBezierPath.strokeLine(from: NSPoint(x: 0, y: tooltipSize.height - 2), to: NSPoint(x: bounds.width, y: tooltipSize.height - 2))
         }
 
         NSBezierPath.strokeLine(from: NSPoint(x: bounds.width, y: 0), to: NSPoint(x: bounds.width, y: bounds.height))

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -150,6 +150,7 @@ public class VerticalCandidateController: CandidateController {
         tooltipView.isSelectable = false
         tooltipView.isBezeled = false
         tooltipView.drawsBackground = true
+        tooltipView.backgroundColor = NSColor.clear
         tooltipView.lineBreakMode = .byTruncatingTail
 
         contentRect.origin = NSPoint.zero

--- a/Packages/OpenCCBridge/Sources/OpenCCBridge/OpenCCBridge.swift
+++ b/Packages/OpenCCBridge/Sources/OpenCCBridge/OpenCCBridge.swift
@@ -32,10 +32,12 @@ public class OpenCCBridge: NSObject {
 
     @objc(sharedInstance) public static let shared = OpenCCBridge()
 
-    private var converter: ChineseConverter?
+    private var t2s: ChineseConverter?
+    private var s2t: ChineseConverter?
 
     private override init() {
-        try? converter = ChineseConverter(options: .simplify)
+        try? t2s = ChineseConverter(options: .simplify)
+        try? s2t = ChineseConverter(options: .traditionalize)
         super.init()
     }
 
@@ -44,6 +46,14 @@ public class OpenCCBridge: NSObject {
     /// - Parameter string: Text in Traditional Chinese.
     /// - Returns: Text in Simplified Chinese.
     @objc public func convertToSimplified(_ string: String) -> String? {
-        converter?.convert(string)
+        t2s?.convert(string)
+    }
+
+    /// Converts to Traditional Chinese.
+    ///
+    /// - Parameter string: Text in Traditional Chinese.
+    /// - Returns: Text in Simplified Chinese.
+    @objc public func convertTraditional(_ string: String) -> String? {
+        s2t?.convert(string)
     }
 }

--- a/Source/Base.lproj/Localizable.strings
+++ b/Source/Base.lproj/Localizable.strings
@@ -104,3 +104,5 @@
 "Speak \"%@\"…" = "Speak \"%@\"…";
 
 "%@ has been copied." = "%@ has been copied.";
+
+"Look up %@" = "Look up %@";

--- a/Source/DictionaryService.swift
+++ b/Source/DictionaryService.swift
@@ -43,7 +43,7 @@ fileprivate struct CharacterInfo: DictionaryService {
     }
 
     func lookUp(phrase: String, state: InputState, serviceIndex: Int, stateCallback: (InputState) -> ()) -> Bool {
-        guard let state = state as? InputState.SelectingDictionaryService else {
+        guard let state = state as? InputState.SelectingDictionary else {
             return false
         }
         let newState = InputState.ShowingCharInfo(previousState: state, selectedString: state.selectedPhrase, selectedIndex: serviceIndex)

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -93,6 +93,21 @@ bool ReadingGrid::deleteReadingAfterCursor() {
   return true;
 }
 
+std::optional<ReadingGrid::NodePtr> ReadingGrid::findInSpan(
+    size_t cursor, const std::function<bool(const NodePtr&)>& predicate) const {
+  assert(cursor <= readings_.size());
+  std::vector<ReadingGrid::NodeInSpan> nodes =
+      overlappingNodesAt(cursor == readings_.size() ? cursor - 1 : cursor);
+
+  auto nodesIt = std::find_if(
+      nodes.cbegin(), nodes.cend(),
+      [&](const NodeInSpan& nodeInSpan) { return predicate(nodeInSpan.node); });
+
+  return nodesIt == nodes.end()
+             ? std::nullopt
+             : std::optional<ReadingGrid::NodePtr>(nodesIt->node);
+}
+
 namespace {
 
 // Defines a vertex of a DAG. This is a mutable data structure used for both
@@ -471,7 +486,7 @@ bool ReadingGrid::overrideCandidate(
 }
 
 std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
-    size_t loc) {
+    size_t loc) const {
   std::vector<ReadingGrid::NodeInSpan> results;
 
   if (spans_.empty() || loc >= spans_.size()) {

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -235,7 +235,7 @@ class ReadingGrid {
     return readings_;
   }
 
- protected:
+// protected:
   size_t cursor_ = 0;
   std::string separator_ = kDefaultSeparator;
   std::vector<std::string> readings_;

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -153,6 +154,12 @@ class ReadingGrid {
 
   using NodePtr = std::shared_ptr<Node>;
 
+  // Find, in a span at the cursor, the first node satisfying the predicate.
+  // Returns std::nullopt if not found.
+  std::optional<NodePtr> findInSpan(
+      size_t cursor,
+      const std::function<bool(const NodePtr&)>& predicate) const;
+
   struct WalkResult {
     std::vector<NodePtr> nodes;
     size_t totalReadings;
@@ -235,7 +242,7 @@ class ReadingGrid {
     return readings_;
   }
 
-// protected:
+ protected:
   size_t cursor_ = 0;
   std::string separator_ = kDefaultSeparator;
   std::vector<std::string> readings_;
@@ -265,7 +272,7 @@ class ReadingGrid {
 
   // Find all nodes that overlap with the location. The return value is a list
   // of nodes along with their starting location in the grid.
-  std::vector<NodeInSpan> overlappingNodesAt(size_t loc);
+  std::vector<NodeInSpan> overlappingNodesAt(size_t loc) const;
 };
 
 }  // namespace Formosa::Gramambular2

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -457,6 +457,81 @@ TEST(ReadingGridTest, LongGridDeletion) {
   ASSERT_EQ(grid.spans()[8].nodeOf(5)->reading(), "jklmn");
 }
 
+TEST(ReadingGridTest, FindNodeInSpans) {
+  ReadingGrid grid(std::make_shared<MockLM>());
+  grid.setReadingSeparator(";");
+  grid.insertReading("a");
+  grid.insertReading("b");
+  grid.insertReading("c");
+
+  ASSERT_FALSE(
+      grid.findInSpan(0, [](const auto& n) { return n->spanningLength() == 4; })
+          .has_value());
+  ASSERT_FALSE(
+      grid.findInSpan(1, [](const auto& n) { return n->spanningLength() == 0; })
+          .has_value());
+  ASSERT_EQ(
+      grid.findInSpan(0, [](const auto& n) { return n->spanningLength() == 1; })
+          ->get()
+          ->reading(),
+      "a");
+  ASSERT_EQ(
+      grid.findInSpan(1, [](const auto& n) { return n->spanningLength() == 1; })
+          ->get()
+          ->reading(),
+      "b");
+  ASSERT_EQ(
+      grid.findInSpan(2, [](const auto& n) { return n->spanningLength() == 1; })
+          ->get()
+          ->reading(),
+      "c");
+  ASSERT_EQ(
+      grid.findInSpan(3, [](const auto& n) { return n->spanningLength() == 1; })
+          ->get()
+          ->reading(),
+      "c");
+  ASSERT_EQ(
+      grid.findInSpan(0, [](const auto& n) { return n->spanningLength() == 2; })
+          ->get()
+          ->reading(),
+      "a;b");
+  ASSERT_EQ(
+      grid.findInSpan(1, [](const auto& n) { return n->spanningLength() == 2; })
+          ->get()
+          ->reading(),
+      "b;c");
+  ASSERT_EQ(
+      grid.findInSpan(2, [](const auto& n) { return n->spanningLength() == 2; })
+          ->get()
+          ->reading(),
+      "b;c");
+  ASSERT_EQ(
+      grid.findInSpan(3, [](const auto& n) { return n->spanningLength() == 2; })
+          ->get()
+          ->reading(),
+      "b;c");
+  ASSERT_EQ(
+      grid.findInSpan(0, [](const auto& n) { return n->spanningLength() == 3; })
+          ->get()
+          ->reading(),
+      "a;b;c");
+  ASSERT_EQ(
+      grid.findInSpan(1, [](const auto& n) { return n->spanningLength() == 3; })
+          ->get()
+          ->reading(),
+      "a;b;c");
+  ASSERT_EQ(
+      grid.findInSpan(2, [](const auto& n) { return n->spanningLength() == 3; })
+          ->get()
+          ->reading(),
+      "a;b;c");
+  ASSERT_EQ(
+      grid.findInSpan(3, [](const auto& n) { return n->spanningLength() == 3; })
+          ->get()
+          ->reading(),
+      "a;b;c");
+}
+
 TEST(ReadingGridTest, StressTest) {
   constexpr char kStressData[] = R"(
 ㄧ 一 -2.08170692
@@ -668,8 +743,8 @@ TEST(ReadingGridTest, DisambiguateCandidates) {
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "焰", "危險"}));
 
-  ASSERT_TRUE(
-      grid.overrideCandidate(loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥")));
+  ASSERT_TRUE(grid.overrideCandidate(
+      loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥")));
   result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "危險"}));

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -289,7 +289,7 @@ extension McBopomofoInputMethodController {
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.Big5:
             handle(state: newState, previous: previous, client: client)
-        case let newState as InputState.SelectingDictionaryService:
+        case let newState as InputState.SelectingDictionary:
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.ShowingCharInfo:
             handle(state: newState, previous: previous, client: client)
@@ -449,7 +449,7 @@ extension McBopomofoInputMethodController {
         client.setMarkedText(state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
-    private func handle(state: InputState.SelectingDictionaryService, previous: InputState, client: Any?) {
+    private func handle(state: InputState.SelectingDictionary, previous: InputState, client: Any?) {
         hideTooltip()
         guard let client = client as? IMKTextInput else {
             gCurrentCandidateController?.visible = false
@@ -504,7 +504,7 @@ extension McBopomofoInputMethodController {
                 candidates = state.candidates.map {
                     InputState.Candidate(reading: "", value: $0, displayText: $0)
                 }
-            case _ as InputState.SelectingDictionaryService:
+            case _ as InputState.SelectingDictionary:
                 return true
             case _ as InputState.ShowingCharInfo:
                 return true
@@ -681,7 +681,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             UInt(state.candidates.count)
         case let state as InputState.AssociatedPhrases:
             UInt(state.candidates.count)
-        case let state as InputState.SelectingDictionaryService:
+        case let state as InputState.SelectingDictionary:
             UInt(state.menu.count)
         case let state as InputState.ShowingCharInfo:
             UInt(state.menu.count)
@@ -696,7 +696,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             state.candidates[Int(index)].displayText
         case let state as InputState.AssociatedPhrases:
             state.candidates[Int(index)]
-        case let state as InputState.SelectingDictionaryService:
+        case let state as InputState.SelectingDictionary:
             state.menu[Int(index)]
         case let state as InputState.ShowingCharInfo:
             state.menu[Int(index)]
@@ -742,7 +742,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             } else {
                 handle(state: .Empty(), client: client)
             }
-        case let state as InputState.SelectingDictionaryService:
+        case let state as InputState.SelectingDictionary:
             let handled = state.lookUp(usingServiceAtIndex: Int(index), state: state) { state in
                 handle(state: state, client: client)
             }

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -285,7 +285,7 @@ extension McBopomofoInputMethodController {
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.ChoosingCandidate:
             handle(state: newState, previous: previous, client: client)
-        case let newState as InputState.AssociatedPhrases:
+        case let newState as InputState.AssociatedPhrasesPlain:
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.Big5:
             handle(state: newState, previous: previous, client: client)
@@ -425,7 +425,7 @@ extension McBopomofoInputMethodController {
         show(candidateWindowWith: state, client: client)
     }
 
-    private func handle(state: InputState.AssociatedPhrases, previous: InputState, client: Any?) {
+    private func handle(state: InputState.AssociatedPhrasesPlain, previous: InputState, client: Any?) {
         hideTooltip()
         guard let client = client as? IMKTextInput else {
             gCurrentCandidateController?.visible = false
@@ -499,7 +499,7 @@ extension McBopomofoInputMethodController {
             case let state as InputState.ChoosingCandidate:
                 useVerticalMode = state.useVerticalMode
                 candidates = state.candidates
-            case let state as InputState.AssociatedPhrases:
+            case let state as InputState.AssociatedPhrasesPlain:
                 useVerticalMode = state.useVerticalMode
                 candidates = state.candidates.map {
                     InputState.Candidate(reading: "", value: $0, displayText: $0)
@@ -553,7 +553,7 @@ extension McBopomofoInputMethodController {
 
         let candidateKeys = Preferences.candidateKeys
         let keyLabels = candidateKeys.count > 4 ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
-        let keyLabelPrefix = state is InputState.AssociatedPhrases ? "⇧ " : ""
+        let keyLabelPrefix = state is InputState.AssociatedPhrasesPlain ? "⇧ " : ""
         gCurrentCandidateController?.keyLabels = keyLabels.map {
             CandidateKeyLabel(key: String($0), displayedText: keyLabelPrefix + String($0))
         }
@@ -679,7 +679,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
         return switch state {
         case let state as InputState.ChoosingCandidate:
             UInt(state.candidates.count)
-        case let state as InputState.AssociatedPhrases:
+        case let state as InputState.AssociatedPhrasesPlain:
             UInt(state.candidates.count)
         case let state as InputState.SelectingDictionary:
             UInt(state.menu.count)
@@ -694,7 +694,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
         return switch state {
         case let state as InputState.ChoosingCandidate:
             state.candidates[Int(index)].displayText
-        case let state as InputState.AssociatedPhrases:
+        case let state as InputState.AssociatedPhrasesPlain:
             state.candidates[Int(index)]
         case let state as InputState.SelectingDictionary:
             state.menu[Int(index)]
@@ -723,7 +723,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                 let composingBuffer = inputting.composingBuffer
                 handle(state: .Committing(poppedText: composingBuffer), client: client)
                 if Preferences.associatedPhrasesEnabled,
-                   let associatePhrases = keyHandler.buildAssociatePhraseState(withKey: composingBuffer, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrases {
+                   let associatePhrases = keyHandler.buildAssociatePhraseState(withKey: composingBuffer, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
                     self.handle(state: associatePhrases, client: client)
                 } else {
                     handle(state: .Empty(), client: client)
@@ -733,11 +733,11 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             default:
                 break
             }
-        case let state as InputState.AssociatedPhrases:
+        case let state as InputState.AssociatedPhrasesPlain:
             let selectedValue = state.candidates[Int(index)]
             handle(state: .Committing(poppedText: selectedValue), client: currentClient)
             if Preferences.associatedPhrasesEnabled,
-               let associatePhrases = keyHandler.buildAssociatePhraseState(withKey: selectedValue, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrases {
+               let associatePhrases = keyHandler.buildAssociatePhraseState(withKey: selectedValue, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
                 self.handle(state: associatePhrases, client: client)
             } else {
                 handle(state: .Empty(), client: client)

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -73,15 +73,11 @@ class McBopomofoInputMethodController: IMKInputController {
         let halfWidthPunctuationItem = menu.addItem(withTitle: NSLocalizedString("Use Half-Width Punctuations", comment: ""), action: #selector(toggleHalfWidthPunctuation(_:)), keyEquivalent: "h")
         halfWidthPunctuationItem.keyEquivalentModifierMask = [.command, .control]
         halfWidthPunctuationItem.state = Preferences.halfWidthPunctuationEnabled.state
+        let associatedPhrasesItem = menu.addItem(withTitle: NSLocalizedString("Associated Phrases", comment: ""), action: #selector(toggleAssociatedPhrasesEnabled(_:)), keyEquivalent: "")
+        associatedPhrasesItem.state = Preferences.associatedPhrasesEnabled.state
 
         let inputMode = keyHandler.inputMode
         let optionKeyPressed = NSEvent.modifierFlags.contains(.option)
-
-        if inputMode == .plainBopomofo {
-            let associatedPhrasesItem = menu.addItem(withTitle: NSLocalizedString("Associated Phrases", comment: ""), action: #selector(toggleAssociatedPhrasesEnabled(_:)), keyEquivalent: "")
-            associatedPhrasesItem.state = Preferences.associatedPhrasesEnabled.state
-        }
-
         if inputMode == .bopomofo && optionKeyPressed {
             let phaseReplacementItem = menu.addItem(withTitle: NSLocalizedString("Use Phrase Replacement", comment: ""), action: #selector(togglePhraseReplacement(_:)), keyEquivalent: "")
             phaseReplacementItem.state = Preferences.phraseReplacementEnabled.state
@@ -604,7 +600,7 @@ extension McBopomofoInputMethodController {
         var lineHeightRect = NSMakeRect(0.0, 0.0, 16.0, 16.0)
         var cursor: Int = 0
 
-        if let state = state as? InputState.ChoosingCandidate {
+        if let state = state as? InputState.NotEmpty {
             cursor = Int(state.cursorIndex)
             if cursor == state.composingBuffer.count && cursor != 0 {
                 cursor -= 1
@@ -782,7 +778,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                 let selectedCandidate = previous.candidates[selectedIndex]
                 keyHandler.fixNode(index:keyHandler.actualCandidateCursorIndex, reading: selectedCandidate.reading, value: selectedCandidate.value, associatedPhrase: selectedPhrase)
             case _ as InputState.Inputting:
-                keyHandler.fixNode(index:keyHandler.cursorIndex, reading: state.selectedReading, value: state.selectedPhrase, associatedPhrase: selectedPhrase)
+                keyHandler.fixNode(index:keyHandler.cursorIndex - 1, reading: state.selectedReading, value: state.selectedPhrase, associatedPhrase: selectedPhrase)
             default:
                 break
             }

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -346,11 +346,11 @@ class InputState: NSObject {
         @objc private(set) var selectedPhrase: String = ""
         @objc private(set) var selectedReading: String = ""
         @objc private(set) var selectedIndex: Int = 0
-        @objc private(set) var candidates: [String] = []
+        @objc private(set) var candidates: [Candidate] = []
         @objc private(set) var useVerticalMode: Bool = false
 
 
-        @objc init(previousState: NotEmpty, selectedPhrase: String, selectedReading: String, selectedIndex: Int, candidates: [String], useVerticalMode: Bool) {
+        @objc init(previousState: NotEmpty, selectedPhrase: String, selectedReading: String, selectedIndex: Int, candidates: [Candidate], useVerticalMode: Bool) {
             self.previousState = previousState
             self.selectedPhrase = selectedPhrase
             self.selectedReading = selectedReading

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -338,6 +338,28 @@ class InputState: NSObject {
 
     /// Represents that the user is choosing in a candidates list
     /// in the associated phrases mode.
+    @objc(InputStateAssociatedPhrases)
+    class AssociatedPhrases: NotEmpty {
+        @objc private(set) var previousState: NotEmpty
+        @objc private(set) var candidates: [String] = []
+        @objc private(set) var useVerticalMode: Bool = false
+        @objc private(set) var selectedIndex: Int = 0
+
+        @objc init(previousState: NotEmpty, selectedIndex: Int, candidates: [String], useVerticalMode: Bool) {
+            self.previousState = previousState
+            self.selectedIndex = selectedIndex
+            self.candidates = candidates
+            self.useVerticalMode = useVerticalMode
+            super.init(composingBuffer: previousState.composingBuffer, cursorIndex: previousState.cursorIndex)
+        }
+
+        override var description: String {
+            "<InputState.AssociatedPhrases, previousState:\(previousState), candidates:\(candidates), useVerticalMode:\(useVerticalMode)>"
+        }
+    }
+
+    /// Represents that the user is choosing in a candidates list
+    /// in the associated phrases mode.
     @objc(InputStateAssociatedPhrasesPlain)
     class AssociatedPhrasesPlain: InputState {
         @objc private(set) var candidates: [String] = []
@@ -350,9 +372,11 @@ class InputState: NSObject {
         }
 
         override var description: String {
-            "<InputState.AssociatedPhrases, candidates:\(candidates), useVerticalMode:\(useVerticalMode)>"
+            "<InputState.AssociatedPhrasesPlain, candidates:\(candidates), useVerticalMode:\(useVerticalMode)>"
         }
     }
+
+    // MARK: -
 
     @objc(InputStateSelectingDictionary)
     class SelectingDictionary: NotEmpty {

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -341,12 +341,17 @@ class InputState: NSObject {
     @objc(InputStateAssociatedPhrases)
     class AssociatedPhrases: NotEmpty {
         @objc private(set) var previousState: NotEmpty
+        @objc private(set) var selectedPhrase: String = ""
+        @objc private(set) var selectedReading: String = ""
+        @objc private(set) var selectedIndex: Int = 0
         @objc private(set) var candidates: [String] = []
         @objc private(set) var useVerticalMode: Bool = false
-        @objc private(set) var selectedIndex: Int = 0
 
-        @objc init(previousState: NotEmpty, selectedIndex: Int, candidates: [String], useVerticalMode: Bool) {
+
+        @objc init(previousState: NotEmpty, selectedPhrase: String, selectedReading: String, selectedIndex: Int, candidates: [String], useVerticalMode: Bool) {
             self.previousState = previousState
+            self.selectedPhrase = selectedPhrase
+            self.selectedReading = selectedReading
             self.selectedIndex = selectedIndex
             self.candidates = candidates
             self.useVerticalMode = useVerticalMode

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -338,8 +338,8 @@ class InputState: NSObject {
 
     /// Represents that the user is choosing in a candidates list
     /// in the associated phrases mode.
-    @objc(InputStateAssociatedPhrases)
-    class AssociatedPhrases: InputState {
+    @objc(InputStateAssociatedPhrasesPlain)
+    class AssociatedPhrasesPlain: InputState {
         @objc private(set) var candidates: [String] = []
         @objc private(set) var useVerticalMode: Bool = false
 

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -354,8 +354,8 @@ class InputState: NSObject {
         }
     }
 
-    @objc(InputStateSelectingDictionaryService)
-    class SelectingDictionaryService: NotEmpty {
+    @objc(InputStateSelectingDictionary)
+    class SelectingDictionary: NotEmpty {
         @objc private(set) var previousState: NotEmpty
         @objc private(set) var selectedPhrase: String = ""
         @objc private(set) var selectedIndex: Int = 0
@@ -384,14 +384,14 @@ class InputState: NSObject {
     @objc(InputStateShowingCharInfo)
     class ShowingCharInfo: NotEmpty {
 
-        @objc private(set) var previousState: SelectingDictionaryService
+        @objc private(set) var previousState: SelectingDictionary
         @objc private(set) var selectedPhrase: String = ""
         @objc private(set) var selectedIndex: Int = 0
         @objc private(set) var menu: [String]
         private(set) var menuTitleValueMapping: [(String, String)]
 
         @objc
-        init(previousState: SelectingDictionaryService, selectedString: String, selectedIndex: Int) {
+        init(previousState: SelectingDictionary, selectedString: String, selectedIndex: Int) {
             self.previousState = previousState
             self.selectedPhrase = selectedString
             self.selectedIndex = selectedIndex

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -338,6 +338,8 @@ class InputState: NSObject {
 
     /// Represents that the user is choosing in a candidates list
     /// in the associated phrases mode.
+    ///
+    /// This is for Bopomofo input mode.
     @objc(InputStateAssociatedPhrases)
     class AssociatedPhrases: NotEmpty {
         @objc private(set) var previousState: NotEmpty
@@ -365,6 +367,8 @@ class InputState: NSObject {
 
     /// Represents that the user is choosing in a candidates list
     /// in the associated phrases mode.
+    ///
+    /// This is for Plain Bopomofo input mode.
     @objc(InputStateAssociatedPhrasesPlain)
     class AssociatedPhrasesPlain: InputState {
         @objc private(set) var candidates: [String] = []
@@ -383,6 +387,7 @@ class InputState: NSObject {
 
     // MARK: -
 
+    /// Represents that the user is choosing a dictionary service.
     @objc(InputStateSelectingDictionary)
     class SelectingDictionary: NotEmpty {
         @objc private(set) var previousState: NotEmpty
@@ -410,9 +415,10 @@ class InputState: NSObject {
         }
     }
 
+    /// Represents that the user is choosing information about selected
+    /// characters.
     @objc(InputStateShowingCharInfo)
     class ShowingCharInfo: NotEmpty {
-
         @objc private(set) var previousState: SelectingDictionary
         @objc private(set) var selectedPhrase: String = ""
         @objc private(set) var selectedIndex: Int = 0

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -49,7 +49,7 @@ extern InputMode InputModePlainBopomofo;
 
 - (void)syncWithPreferences;
 - (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value useMoveCursorAfterSelectionSetting:(BOOL)flag NS_SWIFT_NAME(fixNode(reading:value:useMoveCursorAfterSelectionSetting:));
-- (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase NS_SWIFT_NAME(fixNode(reading:value:associatedPhrase:));
+- (void)fixNodeAtIndex:(NSInteger)index Reading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase NS_SWIFT_NAME(fixNode(index:reading:value:associatedPhrase:));
 
 - (void)clear;
 
@@ -58,11 +58,12 @@ extern InputMode InputModePlainBopomofo;
 
 - (InputState *)buildInputtingState;
 - (nullable InputState *)buildAssociatePhrasePlainStateWithKey:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
-- (nullable InputState *)buildAssociatePhraseStateWithPreviousState:(id)state selectedIndex:(NSInteger)index key:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
-
+- (nullable InputState *)buildAssociatePhraseStateWithPreviousState:(id)state selectedIndex:(NSInteger)index selectedPhrase:(NSString *)key selectedReading:(NSString *)selectedReading useVerticalMode:(BOOL)useVerticalMode;
 
 @property (strong, nonatomic) InputMode inputMode;
 @property (weak, nonatomic) id<KeyHandlerDelegate> delegate;
+@property (assign, nonatomic, readonly) NSInteger actualCandidateCursorIndex;
+@property (assign, nonatomic, readonly) NSInteger cursorIndex;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -40,6 +40,15 @@ extern InputMode InputModePlainBopomofo;
 - (BOOL)keyHandler:(KeyHandler *)keyHandler didRequestWriteUserPhraseWithState:(InputState *)state;
 @end
 
+@interface AssociatedPhraseArrayItem : NSObject
+
++ (NSArray <AssociatedPhraseArrayItem *>*)createItemWithModelSearchableText:(NSString *)modelText readingSearchableText:(NSString *)readingText;
+
+- (instancetype)initWithValue:(NSString *)character reading:(NSString *)reading;
+@property (strong, nonatomic) NSString *value;
+@property (strong, nonatomic) NSString *reading;
+@end
+
 @interface KeyHandler : NSObject
 
 - (BOOL)handleInput:(KeyHandlerInput *)input
@@ -49,7 +58,7 @@ extern InputMode InputModePlainBopomofo;
 
 - (void)syncWithPreferences;
 - (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value useMoveCursorAfterSelectionSetting:(BOOL)flag NS_SWIFT_NAME(fixNode(reading:value:useMoveCursorAfterSelectionSetting:));
-- (void)fixNodeAtIndex:(NSInteger)index Reading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase NS_SWIFT_NAME(fixNode(index:reading:value:associatedPhrase:));
+- (void)fixNodeAtIndex:(NSInteger)index Reading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <AssociatedPhraseArrayItem *> *)associatedPhrase NS_SWIFT_NAME(fixNode(index:reading:value:associatedPhrase:));
 
 - (void)clear;
 

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -49,13 +49,17 @@ extern InputMode InputModePlainBopomofo;
 
 - (void)syncWithPreferences;
 - (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value useMoveCursorAfterSelectionSetting:(BOOL)flag NS_SWIFT_NAME(fixNode(reading:value:useMoveCursorAfterSelectionSetting:));
+- (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase NS_SWIFT_NAME(fixNode(reading:value:associatedPhrase:));
+
 - (void)clear;
 
 - (void)handleForceCommitWithStateCallback:(void (^)(InputState *))stateCallback
     NS_SWIFT_NAME(handleForceCommit(stateCallback:));
 
 - (InputState *)buildInputtingState;
-- (nullable InputState *)buildAssociatePhraseStateWithKey:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
+- (nullable InputState *)buildAssociatePhrasePlainStateWithKey:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
+- (nullable InputState *)buildAssociatePhraseStateWithPreviousState:(id)state selectedIndex:(NSInteger)index key:(NSString *)key useVerticalMode:(BOOL)useVerticalMode;
+
 
 @property (strong, nonatomic) InputMode inputMode;
 @property (weak, nonatomic) id<KeyHandlerDelegate> delegate;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -190,8 +190,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 }
 
-//- (void)fixNodeWithReading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase
-
 - (void)fixNodeAtIndex:(NSInteger)index Reading:(NSString *)reading value:(NSString *)value associatedPhrase:(NSArray <NSString *> *)associatedPhrase
 {
     size_t actualCursor = index;
@@ -555,17 +553,16 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         if ([input isControlHold] && Preferences.controlEnterOutput != 0) {
             return [self _handleCtrlEnterWithState:state stateCallback:stateCallback errorCallback:errorCallback];
         }
-        // TODO: use associated phrase flag
         if (_inputMode == InputModeBopomofo &&
             [input isShiftHold] &&
-            [state isKindOfClass:[InputStateInputting class]]) {
+            [state isKindOfClass:[InputStateInputting class]] &&
+            Preferences.associatedPhrasesEnabled) {
             return [self _handleAssociatedPhraseWithState:(InputStateInputting *)state stateCallback:stateCallback errorCallback:errorCallback];
         }
         return [self _handleEnterWithState:state stateCallback:stateCallback errorCallback:errorCallback];
     }
 
     // MARK: Enter Big5 code mode
-
     if ([input isControlHold] && (charCode == '`')) {
         if (Preferences.big5InputEnabled) {
             [self clear];
@@ -1169,8 +1166,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     if (charCode == 13 || [input isEnter]) {
         // Start associated phrases
-        // TODO: check if associated phrase flag is on
-        if (_inputMode == InputModeBopomofo && [input isShiftHold]) {
+        if (_inputMode == InputModeBopomofo &&
+            [input isShiftHold] &&
+            Preferences.associatedPhrasesEnabled) {
             if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
                 InputStateChoosingCandidate *current = (InputStateChoosingCandidate *)state;
                 NSInteger index = gCurrentCandidateController.selectedCandidateIndex;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -259,6 +259,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     for (NSInteger i = 0; i < associatedPhrase.count; i++) {
         NSString *itemReading = associatedPhrase[i].reading;
         _grid->insertReading(itemReading.UTF8String);
+        NSString *phrase = associatedPhrase[i].value;
+        NSInteger candidateIIndex = accumulatedCursor + i;
+        _grid->overrideCandidate(candidateIIndex, phrase.UTF8String);
     }
     [self _walk];
 }
@@ -1698,7 +1701,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return nil;
     }
 
-    // zonble
     BOOL scToTc = Preferences.chineseConversionEnabled &&
             Preferences.chineseConversionStyle == 1;
     if (scToTc) {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -236,7 +236,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     // if the composing buffer is empty and there's no reading, and there is some function key combination, we ignore it
     BOOL isFunctionKey = ([input isCommandHold] || [input isOptionHold] || [input isNumericPad]) || [input isControlHotKey];
-    if (![state isKindOfClass:[InputStateNotEmpty class]] && ![state isKindOfClass:[InputStateAssociatedPhrases class]] && isFunctionKey) {
+    if (![state isKindOfClass:[InputStateNotEmpty class]] && ![state isKindOfClass:[InputStateAssociatedPhrasesPlain class]] && isFunctionKey) {
         return NO;
     }
 
@@ -284,7 +284,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     // MARK: Handle Associated Phrases
-    if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+    if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
         BOOL result = [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
         if (result) {
             return YES;
@@ -391,7 +391,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     InputStateEmpty *empty = [[InputStateEmpty alloc] init];
                     stateCallback(empty);
                 } else {
-                    InputStateAssociatedPhrases *associatedPhrases = (InputStateAssociatedPhrases *)[self buildAssociatePhraseStateWithKey:text useVerticalMode:input.useVerticalMode];
+                    InputStateAssociatedPhrasesPlain *associatedPhrases = (InputStateAssociatedPhrasesPlain *)[self buildAssociatePhraseStateWithKey:text useVerticalMode:input.useVerticalMode];
                     if (associatedPhrases) {
                         stateCallback(associatedPhrases);
                     } else {
@@ -1083,7 +1083,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             stateCallback(newState);
             gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
             gCurrentCandidateController.selectedCandidateIndex = selectedIndex;
-        } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+        } else if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
             [self clear];
             InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
             stateCallback(empty);
@@ -1099,7 +1099,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (charCode == 13 || [input isEnter]) {
-        if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+        if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
             [self clear];
             InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
             stateCallback(empty);
@@ -1215,8 +1215,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
         candidates = [(InputStateChoosingCandidate *)state candidates];
-    } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-        candidates = [(InputStateAssociatedPhrases *)state candidates];
+    } else if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
+        candidates = [(InputStateAssociatedPhrasesPlain *)state candidates];
     } else if ([state isKindOfClass:[InputStateSelectingDictionary class]]) {
         candidates = [(InputStateSelectingDictionary *)state menu];
     }
@@ -1234,7 +1234,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
-    if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+    if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
         if (![input isShiftHold]) {
             return NO;
         }
@@ -1242,7 +1242,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     NSInteger index = NSNotFound;
     NSString *match;
-    if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+    if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
         match = input.inputTextIgnoringModifiers;
     } else {
         match = inputText;
@@ -1264,7 +1264,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         }
     }
 
-    if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
+    if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
         return NO;
     }
 
@@ -1522,7 +1522,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             NSString *item = [[NSString alloc] initWithUTF8String:phrase.c_str()];
             [array addObject:item];
         }
-        InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithCandidates:array useVerticalMode:useVerticalMode];
+        InputStateAssociatedPhrasesPlain *associatedPhrases = [[InputStateAssociatedPhrasesPlain alloc] initWithCandidates:array useVerticalMode:useVerticalMode];
         return associatedPhrases;
     }
     return nil;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -294,7 +294,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     // MARK: Handle Selecting Dictionary Service
-    if ([state isKindOfClass:[InputStateSelectingDictionaryService class]]) {
+    if ([state isKindOfClass:[InputStateSelectingDictionary class]]) {
         return [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
 
@@ -991,7 +991,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     // Dictionary look up
     if ([input.inputText isEqualToString:@"?"]) {
         if (state.markedRange.length > 0) {
-            InputStateSelectingDictionaryService *newState = [[InputStateSelectingDictionaryService alloc] initWithPreviousState:state selectedString:state.selectedText selectedIndex:0];
+            InputStateSelectingDictionary *newState = [[InputStateSelectingDictionary alloc] initWithPreviousState:state selectedString:state.selectedText selectedIndex:0];
             stateCallback(newState);
             return YES;
         }
@@ -1056,13 +1056,13 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     if (_inputMode == InputModeBopomofo && [[input inputText] isEqualToString:@"?"]) {
         if ([state isKindOfClass:[InputStateShowingCharInfo class]]) {
             cancelCandidateKey = YES;
-        } else if ([state isKindOfClass:[InputStateSelectingDictionaryService class]]) {
+        } else if ([state isKindOfClass:[InputStateSelectingDictionary class]]) {
             cancelCandidateKey = YES;
         } else if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
             InputStateChoosingCandidate *currentState = (InputStateChoosingCandidate *)state;
             NSInteger index = gCurrentCandidateController.selectedCandidateIndex;
             NSString *selectedPhrase = currentState.candidates[index].displayText;
-            InputStateSelectingDictionaryService *newState = [[InputStateSelectingDictionaryService alloc] initWithPreviousState:currentState selectedString:selectedPhrase selectedIndex:index];
+            InputStateSelectingDictionary *newState = [[InputStateSelectingDictionary alloc] initWithPreviousState:currentState selectedString:selectedPhrase selectedIndex:index];
             stateCallback(newState);
             return YES;
         }
@@ -1076,8 +1076,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             stateCallback(newState);
             gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
             gCurrentCandidateController.selectedCandidateIndex = selectedIndex;
-        } else if ([state isKindOfClass:[InputStateSelectingDictionaryService class]]) {
-            InputStateSelectingDictionaryService *current = (InputStateSelectingDictionaryService *)state;
+        } else if ([state isKindOfClass:[InputStateSelectingDictionary class]]) {
+            InputStateSelectingDictionary *current = (InputStateSelectingDictionary *)state;
             NSInteger selectedIndex = current.selectedIndex;
             InputStateNotEmpty *newState = current.previousState;
             stateCallback(newState);
@@ -1217,8 +1217,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         candidates = [(InputStateChoosingCandidate *)state candidates];
     } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
         candidates = [(InputStateAssociatedPhrases *)state candidates];
-    } else if ([state isKindOfClass:[InputStateSelectingDictionaryService class]]) {
-        candidates = [(InputStateSelectingDictionaryService *)state menu];
+    } else if ([state isKindOfClass:[InputStateSelectingDictionary class]]) {
+        candidates = [(InputStateSelectingDictionary *)state menu];
     }
 
     if (!candidates) {

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -62,6 +62,10 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     if (!gLanguageModelMcBopomofo.isDataModelLoaded()) {
         LTLoadLanguageModelFile(@"data", gLanguageModelMcBopomofo);
     }
+    if (!gLanguageModelMcBopomofo.isAssociatedPhrasesLoaded()) {
+        LTLoadAssociatedPhrases(gLanguageModelMcBopomofo);
+    }
+
     if (!gLanguageModelPlainBopomofo.isDataModelLoaded()) {
         LTLoadLanguageModelFile(@"data-plain-bpmf", gLanguageModelPlainBopomofo);
     }
@@ -75,6 +79,9 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     if ([mode isEqualToString:InputModeBopomofo]) {
         if (!gLanguageModelMcBopomofo.isDataModelLoaded()) {
             LTLoadLanguageModelFile(@"data", gLanguageModelMcBopomofo);
+        }
+        if (!gLanguageModelMcBopomofo.isAssociatedPhrasesLoaded()) {
+            LTLoadAssociatedPhrases(gLanguageModelMcBopomofo);
         }
     }
 

--- a/Source/UTF8Helper.cpp
+++ b/Source/UTF8Helper.cpp
@@ -118,5 +118,24 @@ std::string SubstringToCodePoints(const std::string& s, size_t cp) {
   return {s.cbegin(), i};
 }
 
+std::string GetCodePoint(const std::string& s, size_t cp)
+{
+    size_t c = 0;
+    std::string::const_iterator i = s.cbegin();
+    std::string::const_iterator lastUsed = s.cbegin();
+    std::string::const_iterator end = s.cend();
+    while (i != end && c <= cp) {
+        lastUsed = i;
+        bool r = DecodeUTF8(i, end);
+        if (!r) {
+            break;
+        }
+        ++c;
+    }
+
+    return {lastUsed, i};
+}
+
+
 // NOLINTEND(readability-magic-numbers)
 }  // namespace McBopomofo

--- a/Source/UTF8Helper.h
+++ b/Source/UTF8Helper.h
@@ -38,6 +38,9 @@ size_t CodePointCount(const std::string& s);
 // will be the string clamped up to before that invalid sequence.
 std::string SubstringToCodePoints(const std::string& s, size_t cp);
 
+// Gets the code point at the given index.
+std::string GetCodePoint(const std::string& s, size_t cp);
+
 }  // namespace McBopomofo
 
 #endif  // SRC_UTF8HELPER_H_

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -107,3 +107,4 @@
 
 "%@ has been copied." = "%@ has been copied.";
 
+"Look up %@" = "Look up %@";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -104,3 +104,5 @@
 "Speak \"%@\"…" = "朗讀「%@」…";
 
 "%@ has been copied." = "已成功複製 %@";
+
+"Look up %@" = "Look up %@";


### PR DESCRIPTION
The associated phrases is a feature lives in the traditional phonetic input methods, as the "Plain Bopomofo" mode of McBopomofo, or ㄅ半. The PR tries to bridge the feature to the smart bopomofo mode.

When a user presses shift + enter after inputting a character, the input method will open a menu containing associated phrases, then it inserts the readings and fixes the node after the user selects one. 

Or, the user can press shift + enter on a candidate when the candidate window appears, and the input method will give the second level of the candidate window of the associated phrases. When a phrase is selected, the input method selects the candidate and inserts the readings accordingly.

A user can use esc to cancel the associated phrases candidate window anytime.
