### PR TITLE
Sync linted C++ source with fcitx5-mcbopomofo

### DIFF
--- a/Source/Engine/AssociatedPhrases.cpp
+++ b/Source/Engine/AssociatedPhrases.cpp
@@ -28,10 +28,11 @@
 #include "AssociatedPhrases.h"
 
 #include <fcntl.h>
-#include <fstream>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <fstream>
 
 #include "KeyValueBlobReader.h"
 
@@ -74,7 +75,7 @@ bool AssociatedPhrases::open(const char* path)
         return false;
     }
 
-    length = (size_t)sb.st_size;
+    length = static_cast<size_t>(sb.st_size);
 
     data = mmap(NULL, length, PROT_READ, MAP_SHARED, fd, 0);
     if (!data) {

--- a/Source/Engine/AssociatedPhrases.h
+++ b/Source/Engine/AssociatedPhrases.h
@@ -25,12 +25,13 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#ifndef ASSOCIATEDPHRASES_H
-#define ASSOCIATEDPHRASES_H
+#ifndef SRC_ENGINE_ASSOCIATEDPHRASES_H_
+#define SRC_ENGINE_ASSOCIATEDPHRASES_H_
 
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace McBopomofo {
@@ -48,13 +49,13 @@ public:
 
 protected:
     struct Row {
-        Row(std::string_view& k, std::string_view& v)
-            : key(k)
-            , value(v)
+        Row(std::string_view k, std::string_view v)
+            : key(std::move(k))
+            , value(std::move(v))
         {
         }
-        std::string_view key;
-        std::string_view value;
+        const std::string_view key;
+        const std::string_view value;
     };
 
     std::map<std::string_view, std::vector<Row>> keyRowMap;
@@ -64,6 +65,6 @@ protected:
     size_t length;
 };
 
-}
+} // namespace McBopomofo
 
-#endif // ASSOCIATEDPHRASES_H
+#endif // SRC_ENGINE_ASSOCIATEDPHRASES_H_

--- a/Source/Engine/KeyValueBlobReader.h
+++ b/Source/Engine/KeyValueBlobReader.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOURCE_ENGINE_KEYVALUEBLOBREADER_H_
-#define SOURCE_ENGINE_KEYVALUEBLOBREADER_H_
+#ifndef SRC_ENGINE_KEYVALUEBLOBREADER_H_
+#define SRC_ENGINE_KEYVALUEBLOBREADER_H_
 
 #include <cstddef>
 #include <functional>
@@ -103,4 +103,4 @@ std::ostream& operator<<(std::ostream&, const KeyValueBlobReader::KeyValue&);
 
 } // namespace McBopomofo
 
-#endif // SOURCE_ENGINE_KEYVALUEBLOBREADER_H_
+#endif // SRC_ENGINE_KEYVALUEBLOBREADER_H_

--- a/Source/Engine/Mandarin/Mandarin.cpp
+++ b/Source/Engine/Mandarin/Mandarin.cpp
@@ -31,6 +31,7 @@ namespace Mandarin {
 
 class PinyinParseHelper {
  public:
+  // Returns true after `target` got stripped the specified `prefix`.
   static bool ConsumePrefix(std::string& target, const std::string& prefix) {
     if (target.length() < prefix.length()) {
       return false;

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef MANDARIN_H_
-#define MANDARIN_H_
+#ifndef SRC_ENGINE_MANDARIN_MANDARIN_H_
+#define SRC_ENGINE_MANDARIN_MANDARIN_H_
 
 #include <cstdint>
 #include <iostream>
@@ -483,4 +483,4 @@ class BopomofoReadingBuffer {
 }  // namespace Mandarin
 }  // namespace Formosa
 
-#endif  // MANDARIN_H_
+#endif  // SRC_ENGINE_MANDARIN_MANDARIN_H_

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -23,9 +23,10 @@
 
 #include "McBopomofoLM.h"
 #include <algorithm>
-#include <float.h>
 #include <iterator>
 #include <limits>
+#include <string>
+#include <vector>
 
 namespace McBopomofo {
 
@@ -176,7 +177,8 @@ void McBopomofoLM::setExternalConverter(std::function<std::string(std::string)> 
     m_externalConverter = externalConverter;
 }
 
-void McBopomofoLM::setMacroConverter(std::function<std::string(std::string)> macroConverter) {
+void McBopomofoLM::setMacroConverter(std::function<std::string(std::string)> macroConverter)
+{
     m_macroConverter = macroConverter;
 }
 
@@ -193,7 +195,6 @@ std::vector<Formosa::Gramambular2::LanguageModel::Unigram> McBopomofoLM::filterA
         }
 
         std::string value = originalValue;
-
         if (m_phraseReplacementEnabled) {
             std::string replacement = m_phraseReplacement.valueForKey(value);
             if (!replacement.empty()) {
@@ -208,7 +209,7 @@ std::vector<Formosa::Gramambular2::LanguageModel::Unigram> McBopomofoLM::filterA
             std::string replacement = m_externalConverter(value);
             value = replacement;
         }
-        if (!value.empty() && insertedValues.find(value) == insertedValues.end()) {
+        if (insertedValues.find(value) == insertedValues.end()) {
             results.emplace_back(value, unigram.score());
             insertedValues.insert(value);
         }

--- a/Source/Engine/McBopomofoLM.h
+++ b/Source/Engine/McBopomofoLM.h
@@ -21,17 +21,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef MCBOPOMOFOLM_H
-#define MCBOPOMOFOLM_H
+#ifndef SRC_ENGINE_MCBOPOMOFOLM_H_
+#define SRC_ENGINE_MCBOPOMOFOLM_H_
 
 #include "AssociatedPhrases.h"
 #include "ParselessLM.h"
 #include "PhraseReplacementMap.h"
 #include "UserPhrasesLM.h"
 #include "gramambular2/language_model.h"
+#include <cstdio>
 #include <functional>
-#include <stdio.h>
+#include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace McBopomofo {
 
@@ -101,7 +103,8 @@ public:
     bool externalConverterEnabled() const;
     /// Sets a lambda to let the values of unigrams could be converted by it.
     void setExternalConverter(std::function<std::string(std::string)> externalConverter);
-    /// Sets a lambda to convert the macros.
+
+    /// Sets a lambda to convert the macro to a string.
     void setMacroConverter(std::function<std::string(std::string)> macroConverter);
 
     const std::vector<std::string> associatedPhrasesForKey(const std::string& key);
@@ -127,11 +130,11 @@ protected:
     UserPhrasesLM m_excludedPhrases;
     PhraseReplacementMap m_phraseReplacement;
     AssociatedPhrases m_associatedPhrases;
+    std::function<std::string(std::string)> m_macroConverter;
     bool m_phraseReplacementEnabled;
     bool m_externalConverterEnabled;
     std::function<std::string(std::string)> m_externalConverter;
-    std::function<std::string(std::string)> m_macroConverter;
 };
-};
+} // namespace McBopomofo
 
-#endif
+#endif // SRC_ENGINE_MCBOPOMOFOLM_H_

--- a/Source/Engine/ParselessLM.cpp
+++ b/Source/Engine/ParselessLM.cpp
@@ -24,12 +24,13 @@
 #include "ParselessLM.h"
 
 #include <fcntl.h>
-#include <string_view>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 #include <memory>
+#include <string_view>
+#include <utility>
 
 McBopomofo::ParselessLM::~ParselessLM() { close(); }
 

--- a/Source/Engine/ParselessLM.h
+++ b/Source/Engine/ParselessLM.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOURCE_ENGINE_PARSELESSLM_H_
-#define SOURCE_ENGINE_PARSELESSLM_H_
+#ifndef SRC_ENGINE_PARSELESSLM_H_
+#define SRC_ENGINE_PARSELESSLM_H_
 
 #include <memory>
 #include <string>
@@ -59,6 +59,6 @@ private:
     std::unique_ptr<ParselessPhraseDB> db_;
 };
 
-}; // namespace McBopomofo
+} // namespace McBopomofo
 
-#endif // SOURCE_ENGINE_PARSELESSLM_H_
+#endif // SRC_ENGINE_PARSELESSLM_H_

--- a/Source/Engine/ParselessLMTest.cpp
+++ b/Source/Engine/ParselessLMTest.cpp
@@ -70,4 +70,4 @@ TEST(ParselessLMTest, SanityCheckTest)
     lm.close();
 }
 
-}; // namespace McBopomofo
+} // namespace McBopomofo

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -196,4 +196,4 @@ std::vector<std::string> ParselessPhraseDB::reverseFindRows(
     return rows;
 }
 
-}; // namespace McBopomofo
+} // namespace McBopomofo

--- a/Source/Engine/ParselessPhraseDB.h
+++ b/Source/Engine/ParselessPhraseDB.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef SOURCE_ENGINE_PARSELESSPHRASEDB_H_
-#define SOURCE_ENGINE_PARSELESSPHRASEDB_H_
+#ifndef SRC_ENGINE_PARSELESSPHRASEDB_H_
+#define SRC_ENGINE_PARSELESSPHRASEDB_H_
 
 #include <cstddef>
 #include <string>
@@ -63,6 +63,6 @@ private:
     const char* end_;
 };
 
-}; // namespace McBopomofo
+} // namespace McBopomofo
 
-#endif // SOURCE_ENGINE_PARSELESSPHRASEDB_H_
+#endif // SRC_ENGINE_PARSELESSPHRASEDB_H_

--- a/Source/Engine/ParselessPhraseDBTest.cpp
+++ b/Source/Engine/ParselessPhraseDBTest.cpp
@@ -221,4 +221,4 @@ TEST(ParselessPhraseDBTest, LookUpByValue)
     ASSERT_TRUE(rows.empty());
 }
 
-}; // namespace McBopomofo
+} // namespace McBopomofo

--- a/Source/Engine/PhraseReplacementMap.cpp
+++ b/Source/Engine/PhraseReplacementMap.cpp
@@ -1,10 +1,34 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 #include "PhraseReplacementMap.h"
 
 #include <fcntl.h>
-#include <fstream>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <fstream>
 
 #include "KeyValueBlobReader.h"
 
@@ -44,7 +68,7 @@ bool PhraseReplacementMap::open(const char* path)
         return false;
     }
 
-    length = (size_t)sb.st_size;
+    length = static_cast<size_t>(sb.st_size);
 
     data = mmap(NULL, length, PROT_READ, MAP_SHARED, fd, 0);
     if (!data) {
@@ -81,4 +105,4 @@ const std::string PhraseReplacementMap::valueForKey(const std::string& key)
     return string("");
 }
 
-}
+} // namespace McBopomofo

--- a/Source/Engine/PhraseReplacementMap.h
+++ b/Source/Engine/PhraseReplacementMap.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef PHRASEREPLACEMENTMAP_H
-#define PHRASEREPLACEMENTMAP_H
+#ifndef SRC_ENGINE_PHRASEREPLACEMENTMAP_H_
+#define SRC_ENGINE_PHRASEREPLACEMENTMAP_H_
 
 #include <iostream>
 #include <map>
@@ -46,6 +46,6 @@ protected:
     size_t length;
 };
 
-}
+} // namespace McBopomofo
 
-#endif
+#endif // SRC_ENGINE_PHRASEREPLACEMENTMAP_H_

--- a/Source/Engine/UserOverrideModel.cpp
+++ b/Source/Engine/UserOverrideModel.cpp
@@ -27,6 +27,8 @@
 #include "gramambular2/reading_grid.h"
 #include <cassert>
 #include <cmath>
+#include <utility>
+#include <vector>
 
 namespace McBopomofo {
 
@@ -236,7 +238,7 @@ static double Score(size_t eventCount,
         return 0.0;
     }
 
-    double prob = (double)eventCount / (double)totalCount;
+    double prob = static_cast<double>(eventCount) / static_cast<double>(totalCount);
     return prob * decay;
 }
 

--- a/Source/Engine/UserOverrideModel.h
+++ b/Source/Engine/UserOverrideModel.h
@@ -21,12 +21,13 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef USEROVERRIDEMODEL_H
-#define USEROVERRIDEMODEL_H
+#ifndef SRC_ENGINE_USEROVERRIDEMODEL_H_
+#define SRC_ENGINE_USEROVERRIDEMODEL_H_
 
 #include <list>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "gramambular2/reading_grid.h"
 
@@ -95,4 +96,4 @@ private:
 
 } // namespace McBopomofo
 
-#endif
+#endif // SRC_ENGINE_USEROVERRIDEMODEL_H_

--- a/Source/Engine/UserPhrasesLM.cpp
+++ b/Source/Engine/UserPhrasesLM.cpp
@@ -24,10 +24,12 @@
 #include "UserPhrasesLM.h"
 
 #include <fcntl.h>
-#include <fstream>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+#include <fstream>
+#include <vector>
 
 #include "KeyValueBlobReader.h"
 
@@ -70,7 +72,7 @@ bool UserPhrasesLM::open(const char* path)
         return false;
     }
 
-    length = (size_t)sb.st_size;
+    length = static_cast<size_t>(sb.st_size);
 
     data = mmap(NULL, length, PROT_READ, MAP_SHARED, fd, 0);
     if (!data) {
@@ -127,4 +129,4 @@ bool UserPhrasesLM::hasUnigrams(const std::string& key)
     return keyRowMap.find(key) != keyRowMap.end();
 }
 
-}; // namespace McBopomofo
+} // namespace McBopomofo

--- a/Source/Engine/UserPhrasesLM.h
+++ b/Source/Engine/UserPhrasesLM.h
@@ -21,13 +21,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef USERPHRASESLM_H
-#define USERPHRASESLM_H
+#ifndef SRC_ENGINE_USERPHRASESLM_H_
+#define SRC_ENGINE_USERPHRASESLM_H_
 
 #include "gramambular2/language_model.h"
 #include <iostream>
 #include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace McBopomofo {
 
@@ -46,13 +48,13 @@ public:
 
 protected:
     struct Row {
-        Row(std::string_view& k, std::string_view& v)
-            : key(k)
-            , value(v)
+        Row(std::string_view k, std::string_view v)
+            : key(std::move(k))
+            , value(std::move(v))
         {
         }
-        std::string_view key;
-        std::string_view value;
+        const std::string_view key;
+        const std::string_view value;
     };
 
     std::map<std::string_view, std::vector<Row>> keyRowMap;
@@ -61,6 +63,6 @@ protected:
     size_t length;
 };
 
-}
+} // namespace McBopomofo
 
-#endif
+#endif // SRC_ENGINE_USERPHRASESLM_H_

--- a/Source/Engine/gramambular2/language_model.h
+++ b/Source/Engine/gramambular2/language_model.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef LANGUAGE_MODEL_H_
-#define LANGUAGE_MODEL_H_
+#ifndef SRC_ENGINE_GRAMAMBULAR2_LANGUAGE_MODEL_H_
+#define SRC_ENGINE_GRAMAMBULAR2_LANGUAGE_MODEL_H_
 
 #include <string>
 #include <utility>
@@ -59,4 +59,4 @@ class LanguageModel {
 
 }  // namespace Formosa::Gramambular2
 
-#endif
+#endif  // SRC_ENGINE_GRAMAMBULAR2_LANGUAGE_MODEL_H_

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#ifndef READING_GRID_H_
-#define READING_GRID_H_
+#ifndef SRC_ENGINE_GRAMAMBULAR2_READING_GRID_H_
+#define SRC_ENGINE_GRAMAMBULAR2_READING_GRID_H_
 
 #include <array>
 #include <cassert>
@@ -270,4 +270,4 @@ class ReadingGrid {
 
 }  // namespace Formosa::Gramambular2
 
-#endif
+#endif  // SRC_ENGINE_GRAMAMBULAR2_READING_GRID_H_

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -23,13 +23,12 @@
 
 #include "reading_grid.h"
 
-#include <gtest/gtest.h>
-
 #include <iostream>
 #include <map>
 #include <string>
 #include <vector>
 
+#include "gtest/gtest.h"
 #include "language_model.h"
 
 namespace Formosa::Gramambular2 {
@@ -668,8 +667,8 @@ TEST(ReadingGridTest, DisambiguateCandidates) {
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "焰", "危險"}));
 
-  ASSERT_TRUE(
-      grid.overrideCandidate(loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥")));
+  ASSERT_TRUE(grid.overrideCandidate(
+      loc, ReadingGrid::Candidate("ㄏㄨㄛˇㄧㄢˋ", "🔥")));
   result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"高熱", "🔥", "危險"}));


### PR DESCRIPTION
This carries over several fixes there.

Note: after this, the header guards will be like "SRC_ENGINE_FOO_H" in accordance with Google C++ style. We understand that in the macOS version, the source is located in Source/. However the source in fcitx5-mcbopomofo is in src/. Since we do most of the linting and tidying there, we think it makes sense to use the header guards this way.