### PR TITLE
Makes it able to move cursor when the candidate window is presented

### DIFF
--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -33,6 +33,7 @@ class KeyHandlerBopomofoTests: XCTestCase {
     var handler = KeyHandler()
 
     override func setUpWithError() throws {
+        Preferences.chineseConversionEnabled = false
         LanguageModelManager.loadDataModels()
         handler = KeyHandler()
         handler.inputMode = .bopomofo

--- a/Packages/ChineseNumbers/Sources/ChineseNumbers/ChineseNumbers.swift
+++ b/Packages/ChineseNumbers/Sources/ChineseNumbers/ChineseNumbers.swift
@@ -30,7 +30,7 @@ import Foundation
         }
     }
 
-    fileprivate static let higherPlaces = ["", "萬", "億", "兆", "京", "垓", "秭", "穰"]
+    fileprivate static let higherPlaces = ["", "萬", "億", "兆", "京", "垓", "秭", "穰", "溝", "澗", "正", "載"]
 
     /// Converts an Arabic number to a Chinese number
     /// - Parameters:

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,19 +37,21 @@
         </window>
         <userDefaultsController representsSharedInstance="YES" id="32"/>
         <view autoresizesSubviews="NO" id="YEO-Nr-Xri">
-            <rect key="frame" x="0.0" y="0.0" width="477" height="505"/>
+            <rect key="frame" x="0.0" y="0.0" width="477" height="524"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
-                    <rect key="frame" x="42" y="468" width="176" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
+                    <rect key="frame" x="44" y="482" width="176" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bopomofo Keyboard Layout:" id="VTD-h6-q9r">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cb1-du-5Jn">
-                    <rect key="frame" x="226" y="430" width="233" height="25"/>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cb1-du-5Jn">
+                    <rect key="frame" x="229" y="444" width="226" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="n2z-u9-T3b">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -59,32 +61,29 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="mjl-uI-U8T"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
-                    <rect key="frame" x="21" y="436" width="197" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
+                    <rect key="frame" x="23" y="450" width="197" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric Keyboard Layout:" id="cTl-dv-9gx">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="Nma-j4-skB">
-                    <rect key="frame" x="227" y="344" width="207" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nma-j4-skB">
+                    <rect key="frame" x="230" y="358" width="206" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Space key chooses candidate" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="07b-85-YOF">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="16" id="T4T-em-Lr7"/>
-                    </constraints>
                     <connections>
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="Z1u-Xj-5q7"/>
                     </connections>
                 </button>
-                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
-                    <rect key="frame" x="228" y="372" width="230" height="22"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="19" id="y4d-Id-9g5"/>
-                    </constraints>
+                <comboBox focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
+                    <rect key="frame" x="231" y="386" width="221" height="22"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="YUT-KV-za8">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -99,16 +98,18 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="dwv-UP-fcW"/>
                     </connections>
                 </comboBox>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
-                    <rect key="frame" x="121" y="377" width="97" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
+                    <rect key="frame" x="123" y="391" width="97" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Selection Keys:" id="5RC-uF-JMe">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
-                    <rect key="frame" x="226" y="460" width="125" height="25"/>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
+                    <rect key="frame" x="229" y="474" width="118" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Standard" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="PTu-Ks-u1l" id="tPE-G4-rho">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -127,8 +128,9 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
-                    <rect key="frame" x="227" y="85" width="228" height="18"/>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
+                    <rect key="frame" x="230" y="80" width="229" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="ESC key clears entire input buffer" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="04m-pr-CAi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -137,67 +139,36 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="uBc-h3-Lqq"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
-                    <rect key="frame" x="66" y="318" width="152" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
+                    <rect key="frame" x="68" y="333" width="152" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Candidate Phrase:" id="Old-PI-MEs">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
-                    <rect key="frame" x="89" y="234" width="129" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
+                    <rect key="frame" x="91" y="221" width="129" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate List Style:" id="Xj4-f5-50V">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
-                    <rect key="frame" x="89" y="187" width="129" height="17"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="17" id="hPg-FR-H8n"/>
-                    </constraints>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
+                    <rect key="frame" x="91" y="173" width="129" height="17"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-25-09x">
-                    <rect key="frame" x="229" y="297" width="205" height="38"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="205" id="9yY-Zy-1G5"/>
-                        <constraint firstAttribute="height" constant="38" id="EHw-WE-cqD"/>
-                    </constraints>
-                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="205" height="18"/>
-                    <size key="intercellSpacing" width="4" height="2"/>
-                    <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="xcx-K6-Cxq">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <cells>
-                        <column>
-                            <buttonCell type="radio" title="Before the cursor (like Hanin)" imagePosition="left" alignment="left" state="on" inset="2" id="bH1-P4-146">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <buttonCell type="radio" title="After the cursor (like MS IME)" imagePosition="left" alignment="left" tag="1" inset="2" id="6jL-NM-3fC">
-                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                        </column>
-                    </cells>
-                    <connections>
-                        <binding destination="32" name="selectedTag" keyPath="values.SelectPhraseAfterCursorAsCandidate" id="CKd-Sk-Koh"/>
-                    </connections>
-                </matrix>
-                <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pdz-c8-G89">
-                    <rect key="frame" x="229" y="216" width="88" height="38"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="38" id="vCD-Dm-J78"/>
-                    </constraints>
+                <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pdz-c8-G89">
+                    <rect key="frame" x="232" y="200" width="88" height="38"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="88" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -221,8 +192,9 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="o5T-Km-VhT"/>
                     </connections>
                 </matrix>
-                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
-                    <rect key="frame" x="226" y="182" width="65" height="25"/>
+                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
+                    <rect key="frame" x="229" y="165" width="88" height="26"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="64X-UF-Vz6" id="Bsy-hs-5q4">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -243,40 +215,52 @@
                         <binding destination="32" name="selectedTag" keyPath="values.CandidateListTextSize" id="eR6-uj-SZ2"/>
                     </connections>
                 </popUpButton>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="wIs-KO-qx1">
-                    <rect key="frame" x="22" y="411" width="433" height="5"/>
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="wIs-KO-qx1">
+                    <rect key="frame" x="20" y="423" width="437" height="9"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
-                    <rect key="frame" x="22" y="159" width="433" height="5"/>
+                <box horizontalHuggingPriority="234" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
+                    <rect key="frame" x="20" y="152" width="444" height="9"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
-                    <rect key="frame" x="227" y="272" width="193" height="18"/>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
+                    <rect key="frame" x="230" y="286" width="192" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Move cursor after selection" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="SK6-0h-omu">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="16" id="qDO-Fc-wTQ"/>
-                    </constraints>
                     <connections>
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="Jra-P0-jp5"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
-                    <rect key="frame" x="98" y="133" width="120" height="16"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="116" id="fNK-qR-ZyW"/>
-                    </constraints>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UiH-9a-GF7">
+                    <rect key="frame" x="230" y="239" width="221" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Z7n-dF-oDt">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <string key="title">Allow moving cursor by JK keys 
+when selecting candidats</string>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="32" name="value" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="RLp-ue-39w"/>
+                    </connections>
+                </button>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
+                    <rect key="frame" x="100" y="128" width="120" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s4T-Mw-U2e">
-                    <rect key="frame" x="229" y="111" width="226" height="38"/>
+                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s4T-Mw-U2e">
+                    <rect key="frame" x="232" y="106" width="227" height="38"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="226" height="18"/>
+                    <size key="cellSize" width="227" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
                     <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="yD6-qb-zFd">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -298,16 +282,18 @@
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="YP4-Tc-T1I"/>
                     </connections>
                 </matrix>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
-                    <rect key="frame" x="159" y="86" width="59" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
+                    <rect key="frame" x="161" y="81" width="59" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
-                    <rect key="frame" x="227" y="19" width="222" height="18"/>
+                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
+                    <rect key="frame" x="230" y="19" width="222" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="W90-DF-5t4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -316,90 +302,49 @@
                         <binding destination="32" name="value" keyPath="values.CheckUpdateAutomatically" id="UjB-eN-wOI"/>
                     </connections>
                 </button>
+                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-25-09x">
+                    <rect key="frame" x="232" y="311" width="206" height="38"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    <size key="cellSize" width="206" height="18"/>
+                    <size key="intercellSpacing" width="4" height="2"/>
+                    <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="xcx-K6-Cxq">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <cells>
+                        <column>
+                            <buttonCell type="radio" title="Before the cursor (like Hanin)" imagePosition="left" alignment="left" state="on" inset="2" id="bH1-P4-146">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <buttonCell type="radio" title="After the cursor (like MS IME)" imagePosition="left" alignment="left" tag="1" inset="2" id="6jL-NM-3fC">
+                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                        </column>
+                    </cells>
+                    <connections>
+                        <binding destination="32" name="selectedTag" keyPath="values.SelectPhraseAfterCursorAsCandidate" id="CKd-Sk-Koh"/>
+                    </connections>
+                </matrix>
             </subviews>
-            <constraints>
-                <constraint firstItem="3oc-Wl-pem" firstAttribute="top" secondItem="eBz-xC-fkE" secondAttribute="bottom" constant="30" id="16v-SC-A95"/>
-                <constraint firstItem="7dj-MJ-a2i" firstAttribute="top" secondItem="iZs-U3-CJx" secondAttribute="bottom" constant="50" id="1T0-xR-5DJ"/>
-                <constraint firstItem="bhe-DC-FkH" firstAttribute="leading" secondItem="cb1-du-5Jn" secondAttribute="leading" id="1vg-tk-Fdx"/>
-                <constraint firstItem="buv-Na-btc" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="395-pD-MUb"/>
-                <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="3ZY-iI-Ira"/>
-                <constraint firstAttribute="trailing" secondItem="bhe-DC-FkH" secondAttribute="trailing" constant="130" id="4Ri-es-P93"/>
-                <constraint firstItem="AvT-mU-HNg" firstAttribute="leading" secondItem="s4T-Mw-U2e" secondAttribute="leading" id="4vx-1v-ljq"/>
-                <constraint firstItem="8Kb-9o-Czh" firstAttribute="leading" secondItem="Nma-j4-skB" secondAttribute="leading" id="6Oz-Aj-bCN"/>
-                <constraint firstItem="Sp0-2u-7hi" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="8Cu-NJ-Mfa"/>
-                <constraint firstItem="AvT-mU-HNg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="s4T-Mw-U2e" secondAttribute="leading" id="A7X-Tm-ABh"/>
-                <constraint firstItem="YIg-XJ-f3T" firstAttribute="baseline" secondItem="iZs-U3-CJx" secondAttribute="baseline" id="AmN-yX-dfP"/>
-                <constraint firstItem="Sp0-2u-7hi" firstAttribute="top" secondItem="s4T-Mw-U2e" secondAttribute="top" id="ApK-TL-QD8"/>
-                <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="Nma-j4-skB" secondAttribute="bottom" constant="10" id="BI4-g9-Qq8"/>
-                <constraint firstItem="wIs-KO-qx1" firstAttribute="leading" secondItem="Frc-9z-VZe" secondAttribute="leading" id="CEe-fD-3zO"/>
-                <constraint firstAttribute="trailing" secondItem="9MN-II-LQm" secondAttribute="trailing" constant="57" id="CLq-0p-e5G"/>
-                <constraint firstItem="Nma-j4-skB" firstAttribute="top" secondItem="8Kb-9o-Czh" secondAttribute="bottom" constant="13" id="D0O-UA-em4"/>
-                <constraint firstItem="3oc-Wl-pem" firstAttribute="centerY" secondItem="AvT-mU-HNg" secondAttribute="centerY" id="D5f-S4-4hI"/>
-                <constraint firstItem="9Hh-po-xMG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="EgO-gd-gjs"/>
-                <constraint firstItem="fxC-25-09x" firstAttribute="leading" secondItem="Pdz-c8-G89" secondAttribute="leading" id="EuW-qE-rgf"/>
-                <constraint firstItem="wIs-KO-qx1" firstAttribute="trailing" secondItem="8Kb-9o-Czh" secondAttribute="trailing" id="IUD-MZ-G6C"/>
-                <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="AvT-mU-HNg" secondAttribute="leading" id="KEW-w1-uo0"/>
-                <constraint firstAttribute="bottom" secondItem="3oc-Wl-pem" secondAttribute="bottom" constant="187" id="MVt-hj-dfl"/>
-                <constraint firstAttribute="trailing" secondItem="7dj-MJ-a2i" secondAttribute="trailing" constant="28" id="N9x-sw-73Q"/>
-                <constraint firstItem="eBz-xC-fkE" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="NZ8-ww-TgM"/>
-                <constraint firstItem="9MN-II-LQm" firstAttribute="top" secondItem="fxC-25-09x" secondAttribute="bottom" constant="8" symbolic="YES" id="PX1-a8-35R"/>
-                <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="9MN-II-LQm" secondAttribute="bottom" constant="19" id="RwF-9v-LYa"/>
-                <constraint firstItem="buv-Na-btc" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="112" id="SLo-Xw-8f4"/>
-                <constraint firstItem="8Kb-9o-Czh" firstAttribute="trailing" secondItem="Frc-9z-VZe" secondAttribute="trailing" id="TjF-V8-fBO"/>
-                <constraint firstItem="AvT-mU-HNg" firstAttribute="top" secondItem="Pdz-c8-G89" secondAttribute="bottom" constant="10" id="VFt-Rt-lPn"/>
-                <constraint firstItem="buv-Na-btc" firstAttribute="top" secondItem="8Kb-9o-Czh" secondAttribute="top" id="Vcz-X6-pTg"/>
-                <constraint firstItem="Sp0-2u-7hi" firstAttribute="top" secondItem="Frc-9z-VZe" secondAttribute="bottom" constant="12" id="XRA-i7-mcC"/>
-                <constraint firstItem="buv-Na-btc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="XhI-kR-kAm"/>
-                <constraint firstAttribute="bottom" secondItem="7dj-MJ-a2i" secondAttribute="bottom" constant="20" id="YJo-M5-GJK"/>
-                <constraint firstItem="cb1-du-5Jn" firstAttribute="top" secondItem="bhe-DC-FkH" secondAttribute="bottom" constant="10" symbolic="YES" id="Zdn-0t-MYp"/>
-                <constraint firstItem="s4T-Mw-U2e" firstAttribute="centerX" secondItem="iZs-U3-CJx" secondAttribute="centerX" id="Zl9-Og-6zP"/>
-                <constraint firstItem="JFW-qA-UTv" firstAttribute="centerY" secondItem="cb1-du-5Jn" secondAttribute="centerY" id="aIC-5f-SnD"/>
-                <constraint firstItem="s4T-Mw-U2e" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7dj-MJ-a2i" secondAttribute="leading" id="bXu-JM-DE1"/>
-                <constraint firstItem="wIs-KO-qx1" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="22" id="bhE-oW-IzU"/>
-                <constraint firstItem="buv-Na-btc" firstAttribute="top" secondItem="wIs-KO-qx1" secondAttribute="bottom" constant="20" id="bir-1i-vJo"/>
-                <constraint firstItem="YIg-XJ-f3T" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="d5U-wA-KPC"/>
-                <constraint firstItem="Nma-j4-skB" firstAttribute="centerX" secondItem="fxC-25-09x" secondAttribute="centerX" id="dKm-Pb-vxH"/>
-                <constraint firstItem="bhe-DC-FkH" firstAttribute="top" secondItem="1UT-Vk-jJp" secondAttribute="top" id="dSg-5E-OYD"/>
-                <constraint firstItem="JFW-qA-UTv" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="dVE-1V-AWj"/>
-                <constraint firstItem="s4T-Mw-U2e" firstAttribute="leading" secondItem="Sp0-2u-7hi" secondAttribute="trailing" constant="13" id="eBi-9H-uDe"/>
-                <constraint firstItem="Nma-j4-skB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9MN-II-LQm" secondAttribute="leading" id="ea3-P6-jFs"/>
-                <constraint firstItem="cb1-du-5Jn" firstAttribute="leading" secondItem="fxC-25-09x" secondAttribute="leading" id="ftF-mC-18D"/>
-                <constraint firstItem="s4T-Mw-U2e" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iZs-U3-CJx" secondAttribute="trailing" id="hlz-bZ-f2C"/>
-                <constraint firstItem="cb1-du-5Jn" firstAttribute="trailing" secondItem="wIs-KO-qx1" secondAttribute="trailing" id="jPN-kZ-qDJ"/>
-                <constraint firstItem="Nma-j4-skB" firstAttribute="trailing" secondItem="fxC-25-09x" secondAttribute="trailing" id="jZC-rd-UQh"/>
-                <constraint firstAttribute="trailing" secondItem="AvT-mU-HNg" secondAttribute="trailing" constant="190" id="kCf-H0-cc2"/>
-                <constraint firstItem="9Hh-po-xMG" firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" id="nhE-M5-TNN"/>
-                <constraint firstItem="wIs-KO-qx1" firstAttribute="centerX" secondItem="YEO-Nr-Xri" secondAttribute="centerX" id="ouV-q2-rLG"/>
-                <constraint firstItem="1UT-Vk-jJp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="pSu-mT-8bO"/>
-                <constraint firstItem="9MN-II-LQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="iZs-U3-CJx" secondAttribute="leading" id="qCB-m1-4W6"/>
-                <constraint firstItem="iZs-U3-CJx" firstAttribute="top" secondItem="s4T-Mw-U2e" secondAttribute="bottom" constant="9" id="qz7-2D-U2B"/>
-                <constraint firstItem="9Hh-po-xMG" firstAttribute="top" secondItem="buv-Na-btc" secondAttribute="bottom" constant="43" id="rQS-Al-dq3"/>
-                <constraint firstItem="YIg-XJ-f3T" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="szu-Px-a2C"/>
-                <constraint firstItem="wIs-KO-qx1" firstAttribute="top" secondItem="cb1-du-5Jn" secondAttribute="bottom" constant="20" id="vEM-cu-t9g"/>
-                <constraint firstItem="3oc-Wl-pem" firstAttribute="centerX" secondItem="eBz-xC-fkE" secondAttribute="centerX" id="wK8-Q3-9me"/>
-                <constraint firstItem="Sp0-2u-7hi" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="x0x-Ld-ruA"/>
-                <constraint firstItem="8Kb-9o-Czh" firstAttribute="centerX" secondItem="s4T-Mw-U2e" secondAttribute="centerX" id="xqx-2Y-MG1"/>
-                <constraint firstItem="JFW-qA-UTv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="y4Q-vk-QHc"/>
-                <constraint firstAttribute="trailing" secondItem="Nma-j4-skB" secondAttribute="trailing" constant="43" id="yGp-tz-BvD"/>
-            </constraints>
-            <point key="canvasLocation" x="-413.5" y="-366.5"/>
+            <point key="canvasLocation" x="-410.5" y="-359"/>
         </view>
         <view id="S2Y-nP-nn8">
             <rect key="frame" x="0.0" y="0.0" width="477" height="156"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gu5-mN-Rn7">
-                    <rect key="frame" x="49" y="74" width="173" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gu5-mN-Rn7">
+                    <rect key="frame" x="64" y="74" width="173" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Chinese Conversion Engine:" id="mgC-11-2qn">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gsg-Ew-VBh">
-                    <rect key="frame" x="227" y="53" width="213" height="38"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gsg-Ew-VBh">
+                    <rect key="frame" x="242" y="53" width="213" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="213" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -423,18 +368,16 @@
                         <binding destination="32" name="selectedTag" keyPath="values.ChineseConversionEngine" id="Xd8-aZ-29H"/>
                     </connections>
                 </matrix>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
-                    <rect key="frame" x="59" y="120" width="163" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
+                    <rect key="frame" x="74" y="120" width="163" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Chinese Conversion Style:" id="cMO-Ss-Jar">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xwt-fe-fQG">
-                    <rect key="frame" x="228" y="99" width="213" height="38"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xwt-fe-fQG">
+                    <rect key="frame" x="243" y="99" width="213" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="213" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -458,13 +401,11 @@
                         <binding destination="32" name="selectedTag" keyPath="values.ChineseConversionStyle" id="cnK-mJ-pCg"/>
                     </connections>
                 </matrix>
-                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="6u2-Su-7mb">
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="6u2-Su-7mb">
                     <rect key="frame" x="20" y="42" width="437" height="5"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                 </box>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NGh-Dn-Qpf">
-                    <rect key="frame" x="226" y="19" width="234" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NGh-Dn-Qpf">
+                    <rect key="frame" x="241" y="19" width="161" height="18"/>
                     <buttonCell key="cell" type="check" title="Ctrl + ` for Big 5 Code" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9wE-js-xtM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -474,6 +415,23 @@
                     </connections>
                 </button>
             </subviews>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="NGh-Dn-Qpf" secondAttribute="trailing" constant="75" id="5Ht-Dt-dKR"/>
+                <constraint firstItem="gu5-mN-Rn7" firstAttribute="top" secondItem="wds-Zh-QHP" secondAttribute="bottom" constant="30" id="Av7-g6-UYH"/>
+                <constraint firstItem="Gsg-Ew-VBh" firstAttribute="leading" secondItem="gu5-mN-Rn7" secondAttribute="trailing" constant="7" id="B3d-15-KyX"/>
+                <constraint firstItem="6u2-Su-7mb" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="20" symbolic="YES" id="F85-tW-oQT"/>
+                <constraint firstItem="wds-Zh-QHP" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="76" id="GYV-Ei-TBy"/>
+                <constraint firstItem="6u2-Su-7mb" firstAttribute="top" secondItem="Gsg-Ew-VBh" secondAttribute="bottom" constant="8" symbolic="YES" id="KCl-CR-GKe"/>
+                <constraint firstItem="NGh-Dn-Qpf" firstAttribute="leading" secondItem="Xwt-fe-fQG" secondAttribute="leading" id="NXr-qF-ZHZ"/>
+                <constraint firstItem="wds-Zh-QHP" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="20" symbolic="YES" id="P39-Rs-be4"/>
+                <constraint firstItem="Gsg-Ew-VBh" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="242" id="QgL-oP-ZQ8"/>
+                <constraint firstAttribute="bottom" secondItem="NGh-Dn-Qpf" secondAttribute="bottom" constant="20" symbolic="YES" id="XcQ-vP-lvY"/>
+                <constraint firstItem="NGh-Dn-Qpf" firstAttribute="top" secondItem="6u2-Su-7mb" secondAttribute="bottom" constant="8" symbolic="YES" id="Y4H-g2-LHN"/>
+                <constraint firstItem="Gsg-Ew-VBh" firstAttribute="top" secondItem="Xwt-fe-fQG" secondAttribute="bottom" constant="8" symbolic="YES" id="ZG9-US-bLi"/>
+                <constraint firstItem="gu5-mN-Rn7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="20" symbolic="YES" id="ZIO-Aw-kds"/>
+                <constraint firstAttribute="trailing" secondItem="6u2-Su-7mb" secondAttribute="trailing" constant="20" symbolic="YES" id="Zij-FW-FLR"/>
+                <constraint firstItem="Xwt-fe-fQG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="wds-Zh-QHP" secondAttribute="trailing" symbolic="YES" id="rRe-qT-xAw"/>
+            </constraints>
             <point key="canvasLocation" x="129.5" y="-159"/>
         </view>
         <customView id="7EY-3X-sVm">

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -40,18 +40,16 @@
             <rect key="frame" x="0.0" y="0.0" width="477" height="524"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
                     <rect key="frame" x="44" y="482" width="176" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bopomofo Keyboard Layout:" id="VTD-h6-q9r">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cb1-du-5Jn">
-                    <rect key="frame" x="229" y="444" width="226" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cb1-du-5Jn">
+                    <rect key="frame" x="229" y="444" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="n2z-u9-T3b">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -61,18 +59,16 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="mjl-uI-U8T"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
                     <rect key="frame" x="23" y="450" width="197" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric Keyboard Layout:" id="cTl-dv-9gx">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nma-j4-skB">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="Nma-j4-skB">
                     <rect key="frame" x="230" y="358" width="206" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Space key chooses candidate" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="07b-85-YOF">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -81,9 +77,11 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="Z1u-Xj-5q7"/>
                     </connections>
                 </button>
-                <comboBox focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
+                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
                     <rect key="frame" x="231" y="386" width="221" height="22"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="19" id="yz7-87-p3i"/>
+                    </constraints>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="YUT-KV-za8">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -98,18 +96,16 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="dwv-UP-fcW"/>
                     </connections>
                 </comboBox>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
                     <rect key="frame" x="123" y="391" width="97" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Selection Keys:" id="5RC-uF-JMe">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
                     <rect key="frame" x="229" y="474" width="118" height="25"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <popUpButtonCell key="cell" type="push" title="Standard" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="PTu-Ks-u1l" id="tPE-G4-rho">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -128,9 +124,8 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
                     <rect key="frame" x="230" y="80" width="229" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="ESC key clears entire input buffer" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="04m-pr-CAi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -139,36 +134,32 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="uBc-h3-Lqq"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
                     <rect key="frame" x="68" y="333" width="152" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Candidate Phrase:" id="Old-PI-MEs">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
-                    <rect key="frame" x="91" y="221" width="129" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
+                    <rect key="frame" x="91" y="222" width="129" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate List Style:" id="Xj4-f5-50V">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
                     <rect key="frame" x="91" y="173" width="129" height="17"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pdz-c8-G89">
+                <matrix verticalHuggingPriority="750" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Pdz-c8-G89">
                     <rect key="frame" x="232" y="200" width="88" height="38"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="88" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -192,9 +183,8 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="o5T-Km-VhT"/>
                     </connections>
                 </matrix>
-                <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
-                    <rect key="frame" x="229" y="165" width="88" height="26"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
+                    <rect key="frame" x="229" y="165" width="56" height="26"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="64X-UF-Vz6" id="Bsy-hs-5q4">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -215,17 +205,17 @@
                         <binding destination="32" name="selectedTag" keyPath="values.CandidateListTextSize" id="eR6-uj-SZ2"/>
                     </connections>
                 </popUpButton>
-                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="wIs-KO-qx1">
-                    <rect key="frame" x="20" y="423" width="437" height="9"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="wIs-KO-qx1">
+                    <rect key="frame" x="20" y="423" width="437" height="5"/>
                 </box>
-                <box horizontalHuggingPriority="234" verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
+                <box horizontalHuggingPriority="234" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
                     <rect key="frame" x="20" y="152" width="444" height="9"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="5" id="g25-PX-ai3"/>
+                    </constraints>
                 </box>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
                     <rect key="frame" x="230" y="286" width="192" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Move cursor after selection" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="SK6-0h-omu">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -234,31 +224,16 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="Jra-P0-jp5"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UiH-9a-GF7">
-                    <rect key="frame" x="230" y="239" width="221" height="44"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Z7n-dF-oDt">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <string key="title">Allow moving cursor by JK keys 
-when selecting candidats</string>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="32" name="value" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="RLp-ue-39w"/>
-                    </connections>
-                </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
                     <rect key="frame" x="100" y="128" width="120" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s4T-Mw-U2e">
+                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s4T-Mw-U2e">
                     <rect key="frame" x="232" y="106" width="227" height="38"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="227" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -282,18 +257,16 @@ when selecting candidats</string>
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="YP4-Tc-T1I"/>
                     </connections>
                 </matrix>
-                <textField focusRingType="none" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
                     <rect key="frame" x="161" y="81" width="59" height="16"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
                     <rect key="frame" x="230" y="19" width="222" height="18"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="W90-DF-5t4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -302,9 +275,8 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.CheckUpdateAutomatically" id="UjB-eN-wOI"/>
                     </connections>
                 </button>
-                <matrix verticalHuggingPriority="750" fixedFrame="YES" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-25-09x">
+                <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fxC-25-09x">
                     <rect key="frame" x="232" y="311" width="206" height="38"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="206" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -328,7 +300,85 @@ when selecting candidats</string>
                         <binding destination="32" name="selectedTag" keyPath="values.SelectPhraseAfterCursorAsCandidate" id="CKd-Sk-Koh"/>
                     </connections>
                 </matrix>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UiH-9a-GF7">
+                    <rect key="frame" x="230" y="246" width="222" height="32"/>
+                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Z7n-dF-oDt">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <string key="title">Allow moving cursor by JK keys 
+when selecting candidats</string>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="32" name="value" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="RLp-ue-39w"/>
+                    </connections>
+                </button>
             </subviews>
+            <constraints>
+                <constraint firstItem="Frc-9z-VZe" firstAttribute="leading" secondItem="wIs-KO-qx1" secondAttribute="leading" id="0Rp-83-rb3"/>
+                <constraint firstItem="iZs-U3-CJx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="0Ue-BV-em9"/>
+                <constraint firstItem="8Kb-9o-Czh" firstAttribute="top" secondItem="wIs-KO-qx1" secondAttribute="bottom" constant="18" id="3hA-Qj-Ceh"/>
+                <constraint firstItem="9MN-II-LQm" firstAttribute="top" secondItem="fxC-25-09x" secondAttribute="bottom" constant="8" symbolic="YES" id="4BY-PB-UQr"/>
+                <constraint firstItem="8Kb-9o-Czh" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="5Ig-i5-lpd"/>
+                <constraint firstAttribute="trailing" secondItem="AvT-mU-HNg" secondAttribute="trailing" constant="196" id="6DG-3s-663"/>
+                <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="Nma-j4-skB" secondAttribute="bottom" constant="10" id="7sl-1g-vy7"/>
+                <constraint firstItem="YIg-XJ-f3T" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="8JE-Su-7ZC"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="baseline" secondItem="AvT-mU-HNg" secondAttribute="firstBaseline" id="8gy-DP-nrC"/>
+                <constraint firstItem="7dj-MJ-a2i" firstAttribute="centerX" secondItem="UiH-9a-GF7" secondAttribute="centerX" id="AcU-jF-ehe"/>
+                <constraint firstAttribute="trailing" secondItem="bhe-DC-FkH" secondAttribute="trailing" constant="134" id="Byn-Xm-2sc"/>
+                <constraint firstAttribute="bottom" secondItem="Pdz-c8-G89" secondAttribute="bottom" constant="200" id="CsX-Jv-JGp"/>
+                <constraint firstItem="cb1-du-5Jn" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="DqI-u5-0L4"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="YIg-XJ-f3T" secondAttribute="trailing" id="DyU-hc-NaA"/>
+                <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="eBz-xC-fkE" secondAttribute="top" id="GQr-IE-mPN"/>
+                <constraint firstAttribute="trailing" secondItem="iZs-U3-CJx" secondAttribute="trailing" constant="18" id="ICX-nN-t2a"/>
+                <constraint firstItem="UiH-9a-GF7" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="Iej-bp-7J3"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="top" secondItem="AvT-mU-HNg" secondAttribute="top" id="J26-55-kji"/>
+                <constraint firstItem="s4T-Mw-U2e" firstAttribute="top" secondItem="Frc-9z-VZe" secondAttribute="bottom" constant="10" id="L59-Rf-SnT"/>
+                <constraint firstItem="bhe-DC-FkH" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="26" id="L7s-Xm-LXg"/>
+                <constraint firstItem="Nma-j4-skB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" symbolic="YES" id="LCh-b8-xXg"/>
+                <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="UiH-9a-GF7" secondAttribute="bottom" constant="8" id="O2s-wX-T0t"/>
+                <constraint firstItem="Frc-9z-VZe" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="Obg-X1-fuW"/>
+                <constraint firstItem="iZs-U3-CJx" firstAttribute="top" secondItem="s4T-Mw-U2e" secondAttribute="bottom" constant="9" id="QWR-rt-HEb"/>
+                <constraint firstAttribute="bottom" secondItem="7dj-MJ-a2i" secondAttribute="bottom" constant="20" symbolic="YES" id="R07-SD-4Sq"/>
+                <constraint firstItem="AvT-mU-HNg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" symbolic="YES" id="SLf-GY-58Y"/>
+                <constraint firstAttribute="trailing" secondItem="Frc-9z-VZe" secondAttribute="trailing" constant="13" id="U3T-Ij-i1M"/>
+                <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="Up9-ed-0dG"/>
+                <constraint firstItem="AvT-mU-HNg" firstAttribute="top" secondItem="Pdz-c8-G89" secondAttribute="bottom" constant="10" id="VgD-h8-weo"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="Sp0-2u-7hi" secondAttribute="trailing" id="W0h-NP-ex7"/>
+                <constraint firstItem="bhe-DC-FkH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" symbolic="YES" id="YEV-YT-uQf"/>
+                <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="eBz-xC-fkE" secondAttribute="trailing" constant="14" id="Zb9-zd-PG9"/>
+                <constraint firstItem="s4T-Mw-U2e" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Sp0-2u-7hi" secondAttribute="trailing" constant="8" symbolic="YES" id="ayv-gh-1Fj"/>
+                <constraint firstItem="1UT-Vk-jJp" firstAttribute="trailing" secondItem="JFW-qA-UTv" secondAttribute="trailing" id="bir-NM-ZOw"/>
+                <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="9Hh-po-xMG" secondAttribute="top" id="ct4-Cq-2I5"/>
+                <constraint firstItem="7dj-MJ-a2i" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="dGM-2Y-C0k"/>
+                <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="175" id="eFx-le-TlC"/>
+                <constraint firstItem="YIg-XJ-f3T" firstAttribute="baseline" secondItem="iZs-U3-CJx" secondAttribute="baseline" id="fRl-nn-4Qk"/>
+                <constraint firstItem="s4T-Mw-U2e" firstAttribute="top" secondItem="Sp0-2u-7hi" secondAttribute="top" id="fxD-q7-CjV"/>
+                <constraint firstAttribute="bottom" secondItem="Frc-9z-VZe" secondAttribute="bottom" constant="154" id="gyg-nJ-n93"/>
+                <constraint firstItem="s4T-Mw-U2e" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="gzt-2A-Bay"/>
+                <constraint firstAttribute="trailing" secondItem="wIs-KO-qx1" secondAttribute="trailing" constant="20" symbolic="YES" id="jov-sp-DFD"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="leading" secondItem="eBz-xC-fkE" secondAttribute="leading" id="kLg-nb-lBS"/>
+                <constraint firstItem="cb1-du-5Jn" firstAttribute="top" secondItem="bhe-DC-FkH" secondAttribute="bottom" constant="10" symbolic="YES" id="lWX-aG-lvR"/>
+                <constraint firstItem="JFW-qA-UTv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="mvx-tv-OTK"/>
+                <constraint firstItem="Nma-j4-skB" firstAttribute="top" secondItem="8Kb-9o-Czh" secondAttribute="bottom" constant="13" id="neE-LS-Pux"/>
+                <constraint firstItem="8Kb-9o-Czh" firstAttribute="top" secondItem="buv-Na-btc" secondAttribute="top" id="oN5-et-AMb"/>
+                <constraint firstItem="fxC-25-09x" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="qNg-rI-AXH"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="JFW-qA-UTv" secondAttribute="trailing" id="qPV-Ay-cu0"/>
+                <constraint firstItem="1UT-Vk-jJp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="rGt-cX-7MN"/>
+                <constraint firstItem="buv-Na-btc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="rVv-G7-IYo"/>
+                <constraint firstItem="Sp0-2u-7hi" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="102" id="reE-gz-6af"/>
+                <constraint firstAttribute="trailing" secondItem="9MN-II-LQm" secondAttribute="trailing" constant="55" id="rhZ-Ei-vgV"/>
+                <constraint firstItem="bhe-DC-FkH" firstAttribute="top" secondItem="1UT-Vk-jJp" secondAttribute="top" id="rvu-rU-VRH"/>
+                <constraint firstItem="fxC-25-09x" firstAttribute="leading" secondItem="9Hh-po-xMG" secondAttribute="trailing" constant="14" id="sKt-7O-cH7"/>
+                <constraint firstItem="9MN-II-LQm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" symbolic="YES" id="soH-no-9Io"/>
+                <constraint firstItem="8Kb-9o-Czh" firstAttribute="leading" secondItem="buv-Na-btc" secondAttribute="trailing" constant="14" id="t6y-y2-260"/>
+                <constraint firstItem="Frc-9z-VZe" firstAttribute="top" secondItem="AvT-mU-HNg" secondAttribute="bottom" constant="10" id="tfM-7Q-CWt"/>
+                <constraint firstAttribute="bottom" secondItem="s4T-Mw-U2e" secondAttribute="bottom" constant="106" id="wZi-qQ-F4U"/>
+                <constraint firstAttribute="trailing" secondItem="8Kb-9o-Czh" secondAttribute="trailing" constant="28" id="xYJ-NH-Zdx"/>
+                <constraint firstItem="JFW-qA-UTv" firstAttribute="centerY" secondItem="cb1-du-5Jn" secondAttribute="centerY" id="xyb-7e-ZT7"/>
+                <constraint firstAttribute="trailing" secondItem="Nma-j4-skB" secondAttribute="trailing" constant="41" id="y4N-j1-pN0"/>
+                <constraint firstItem="7dj-MJ-a2i" firstAttribute="centerX" secondItem="cb1-du-5Jn" secondAttribute="centerX" id="zCb-cJ-mOg"/>
+                <constraint firstItem="9Hh-po-xMG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="zcu-j5-AyW"/>
+            </constraints>
             <point key="canvasLocation" x="-410.5" y="-359"/>
         </view>
         <view id="S2Y-nP-nn8">

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -644,7 +644,7 @@ extension McBopomofoInputMethodController {
         gCurrentCandidateController?.candidateFont = font(name: Preferences.candidateTextFontName, size: textSize)
 
         let candidateKeys = Preferences.candidateKeys
-        let keyLabels = candidateKeys.count > 4 ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
+        let keyLabels = candidateKeys.count >= 4 ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
         let keyLabelPrefix = state is InputState.AssociatedPhrasesPlain ? "⇧ " : ""
         gCurrentCandidateController?.keyLabels = keyLabels.map {
             CandidateKeyLabel(key: String($0), displayedText: keyLabelPrefix + String($0))

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1160,6 +1160,39 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     BOOL cancelCandidateKey = (charCode == 27) || (charCode == 8) || input.isDelete;
 
+    if ([state isKindOfClass:[InputStateChoosingCandidate class]] &&
+        Preferences.allowMovingCursorWhenChoosingCandidates
+        ) {
+        if ([input.inputText isEqualToString:@"j"] || (input.isLeft && input.isShiftHold)
+            ) {
+            size_t cursor = _grid->cursor();
+            if (cursor > 0) {
+                cursor--;
+                _grid->setCursor(cursor);
+            } else {
+                errorCallback();
+                return YES;
+            }
+            InputState *newState = [self _buildCandidateState:(InputStateChoosingCandidate *)state useVerticalMode:[(InputStateChoosingCandidate *)state useVerticalMode]];
+            stateCallback(newState);
+            return YES;
+        }
+
+        if ([input.inputText isEqualToString:@"k"]  || (input.isRight && input.isShiftHold)) {
+            size_t cursor = _grid->cursor();
+            if (cursor < _grid->length()) {
+                cursor++;
+                _grid->setCursor(cursor);
+            } else {
+                errorCallback();
+                return YES;
+            }
+            InputState *newState = [self _buildCandidateState:(InputStateChoosingCandidate *)state useVerticalMode:[(InputStateChoosingCandidate *)state useVerticalMode]];
+            stateCallback(newState);
+            return YES;
+        }
+    }
+
     if (_inputMode == InputModeBopomofo && [input.inputText isEqualToString:@"?"]) {
         if ([state isKindOfClass:[InputStateShowingCharInfo class]] ||
             [state isKindOfClass:[InputStateSelectingDictionary class]]) {
@@ -1435,6 +1468,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
     }
+
+
 
     errorCallback();
     return YES;
@@ -1761,7 +1796,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         [candidatesArray addObject:candidate];
     }
 
-    InputStateChoosingCandidate *state = [[InputStateChoosingCandidate alloc] initWithComposingBuffer:currentState.composingBuffer cursorIndex:currentState.cursorIndex candidates:candidatesArray useVerticalMode:useVerticalMode];
+    InputStateChoosingCandidate *state = [[InputStateChoosingCandidate alloc] initWithComposingBuffer:currentState.composingBuffer cursorIndex:_grid->cursor() candidates:candidatesArray useVerticalMode:useVerticalMode];
     return state;
 }
 

--- a/Source/LanguageModelManager.h
+++ b/Source/LanguageModelManager.h
@@ -21,8 +21,8 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-#import "KeyHandler.h"
 #import <Foundation/Foundation.h>
+#import "KeyHandler.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -462,7 +462,6 @@ extension Preferences {
     @objc static var selectCandidateWithNumericKeypad: Bool
 }
 
-
 extension Preferences {
     @UserDefault(key: kBig5InputEnabledKey, defaultValue: true)
     @objc static var big5InputEnabled: Bool

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -43,6 +43,8 @@ private let kKeepReadingUponCompositionError = "KeepReadingUponCompositionError"
 private let kCandidateTextFontName = "CandidateTextFontName"
 private let kCandidateKeyLabelFontName = "CandidateKeyLabelFontName"
 private let kCandidateKeys = "CandidateKeys"
+private let kAllowMovingCursorWhenChoosingCandidates = "AllowMovingCursorWhenChoosingCandidates"
+
 private let kPhraseReplacementEnabledKey = "PhraseReplacementEnabled"
 private let kChineseConversionEngineKey = "ChineseConversionEngine"
 private let kChineseConversionStyleKey = "ChineseConversionStyle"
@@ -332,8 +334,12 @@ class Preferences: NSObject {
                 return NSLocalizedString("Candidate keys cannot be longer than 15 characters.", comment: "")
             }
         }
-
     }
+
+    /// Whether allows moving the cursor by J/K keys, when the candidate
+    /// window is presented.
+    @UserDefault(key: kAllowMovingCursorWhenChoosingCandidates, defaultValue: false)
+    @objc static var allowMovingCursorWhenChoosingCandidates: Bool
 }
 
 extension Preferences {

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,11 +37,11 @@
         </window>
         <userDefaultsController representsSharedInstance="YES" id="32"/>
         <view id="eWf-pC-0Bt">
-            <rect key="frame" x="0.0" y="0.0" width="436" height="470"/>
+            <rect key="frame" x="0.0" y="0.0" width="436" height="510"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSi-pH-F8f">
-                    <rect key="frame" x="181" y="426" width="99" height="25"/>
+                    <rect key="frame" x="181" y="466" width="99" height="25"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="iXH-DJ-dBb">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -62,8 +62,8 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KRC-Qj-X94">
-                    <rect key="frame" x="78" y="434" width="100" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KRC-Qj-X94">
+                    <rect key="frame" x="78" y="474" width="97" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="注音鍵盤配置：" id="pgD-ZY-ctk">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -71,7 +71,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6eT-rC-gVz">
-                    <rect key="frame" x="181" y="396" width="236" height="25"/>
+                    <rect key="frame" x="181" y="436" width="236" height="25"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="M0n-R9-S5B">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -81,24 +81,24 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="bhg-HS-4r8"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tK-14-8hw">
-                    <rect key="frame" x="28" y="307" width="150" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tK-14-8hw">
+                    <rect key="frame" x="28" y="347" width="147" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字時，候選詞起點在：" id="NxU-Db-NGM">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KMh-qe-ZAb">
-                    <rect key="frame" x="67" y="237" width="111" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KMh-qe-ZAb">
+                    <rect key="frame" x="67" y="247" width="107" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="候選詞呈現方式：" id="bgn-gs-kBm">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-hI-9WY">
-                    <rect key="frame" x="64" y="179" width="111" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-hI-9WY">
+                    <rect key="frame" x="64" y="189" width="107" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字窗文字大小：" id="Rqe-kZ-F9v">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -106,7 +106,7 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ovb-PR-Z2o">
-                    <rect key="frame" x="184" y="285" width="186" height="38"/>
+                    <rect key="frame" x="184" y="325" width="186" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="186" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -131,7 +131,7 @@
                     </connections>
                 </matrix>
                 <popUpButton verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="YF3-dA-BAc">
-                    <rect key="frame" x="181" y="171" width="56" height="25"/>
+                    <rect key="frame" x="181" y="181" width="56" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="lvY-bs-FFU" id="EI9-WJ-zQC">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -153,7 +153,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2Nx-PK-HCb">
-                    <rect key="frame" x="182" y="330" width="119" height="18"/>
+                    <rect key="frame" x="182" y="370" width="119" height="18"/>
                     <buttonCell key="cell" type="check" title="使用空白鍵選字" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="viN-E3-CpO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -162,8 +162,8 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="9Y3-nN-WmY"/>
                     </connections>
                 </button>
-                <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gtY-jT-2F6">
-                    <rect key="frame" x="183" y="353" width="233" height="23"/>
+                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gtY-jT-2F6">
+                    <rect key="frame" x="183" y="393" width="233" height="23"/>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="SQ9-Pr-yQD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -178,8 +178,8 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="cHc-ww-yZG"/>
                     </connections>
                 </comboBox>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-3w-gC1">
-                    <rect key="frame" x="120" y="359" width="58" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-3w-gC1">
+                    <rect key="frame" x="120" y="399" width="54" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字鍵：" id="8xt-it-NRD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -187,7 +187,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" id="KOq-SU-0dw">
-                    <rect key="frame" x="182" y="92" width="231" height="20"/>
+                    <rect key="frame" x="182" y="102" width="231" height="20"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="按下 ESC 會清除整個輸入緩衝區" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lGd-Af-8ly">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -197,8 +197,8 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="HMq-t1-4Cz"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c1b-KP-F28">
-                    <rect key="frame" x="67" y="404" width="111" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c1b-KP-F28">
+                    <rect key="frame" x="67" y="444" width="107" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="英數字鍵盤配置：" id="LAM-Fg-sIT">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -206,7 +206,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hvF-32-Zw1">
-                    <rect key="frame" x="182" y="24" width="146" height="18"/>
+                    <rect key="frame" x="182" y="34" width="146" height="18"/>
                     <buttonCell key="cell" type="check" title="定期檢查是否有新版" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="k9r-ii-fdD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -216,13 +216,13 @@
                     </connections>
                 </button>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="pjw-8M-CEh">
-                    <rect key="frame" x="20" y="164" width="396" height="5"/>
+                    <rect key="frame" x="20" y="214" width="396" height="5"/>
                 </box>
                 <box horizontalHuggingPriority="249" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uuQ-a9-JKn">
-                    <rect key="frame" x="20" y="389" width="393" height="5"/>
+                    <rect key="frame" x="20" y="429" width="393" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" id="qLt-o2-oPl">
-                    <rect key="frame" x="182" y="260" width="186" height="18"/>
+                    <rect key="frame" x="182" y="300" width="186" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" title="選字之後自動移動游標位置" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jlf-jk-hJY">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -232,8 +232,8 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="g9O-jR-PLB"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMU-k1-QG3">
-                    <rect key="frame" x="80" y="142" width="98" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMU-k1-QG3">
+                    <rect key="frame" x="80" y="152" width="98" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + 字母鍵：" id="v98-LJ-zGS">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -241,7 +241,10 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bc3-oU-EWC">
-                    <rect key="frame" x="184" y="120" width="199" height="38"/>
+                    <rect key="frame" x="184" y="130" width="199" height="38"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="38" id="ygm-dn-RRC"/>
+                    </constraints>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="199" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -265,8 +268,8 @@
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="H57-16-hal"/>
                     </connections>
                 </matrix>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IxA-64-q7d">
-                    <rect key="frame" x="121" y="95" width="57" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IxA-64-q7d">
+                    <rect key="frame" x="121" y="105" width="56" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC 鍵：" id="q86-sV-OE5">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -274,7 +277,7 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" verticalCompressionResistancePriority="741" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eKe-P1-HOz">
-                    <rect key="frame" x="184" y="215" width="80" height="38"/>
+                    <rect key="frame" x="184" y="225" width="80" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="80" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -298,21 +301,27 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="IRV-VT-5Ou"/>
                     </connections>
                 </matrix>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wKx-MS-U5F">
+                    <rect key="frame" x="182" y="271" width="221" height="25"/>
+                    <buttonCell key="cell" type="check" title="選字時可以使用 JK 移動游標" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="saB-TA-BmG">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" size="13" name=".PingFangTC-Regular"/>
+                    </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="23" id="hew-3q-HGA"/>
+                    </constraints>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="leading" secondItem="BSi-pH-F8f" secondAttribute="leading" id="1Is-6A-uDX"/>
                 <constraint firstAttribute="trailing" secondItem="2Nx-PK-HCb" secondAttribute="trailing" constant="135" id="1oK-cy-5rz"/>
                 <constraint firstItem="uuQ-a9-JKn" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="20" symbolic="YES" id="2OQ-NX-qoC"/>
+                <constraint firstItem="Bc3-oU-EWC" firstAttribute="leading" secondItem="wKx-MS-U5F" secondAttribute="leading" id="3MO-vR-4rn"/>
                 <constraint firstItem="8MO-3w-gC1" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="122" id="48h-T5-LRm"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hvF-32-Zw1" secondAttribute="trailing" constant="20" symbolic="YES" id="4EW-pm-2Aw"/>
-                <constraint firstItem="YF3-dA-BAc" firstAttribute="leading" secondItem="Bc3-oU-EWC" secondAttribute="leading" id="54L-Og-8OM"/>
-                <constraint firstItem="Bc3-oU-EWC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sMU-k1-QG3" secondAttribute="trailing" constant="8" symbolic="YES" id="6ii-ph-PAW"/>
                 <constraint firstItem="c1b-KP-F28" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="69" id="71X-kP-3dG"/>
-                <constraint firstItem="sMU-k1-QG3" firstAttribute="top" secondItem="pjw-8M-CEh" secondAttribute="bottom" constant="8" symbolic="YES" id="77q-kx-0C3"/>
-                <constraint firstItem="sMU-k1-QG3" firstAttribute="top" secondItem="Bc3-oU-EWC" secondAttribute="top" id="7Lg-JD-OL4"/>
+                <constraint firstItem="wKx-MS-U5F" firstAttribute="top" secondItem="qLt-o2-oPl" secondAttribute="bottom" constant="6" symbolic="YES" id="7VW-8q-y8U"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="centerX" secondItem="KOq-SU-0dw" secondAttribute="centerX" id="7y1-P1-vky"/>
-                <constraint firstItem="eKe-P1-HOz" firstAttribute="top" secondItem="qLt-o2-oPl" secondAttribute="bottom" constant="8" symbolic="YES" id="AZA-Xm-m1f"/>
-                <constraint firstItem="pjw-8M-CEh" firstAttribute="top" secondItem="YF3-dA-BAc" secondAttribute="bottom" constant="8" symbolic="YES" id="Ako-HU-XVF"/>
                 <constraint firstItem="hlp-hI-9WY" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="66" id="C5n-xZ-Azk"/>
                 <constraint firstItem="qLt-o2-oPl" firstAttribute="top" secondItem="ovb-PR-Z2o" secondAttribute="bottom" constant="8" symbolic="YES" id="FZr-Us-vHK"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8MO-3w-gC1" secondAttribute="trailing" id="GKI-Wn-Sw8"/>
@@ -322,7 +331,6 @@
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="80" id="L8O-S0-6Y6"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="trailing" secondItem="uuQ-a9-JKn" secondAttribute="trailing" id="Llc-RC-JdQ"/>
                 <constraint firstItem="eKe-P1-HOz" firstAttribute="leading" secondItem="qLt-o2-oPl" secondAttribute="leading" id="MIY-Nu-T2B"/>
-                <constraint firstAttribute="trailing" secondItem="pjw-8M-CEh" secondAttribute="trailing" constant="20" symbolic="YES" id="NCI-PC-jz1"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KMh-qe-ZAb" secondAttribute="trailing" id="Pn1-4v-tEB"/>
                 <constraint firstItem="hvF-32-Zw1" firstAttribute="top" secondItem="KOq-SU-0dw" secondAttribute="bottom" constant="52" id="Rct-4h-nso"/>
                 <constraint firstItem="0tK-14-8hw" firstAttribute="top" secondItem="ovb-PR-Z2o" secondAttribute="top" id="SWq-Yy-Dqm"/>
@@ -333,6 +341,7 @@
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="20" symbolic="YES" id="Vcd-VH-A59"/>
                 <constraint firstItem="8MO-3w-gC1" firstAttribute="top" secondItem="gtY-jT-2F6" secondAttribute="top" id="VeT-t7-djJ"/>
                 <constraint firstItem="sMU-k1-QG3" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IxA-64-q7d" secondAttribute="trailing" id="W4g-3D-M7y"/>
+                <constraint firstItem="sMU-k1-QG3" firstAttribute="top" secondItem="Bc3-oU-EWC" secondAttribute="top" id="WFJ-dJ-aGF"/>
                 <constraint firstItem="2Nx-PK-HCb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ovb-PR-Z2o" secondAttribute="leading" id="WKN-0M-mrQ"/>
                 <constraint firstItem="ovb-PR-Z2o" firstAttribute="leading" secondItem="qLt-o2-oPl" secondAttribute="leading" id="Z08-rc-Ryi"/>
                 <constraint firstItem="YF3-dA-BAc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="hlp-hI-9WY" secondAttribute="trailing" constant="8" symbolic="YES" id="ZaP-oe-Gz6"/>
@@ -341,27 +350,33 @@
                 <constraint firstItem="uuQ-a9-JKn" firstAttribute="trailing" secondItem="gtY-jT-2F6" secondAttribute="trailing" id="dPj-Sv-RUG"/>
                 <constraint firstItem="KMh-qe-ZAb" firstAttribute="top" secondItem="eKe-P1-HOz" secondAttribute="top" id="drj-w8-bdM"/>
                 <constraint firstItem="IxA-64-q7d" firstAttribute="top" secondItem="KOq-SU-0dw" secondAttribute="top" id="eXo-xQ-sYd"/>
-                <constraint firstItem="uuQ-a9-JKn" firstAttribute="leading" secondItem="pjw-8M-CEh" secondAttribute="leading" id="hEz-Tx-7Qz"/>
+                <constraint firstItem="KOq-SU-0dw" firstAttribute="top" secondItem="Bc3-oU-EWC" secondAttribute="bottom" constant="9" id="fAb-8J-XY5"/>
+                <constraint firstItem="Bc3-oU-EWC" firstAttribute="top" secondItem="YF3-dA-BAc" secondAttribute="bottom" constant="17" id="gAG-fo-X2j"/>
+                <constraint firstItem="Bc3-oU-EWC" firstAttribute="leading" secondItem="KOq-SU-0dw" secondAttribute="leading" id="hSz-bL-oDB"/>
                 <constraint firstItem="sMU-k1-QG3" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="82" id="hiU-tG-y1R"/>
+                <constraint firstAttribute="trailing" secondItem="wKx-MS-U5F" secondAttribute="trailing" constant="33" id="iow-0O-sRW"/>
+                <constraint firstItem="pjw-8M-CEh" firstAttribute="top" secondItem="eKe-P1-HOz" secondAttribute="bottom" constant="8" symbolic="YES" id="jjc-Gr-qo3"/>
                 <constraint firstItem="KMh-qe-ZAb" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="69" id="kXK-So-Eka"/>
                 <constraint firstItem="hvF-32-Zw1" firstAttribute="leading" secondItem="KOq-SU-0dw" secondAttribute="leading" id="kpu-ay-2cp"/>
                 <constraint firstItem="eKe-P1-HOz" firstAttribute="leading" secondItem="YF3-dA-BAc" secondAttribute="leading" id="lND-fs-zKT"/>
+                <constraint firstAttribute="trailing" secondItem="pjw-8M-CEh" secondAttribute="trailing" constant="20" symbolic="YES" id="nmI-LZ-kdZ"/>
                 <constraint firstItem="BSi-pH-F8f" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="KRC-Qj-X94" secondAttribute="trailing" constant="8" symbolic="YES" id="ol6-vO-beB"/>
                 <constraint firstItem="hlp-hI-9WY" firstAttribute="top" secondItem="YF3-dA-BAc" secondAttribute="top" id="qEs-p4-r8C"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="top" secondItem="BSi-pH-F8f" secondAttribute="bottom" constant="10" symbolic="YES" id="tqL-6p-RgP"/>
+                <constraint firstItem="pjw-8M-CEh" firstAttribute="leading" secondItem="uuQ-a9-JKn" secondAttribute="leading" id="uOd-ta-Qxh"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0tK-14-8hw" secondAttribute="trailing" id="vXa-wy-SNo"/>
                 <constraint firstAttribute="trailing" secondItem="BSi-pH-F8f" secondAttribute="trailing" constant="160" id="vnu-Vp-30x"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YF3-dA-BAc" secondAttribute="trailing" constant="20" symbolic="YES" id="yOH-NG-cRX"/>
                 <constraint firstItem="uuQ-a9-JKn" firstAttribute="top" secondItem="6eT-rC-gVz" secondAttribute="bottom" constant="8" symbolic="YES" id="yyu-N7-CYZ"/>
             </constraints>
-            <point key="canvasLocation" x="168" y="-377"/>
+            <point key="canvasLocation" x="168" y="-357"/>
         </view>
         <view id="L2Q-IX-SXc">
             <rect key="frame" x="0.0" y="0.0" width="436" height="163"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jAZ-sE-wLZ">
-                    <rect key="frame" x="54" y="81" width="124" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jAZ-sE-wLZ">
+                    <rect key="frame" x="57" y="81" width="121" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="中文簡繁轉換引擎：" id="8mX-v8-X1y">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -393,8 +408,8 @@
                         <binding destination="32" name="selectedTag" keyPath="values.ChineseConversionEngine" id="UmH-Rw-leg"/>
                     </connections>
                 </matrix>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cks-CZ-m7g">
-                    <rect key="frame" x="54" y="127" width="124" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cks-CZ-m7g">
+                    <rect key="frame" x="57" y="127" width="121" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="中文簡繁轉換模式：" id="bX9-g7-U8G">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -462,8 +477,8 @@
             <rect key="frame" x="0.0" y="0.0" width="436" height="334"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
-                    <rect key="frame" x="21" y="298" width="111" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
+                    <rect key="frame" x="21" y="298" width="107" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="使用者詞彙位置：" id="ulY-l0-tqg">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -488,7 +503,7 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aAf-VY-6CO">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aAf-VY-6CO">
                     <rect key="frame" x="90" y="261" width="291" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Ooe-Ve-njT">
                         <font key="font" metaFont="system"/>
@@ -500,7 +515,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="KRZ-JC-JCe"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
                     <rect key="frame" x="18" y="177" width="400" height="28"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="8wn-XD-VFx"/>
@@ -512,7 +527,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ibr-mk-lwr">
-                    <rect key="frame" x="90" y="232" width="40" height="21"/>
+                    <rect key="frame" x="90" y="232" width="39" height="21"/>
                     <buttonCell key="cell" type="bevel" title="Button" bezelStyle="rounded" imagePosition="overlaps" alignment="left" controlSize="small" imageScaling="proportionallyDown" inset="2" id="QMk-FM-cgo">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -521,7 +536,7 @@
                         <action selector="openUserPhrasedFolderAction:" target="-2" id="FXB-pN-TqS"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="bHQ-bR-nHc">
+                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="bHQ-bR-nHc">
                     <rect key="frame" x="18" y="120" width="396" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="在手動加入使用者詞彙之後:" id="Yhg-pv-SyV">
                         <font key="font" metaFont="system"/>
@@ -539,7 +554,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookEnabled" id="aI7-Rc-u4x"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VKE-yo-TdG">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VKE-yo-TdG">
                     <rect key="frame" x="71" y="58" width="346" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="346" id="62p-rx-Sp1"/>
@@ -553,7 +568,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookPath" id="KtP-IE-zum"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="8ku-Pt-FIH">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="8ku-Pt-FIH">
                     <rect key="frame" x="21" y="60" width="44" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="路徑：" id="2Ox-BG-OqC">
                         <font key="font" metaFont="system"/>
@@ -575,7 +590,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="v3f-1L-haF"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="kxZ-N1-Oph">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="kxZ-N1-Oph">
                     <rect key="frame" x="19" y="20" width="399" height="28"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="NbE-2C-xvN"/>


### PR DESCRIPTION
This PR fixes #422 and #423.

McBopomofo allows to set size per page to at least 4 candidates, however, there was a bug that causes the minimal size to be 5. The PR fixed the bug.

The PR also adds an option to let users to use J and K keys to move the cursor when the candidate window is visible.