### PR TITLE
Remove the keyboard layout icons from the Prefs

### DIFF
--- a/Source/PreferencesWindowController.swift
+++ b/Source/PreferencesWindowController.swift
@@ -173,28 +173,6 @@ fileprivate let kWindowTitleHeight: CGFloat = 78
             menuItem.title = localizedName
             menuItem.representedObject = sourceID
 
-            if let iconPtr = TISGetInputSourceProperty(source, kTISPropertyIconRef) {
-                let icon = IconRef(iconPtr)
-                let image = NSImage(iconRef: icon)
-
-                func resize(_ image: NSImage) -> NSImage {
-                    let newImage = NSImage(size: NSSize(width: 16, height: 16))
-                    newImage.lockFocus()
-                    image.draw(in: NSRect(x: 0, y: 0, width: 16, height: 16))
-                    newImage.unlockFocus()
-                    return newImage
-                }
-
-                let resizedImage = resize(image)
-                // On newer version of macOS, the icons became black and white
-                // so we make them template images so it could look better
-                // on dark mode.
-                if #available(macOS 10.16, *) {
-                    resizedImage.isTemplate = true
-                }
-                menuItem.image = resizedImage
-            }
-
             if sourceID == "com.apple.keylayout.US" {
                 usKeyboardLayoutItem = menuItem
             }


### PR DESCRIPTION
The layout icons do not differentiate themselves since macOS 14, and there have been appearance differences between macOS 13 and earlier versions. At this point it seems too much work to maintain a meaningful experience across all supported macOS versions, and so we propose removing it.

For what it's worth, Kotoeri (the built-in Japanese IME) also only lists keyboard layouts with their names only.