### PR TITLE
Fixes the issue where it skips the candidates before the new index on the next page when switching pages

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -291,10 +291,13 @@ public class VerticalCandidateController: CandidateController {
 
                 if selectedRow != -1 && itemCount > 0 {
                     let firstVisibleRow = tableView.row(at: scrollView.documentVisibleRect.origin)
+                    // If it's not single row movement, trigger forward page switching.
                     if newIndex > selectedRow && (Int(newIndex) - selectedRow) > 1 {
                         let lastVisibleRow = firstVisibleRow + labelCount - 1
                         rowToScroll = min(lastVisibleRow + labelCount, Int(itemCount) - 1)
-                    } else if newIndex < selectedRow && (selectedRow - Int(newIndex)) > 1 {
+                    }
+                    // If it's not single row movement, trigger backward page switching.
+                    if newIndex < selectedRow && (selectedRow - Int(newIndex)) > 1 {
                         rowToScroll = max(0, firstVisibleRow - labelCount)
                     }
                 }

--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -286,17 +286,22 @@ public class VerticalCandidateController: CandidateController {
                 return
             }
 
-            var lastVisibleRow = newValue
+            if itemCount > labelCount {
+                var rowToScroll = Int(newValue)
 
-            if selectedRow != -1 && itemCount > 0 && itemCount > labelCount {
-                if newIndex > selectedRow && (Int(newIndex) - selectedRow) > 1 {
-                    lastVisibleRow = min(newIndex + UInt(labelCount) - 1, itemCount - 1)
+                if selectedRow != -1 && itemCount > 0 {
+                    let firstVisibleRow = tableView.row(at: scrollView.documentVisibleRect.origin)
+                    if newIndex > selectedRow && (Int(newIndex) - selectedRow) > 1 {
+                        let lastVisibleRow = firstVisibleRow + labelCount - 1
+                        rowToScroll = min(lastVisibleRow + labelCount, Int(itemCount) - 1)
+                    } else if newIndex < selectedRow && (selectedRow - Int(newIndex)) > 1 {
+                        rowToScroll = max(0, firstVisibleRow - labelCount)
+                    }
                 }
-                // no need to handle the backward case: (newIndex < selectedRow && selectedRow - newIndex > 1)
-            }
 
-            if itemCount > labelCount && lastVisibleRow < Int.max {
-                tableView.scrollRowToVisible(Int(lastVisibleRow))
+                if rowToScroll < Int.max {
+                    tableView.scrollRowToVisible(rowToScroll)
+                }
             }
             tableView.selectRowIndexes(IndexSet(integer: Int(newIndex)), byExtendingSelection: false)
         }


### PR DESCRIPTION
Problem:
- In VerticalCandidateController, consider the scenario where you're searching for the 10th candidate "試", located at the top of the second page. Upon highlighting the 4th candidate "式" and moving to the next page, "室" appears at the top. This sequence completely skips over "試", "勢" and "適".

Solution:
1. For forward page switching: Retrieve the index of the last visible row and scroll to the subsequent last visible row.
2. For backward page switching: Retrieve the index of the first visible row and scroll to the previous first visible row.
3. Otherwise, scroll to the new value.
4. Handling scenarios involving scrolling: Even the selected candidate is not visible after scrolling, the page can be switched forth or back. The underlying selected candidate index can be updated accordingly. Pressing the up or down button will then bring the selected candidate back visible at the top of the page.