### PR TITLE
Fix a regression that broke phrase replacements

### DIFF
--- a/Source/Engine/PhraseReplacementMap.cpp
+++ b/Source/Engine/PhraseReplacementMap.cpp
@@ -49,11 +49,6 @@ void PhraseReplacementMap::close() {
 }
 
 bool PhraseReplacementMap::load(const char* data, size_t length) {
-  if (mmapedFile_.data() != nullptr) {
-    // Cannot load while mmapedFile_ is already open.
-    return false;
-  }
-
   if (data == nullptr || length == 0) {
     return false;
   }


### PR DESCRIPTION
A wrong check was introduced when PhraseReplacementMap was refactored, and therefore it broke phrase replacement for v2.7 users. This fixes it.