### PR TITLE
Add missing phonetics for 硅

### DIFF
--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -4601,6 +4601,7 @@
 溈 ㄍㄨㄟ gui ejo big5
 嫢 ㄍㄨㄟ gui ejo big5
 摫 ㄍㄨㄟ gui ejo big5
+硅 ㄍㄨㄟ gui ejo big5
 鬼 ㄍㄨㄟˇ gui3 ejo3 big5
 軌 ㄍㄨㄟˇ gui3 ejo3 big5
 詭 ㄍㄨㄟˇ gui3 ejo3 big5


### PR DESCRIPTION
It seems only the variants dict has `ㄏㄨㄛˋ`, other dictionaries have `ㄍㄨㄟ` only.

Ref:

https://dict.variants.moe.edu.tw/dictView.jsp?ID=94917&la=0
https://dict.revised.moe.edu.tw/dictView.jsp?ID=4271&q=1&word=%E7%A1%85 
https://www.moedict.tw/%E7%A1%85
https://dict.concised.moe.edu.tw/search.jsp?md=1&word=%E7%A1%85#searchL 
 <div id='description'>
<h3>Summary by Bito</h3>
Added missing phonetic entry 'gui' (ㄍㄨㄟ) for the character 硅 (silicon) in BPMFBase.txt dictionary to align with authoritative Chinese dictionaries' standard pronunciation.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>