### PR TITLE
Maintain infrequent characters' order

### DIFF
--- a/Source/Data/bin/cook.py
+++ b/Source/Data/bin/cook.py
@@ -124,6 +124,12 @@ if __name__ == '__main__':
 
     output = []
 
+    # Populate phrases dict with entries from BPMFBase.txt first: this is so
+    # that the resulting phrases dict will maintain the order from
+    # BPMFBase.txt; this is important for rarely used characters.
+    for key in bpmf_chars:
+        phrases[key] = UNK_LOG_FREQ
+
     while True:
         line = handle.readline()
         if not line: break
@@ -135,7 +141,14 @@ if __name__ == '__main__':
             readings = bpmf_phrases[mykey]
         except:
             sys.exit('[ERROR] %s key mismatches.' % mykey)
-        phrases[mykey] = True
+        phrases[mykey] = myvalue
+
+    for (mykey, myvalue) in phrases.items():
+        try:
+            readings = bpmf_phrases[mykey]
+        except:
+            sys.exit('[ERROR] %s key mismatches.' % mykey)
+
         # print mykey
         if readings:
             # 剛好一個中文字字的長度目前還是 3 (標點、聲調好像都是2)

--- a/Source/Data/bin/cook.py
+++ b/Source/Data/bin/cook.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
             sys.exit('[ERROR] %s key mismatches.' % mykey)
         phrases[mykey] = myvalue
 
-    for (mykey, myvalue) in phrases.items():
+    for mykey, myvalue in phrases.items():
         readings = bpmf_phrases.get(mykey)
 
         if readings:
@@ -191,11 +191,6 @@ if __name__ == '__main__':
                     # 很罕用的注音建議不要列入 heterophony?.list，這樣的話
                     # 就可以直接進來這個 condition
     handle.close()
-    for k in bpmf_chars:
-        if k not in phrases:
-            for v in bpmf_chars[k]:
-                output.append((k, v, UNK_LOG_FREQ))
-                pass
 
     with open(sys.argv[4]) as punctuations_file:
         for line in punctuations_file:

--- a/Source/Data/bin/cook.py
+++ b/Source/Data/bin/cook.py
@@ -144,12 +144,8 @@ if __name__ == '__main__':
         phrases[mykey] = myvalue
 
     for (mykey, myvalue) in phrases.items():
-        try:
-            readings = bpmf_phrases[mykey]
-        except:
-            sys.exit('[ERROR] %s key mismatches.' % mykey)
+        readings = bpmf_phrases.get(mykey)
 
-        # print mykey
         if readings:
             # 剛好一個中文字字的長度目前還是 3 (標點、聲調好像都是2)
             if len(mykey) > 3:


### PR DESCRIPTION
### **User description**
This pre-populates the `phrases` dictionary from the entries in `BPMFBase.txt` such that the dictionary will maintain the original insertion order (guaranteed since Python 3.7). The dictionary entries will then be overwritten with the actual data from `PhraseFreq.txt`.

This fixes #582.

## How Tested

A diff of the resulting `data.txt` shows that only infrequently used characters are affected: https://gist.github.com/lukhnos/a93d72da8c77671b2b978f8ac4a3da42


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Pre-populates `phrases` dictionary with `BPMFBase.txt` entries to maintain order.

- Ensures infrequent characters' order matches traditional phonetic order.

- Fixes key mismatch errors during dictionary population.

- Updates `cook.py` to handle `phrases` dictionary more robustly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cook.py</strong><dd><code>Pre-populate and maintain order in `phrases` dictionary</code>&nbsp; &nbsp; </dd></summary>
<hr>

Source/Data/bin/cook.py

<li>Added pre-population of <code>phrases</code> dictionary with <code>BPMFBase.txt</code> entries.<br> <li> Ensured dictionary maintains insertion order for infrequent <br>characters.<br> <li> Fixed key mismatch handling during dictionary population.<br> <li> Updated logic for processing <code>PhraseFreq.txt</code> data.


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/583/files#diff-01b979ece9b9e927699b96001070a41b82cfd999173e554ae8c9bec7e3430a72">+14/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details> 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request fixes a bug in the McBopomofo input method by ensuring the correct ordering of infrequent characters. It modifies the `cook.py` script to pre-populate the `phrases` dictionary from `BPMFBase.txt` and resolves key mismatch errors, enhancing the script's robustness. Additionally, it preserves the traditional phonetic order for rarely used characters, utilizing Python 3.7+'s dictionary insertion order guarantee.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>