### PR TITLE
Introduce the keys to boost and exclude phrases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ xcuserdata
 .vscode
 __pycache__
 codecov_comment.md
+DerivedData

--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		D427F7B6279086F6004A2160 /* InputSourceHelper in Frameworks */ = {isa = PBXBuildFile; productRef = D427F7B5279086F6004A2160 /* InputSourceHelper */; };
 		D427F7C127908EFC004A2160 /* OpenCCBridge in Frameworks */ = {isa = PBXBuildFile; productRef = D427F7C027908EFC004A2160 /* OpenCCBridge */; };
 		D436E23F2CD20BA700C6155D /* AssociatedPhrasesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D436E23E2CD20B9E00C6155D /* AssociatedPhrasesTests.swift */; };
+		D43737C92DF9C35800D9707C /* InputMethodController+KeyHandlerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43737C82DF9C35100D9707C /* InputMethodController+KeyHandlerDelegate.swift */; };
+		D43737CB2DF9C48300D9707C /* InputMethodController+CandidateControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43737CA2DF9C48200D9707C /* InputMethodController+CandidateControllerDelegate.swift */; };
 		D43FC40B2B23788400ED5A1C /* InputMacro.swift in Sources */ = {isa = PBXBuildFile; fileRef = D43FC40A2B23788400ED5A1C /* InputMacro.swift */; };
 		D449AD5F2B393C00000C5812 /* InputMacroTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449AD5E2B393C00000C5812 /* InputMacroTests.swift */; };
 		D449AD612B39506D000C5812 /* ServiceProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449AD602B39506D000C5812 /* ServiceProviderTests.swift */; };
@@ -190,6 +192,8 @@
 		D427F7B2279086B5004A2160 /* InputSourceHelper */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = InputSourceHelper; path = Packages/InputSourceHelper; sourceTree = "<group>"; };
 		D427F7BF27908EAC004A2160 /* OpenCCBridge */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = OpenCCBridge; path = Packages/OpenCCBridge; sourceTree = "<group>"; };
 		D436E23E2CD20B9E00C6155D /* AssociatedPhrasesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssociatedPhrasesTests.swift; sourceTree = "<group>"; };
+		D43737C82DF9C35100D9707C /* InputMethodController+KeyHandlerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InputMethodController+KeyHandlerDelegate.swift"; sourceTree = "<group>"; };
+		D43737CA2DF9C48200D9707C /* InputMethodController+CandidateControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InputMethodController+CandidateControllerDelegate.swift"; sourceTree = "<group>"; };
 		D43FC40A2B23788400ED5A1C /* InputMacro.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMacro.swift; sourceTree = "<group>"; };
 		D449AD5E2B393C00000C5812 /* InputMacroTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMacroTests.swift; sourceTree = "<group>"; };
 		D449AD602B39506D000C5812 /* ServiceProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProviderTests.swift; sourceTree = "<group>"; };
@@ -301,6 +305,8 @@
 				6ACA41E715FC1D9000935EF6 /* Installer */,
 				6A0D4F4715FC0EB900ABF4B3 /* Resources */,
 				D4A13D5927A59D5C003BE359 /* InputMethodController.swift */,
+				D43737C82DF9C35100D9707C /* InputMethodController+KeyHandlerDelegate.swift */,
+				D43737CA2DF9C48200D9707C /* InputMethodController+CandidateControllerDelegate.swift */,
 				D41355D6278D7409005E5CBD /* LanguageModelManager.h */,
 				D495583A27A5C6C4006ADE1C /* LanguageModelManager+Privates.h */,
 				D41355D7278D7409005E5CBD /* LanguageModelManager.mm */,
@@ -707,6 +713,7 @@
 				D427F76C278CA2B0004A2160 /* AppDelegate.swift in Sources */,
 				6ACC3D442793701600F1B140 /* ParselessPhraseDB.cpp in Sources */,
 				D461B792279DAC010070E734 /* InputState.swift in Sources */,
+				D43737CB2DF9C48300D9707C /* InputMethodController+CandidateControllerDelegate.swift in Sources */,
 				D47B92C027972AD100458394 /* main.swift in Sources */,
 				D44FB74D2792189A003C80A6 /* PhraseReplacementMap.cpp in Sources */,
 				D4A13D5A27A59F0B003BE359 /* InputMethodController.swift in Sources */,
@@ -722,6 +729,7 @@
 				6ACC3D452793701600F1B140 /* ParselessLM.cpp in Sources */,
 				D4CB1A5B2B389B78006EA984 /* DictionaryService.swift in Sources */,
 				D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */,
+				D43737C92DF9C35800D9707C /* InputMethodController+KeyHandlerDelegate.swift in Sources */,
 				D43FC40B2B23788400ED5A1C /* InputMacro.swift in Sources */,
 				6ADF5B1A2BA513E000577D98 /* MemoryMappedFile.cpp in Sources */,
 				6ACC3D3F27914F2400F1B140 /* KeyValueBlobReader.cpp in Sources */,

--- a/Source/Base.lproj/Localizable.strings
+++ b/Source/Base.lproj/Localizable.strings
@@ -122,3 +122,13 @@
 "Character Information" = "Character Information";
 
 "Enclosed Numbers" = "Enclosed Numbers";
+
+"Boost" = "Boost";
+
+"Cancel" = "Cancel";
+
+"Exclude" = "Exclude";
+
+"Do you want to boost the score of the phrase \"%@\"?" = "Do you want to boost the score of the phrase \"%@\"?";
+
+"Do you want to exclude the phrase \"%@\"?" = "Do you want to exclude the phrase \"%@\"?";

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -28,7 +28,7 @@ import NotifierUI
 
 extension McBopomofoInputMethodController: CandidateControllerDelegate {
     func candidateCountForController(_ controller: CandidateController) -> UInt {
-        return if let state = state as? CandidateProvider {
+        if let state = state as? CandidateProvider {
             UInt(state.candidateCount)
         } else {
             0
@@ -36,7 +36,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
     }
 
     func candidateController(_ controller: CandidateController, candidateAtIndex index: UInt) -> String {
-        return if let state = state as? CandidateProvider {
+        if let state = state as? CandidateProvider {
             state.candidate(at: Int(index))
         } else {
             ""

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -21,9 +21,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+import CandidateUI
 import Cocoa
 import InputMethodKit
-import CandidateUI
 import NotifierUI
 
 extension McBopomofoInputMethodController: CandidateControllerDelegate {
@@ -35,7 +35,9 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
         }
     }
 
-    func candidateController(_ controller: CandidateController, candidateAtIndex index: UInt) -> String {
+    func candidateController(_ controller: CandidateController, candidateAtIndex index: UInt)
+        -> String
+    {
         return if let state = state as? CandidateProvider {
             state.candidate(at: Int(index))
         } else {
@@ -43,13 +45,18 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
         }
     }
 
-    func candidateController(_ controller: CandidateController, didSelectCandidateAtIndex index: UInt) {
+    func candidateController(
+        _ controller: CandidateController, didSelectCandidateAtIndex index: UInt
+    ) {
         let client = currentClient
 
         switch state {
         case let state as InputState.ChoosingCandidate:
             let selectedCandidate = state.candidates[Int(index)]
-            keyHandler.fixNode(reading: selectedCandidate.reading, value: selectedCandidate.value, originalCursorIndex: Int(state.originalCursorIndex), useMoveCursorAfterSelectionSetting: true)
+            keyHandler.fixNode(
+                reading: selectedCandidate.reading, value: selectedCandidate.value,
+                originalCursorIndex: Int(state.originalCursorIndex),
+                useMoveCursorAfterSelectionSetting: true)
 
             guard let inputting = keyHandler.buildInputtingState() as? InputState.Inputting else {
                 return
@@ -61,7 +68,11 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                 let composingBuffer = inputting.composingBuffer
                 handle(state: .Committing(poppedText: composingBuffer), client: client)
                 if Preferences.associatedPhrasesEnabled,
-                   let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(withReading: selectedCandidate.reading, value: selectedCandidate.value, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
+                    let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(
+                        withReading: selectedCandidate.reading, value: selectedCandidate.value,
+                        useVerticalMode: state.useVerticalMode)
+                        as? InputState.AssociatedPhrasesPlain
+                {
                     self.handle(state: associatePhrases, client: client)
                 } else {
                     handle(state: .Empty(), client: client)
@@ -70,24 +81,32 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                 handle(state: inputting, client: client)
                 if Preferences.associatedPhrasesEnabled {
                     var textFrame = NSRect.zero
-                    let attributes: [AnyHashable: Any]? = (client as? IMKTextInput)?.attributes(forCharacterIndex: 0, lineHeightRectangle: &textFrame)
-                    let useVerticalMode = (attributes?["IMKTextOrientation"] as? NSNumber)?.intValue == 0 || false
+                    let attributes: [AnyHashable: Any]? = (client as? IMKTextInput)?.attributes(
+                        forCharacterIndex: 0, lineHeightRectangle: &textFrame)
+                    let useVerticalMode =
+                        (attributes?["IMKTextOrientation"] as? NSNumber)?.intValue == 0 || false
 
                     let state = keyHandler.buildInputtingState()
-                    keyHandler.handleAssociatedPhrase(with: state, useVerticalMode: useVerticalMode, stateCallback: { newState in
-                        self.handle(state: newState, client: client)
-                    }, errorCallback: {
-                        if (Preferences.beepUponInputError) {
-                            NSSound.beep()
-                        }
-                    }, useShiftKey: true)
+                    keyHandler.handleAssociatedPhrase(
+                        with: state, useVerticalMode: useVerticalMode,
+                        stateCallback: { newState in
+                            self.handle(state: newState, client: client)
+                        },
+                        errorCallback: {
+                            if Preferences.beepUponInputError {
+                                NSSound.beep()
+                            }
+                        }, useShiftKey: true)
                 }
             default:
                 break
             }
         case let state as InputState.AssociatedPhrases:
             let candidate = state.candidates[Int(index)]
-            keyHandler.fixNodeForAssociatedPhraseWithPrefix(at: state.prefixCursorIndex, prefixReading: state.prefixReading, prefixValue: state.prefixValue, associatedPhraseReading: candidate.reading, associatedPhraseValue: candidate.value)
+            keyHandler.fixNodeForAssociatedPhraseWithPrefix(
+                at: state.prefixCursorIndex, prefixReading: state.prefixReading,
+                prefixValue: state.prefixValue, associatedPhraseReading: candidate.reading,
+                associatedPhraseValue: candidate.value)
             guard let inputting = keyHandler.buildInputtingState() as? InputState.Inputting else {
                 return
             }
@@ -97,7 +116,10 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             let selectedCandidate = state.candidates[Int(index)]
             handle(state: .Committing(poppedText: selectedCandidate.value), client: currentClient)
             if Preferences.associatedPhrasesEnabled,
-               let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(withReading: selectedCandidate.reading, value: selectedCandidate.value, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
+                let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(
+                    withReading: selectedCandidate.reading, value: selectedCandidate.value,
+                    useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain
+            {
                 self.handle(state: associatePhrases, client: client)
             } else {
                 handle(state: .Empty(), client: client)
@@ -128,7 +150,9 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             let text = state.menuTitleValueMapping[Int(index)].1
             NSPasteboard.general.declareTypes([.string], owner: nil)
             NSPasteboard.general.setString(text, forType: .string)
-            NotifierController.notify(message:String(format:NSLocalizedString("%@ has been copied.", comment: ""), text))
+            NotifierController.notify(
+                message: String(format: NSLocalizedString("%@ has been copied.", comment: ""), text)
+            )
 
             let previous = state.previousState.previousState
             let candidateIndex = state.previousState.selectedIndex

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -160,6 +160,9 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
             if candidateIndex > 0 {
                 gCurrentCandidateController?.selectedCandidateIndex = UInt(candidateIndex)
             }
+        case let state as InputState.CustomMenu:
+            let entry = state.entries[Int(index)]
+            entry.callback()
         default:
             break
         }

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -1,0 +1,143 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+import Cocoa
+import InputMethodKit
+import CandidateUI
+import NotifierUI
+
+extension McBopomofoInputMethodController: CandidateControllerDelegate {
+    func candidateCountForController(_ controller: CandidateController) -> UInt {
+        return if let state = state as? CandidateProvider {
+            UInt(state.candidateCount)
+        } else {
+            0
+        }
+    }
+
+    func candidateController(_ controller: CandidateController, candidateAtIndex index: UInt) -> String {
+        return if let state = state as? CandidateProvider {
+            state.candidate(at: Int(index))
+        } else {
+            ""
+        }
+    }
+
+    func candidateController(_ controller: CandidateController, didSelectCandidateAtIndex index: UInt) {
+        let client = currentClient
+
+        switch state {
+        case let state as InputState.ChoosingCandidate:
+            let selectedCandidate = state.candidates[Int(index)]
+            keyHandler.fixNode(reading: selectedCandidate.reading, value: selectedCandidate.value, originalCursorIndex: Int(state.originalCursorIndex), useMoveCursorAfterSelectionSetting: true)
+
+            guard let inputting = keyHandler.buildInputtingState() as? InputState.Inputting else {
+                return
+            }
+
+            switch keyHandler.inputMode {
+            case .plainBopomofo:
+                keyHandler.clear()
+                let composingBuffer = inputting.composingBuffer
+                handle(state: .Committing(poppedText: composingBuffer), client: client)
+                if Preferences.associatedPhrasesEnabled,
+                   let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(withReading: selectedCandidate.reading, value: selectedCandidate.value, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
+                    self.handle(state: associatePhrases, client: client)
+                } else {
+                    handle(state: .Empty(), client: client)
+                }
+            case .bopomofo:
+                handle(state: inputting, client: client)
+                if Preferences.associatedPhrasesEnabled {
+                    var textFrame = NSRect.zero
+                    let attributes: [AnyHashable: Any]? = (client as? IMKTextInput)?.attributes(forCharacterIndex: 0, lineHeightRectangle: &textFrame)
+                    let useVerticalMode = (attributes?["IMKTextOrientation"] as? NSNumber)?.intValue == 0 || false
+
+                    let state = keyHandler.buildInputtingState()
+                    keyHandler.handleAssociatedPhrase(with: state, useVerticalMode: useVerticalMode, stateCallback: { newState in
+                        self.handle(state: newState, client: client)
+                    }, errorCallback: {
+                        if (Preferences.beepUponInputError) {
+                            NSSound.beep()
+                        }
+                    }, useShiftKey: true)
+                }
+            default:
+                break
+            }
+        case let state as InputState.AssociatedPhrases:
+            let candidate = state.candidates[Int(index)]
+            keyHandler.fixNodeForAssociatedPhraseWithPrefix(at: state.prefixCursorIndex, prefixReading: state.prefixReading, prefixValue: state.prefixValue, associatedPhraseReading: candidate.reading, associatedPhraseValue: candidate.value)
+            guard let inputting = keyHandler.buildInputtingState() as? InputState.Inputting else {
+                return
+            }
+            handle(state: inputting, client: client)
+            break
+        case let state as InputState.AssociatedPhrasesPlain:
+            let selectedCandidate = state.candidates[Int(index)]
+            handle(state: .Committing(poppedText: selectedCandidate.value), client: currentClient)
+            if Preferences.associatedPhrasesEnabled,
+               let associatePhrases = keyHandler.buildAssociatedPhrasePlainState(withReading: selectedCandidate.reading, value: selectedCandidate.value, useVerticalMode: state.useVerticalMode) as? InputState.AssociatedPhrasesPlain {
+                self.handle(state: associatePhrases, client: client)
+            } else {
+                handle(state: .Empty(), client: client)
+            }
+        case let state as InputState.SelectingFeature:
+            if let nextState = state.nextState(by: Int(index)) {
+                handle(state: nextState, client: client)
+            }
+        case let state as InputState.SelectingDateMacro:
+            let candidate = state.candidate(at: Int(index))
+            if !candidate.isEmpty {
+                let committing = InputState.Committing(poppedText: candidate)
+                handle(state: committing, client: client)
+            }
+        case let state as InputState.SelectingDictionary:
+            let handled = state.lookUp(usingServiceAtIndex: Int(index), state: state) { state in
+                handle(state: state, client: client)
+            }
+            if handled {
+                let previous = state.previousState
+                let candidateIndex = state.selectedIndex
+                handle(state: previous, client: client)
+                if candidateIndex > 0 {
+                    gCurrentCandidateController?.selectedCandidateIndex = UInt(candidateIndex)
+                }
+            }
+        case let state as InputState.ShowingCharInfo:
+            let text = state.menuTitleValueMapping[Int(index)].1
+            NSPasteboard.general.declareTypes([.string], owner: nil)
+            NSPasteboard.general.setString(text, forType: .string)
+            NotifierController.notify(message:String(format:NSLocalizedString("%@ has been copied.", comment: ""), text))
+
+            let previous = state.previousState.previousState
+            let candidateIndex = state.previousState.selectedIndex
+            handle(state: previous, client: client)
+            if candidateIndex > 0 {
+                gCurrentCandidateController?.selectedCandidateIndex = UInt(candidateIndex)
+            }
+        default:
+            break
+        }
+    }
+}

--- a/Source/InputMethodController+KeyHandlerDelegate.swift
+++ b/Source/InputMethodController+KeyHandlerDelegate.swift
@@ -21,16 +21,19 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+import CandidateUI
 import Cocoa
 import InputMethodKit
-import CandidateUI
 
 extension McBopomofoInputMethodController: KeyHandlerDelegate {
     func candidateController(for keyHandler: KeyHandler) -> Any {
         gCurrentCandidateController ?? .vertical
     }
 
-    func keyHandler(_ keyHandler: KeyHandler, didSelectCandidateAt index: Int, candidateController controller: Any) {
+    func keyHandler(
+        _ keyHandler: KeyHandler, didSelectCandidateAt index: Int,
+        candidateController controller: Any
+    ) {
         if index < 0 {
             return
         }
@@ -60,16 +63,16 @@ extension McBopomofoInputMethodController: KeyHandlerDelegate {
             }
 
             #if DEBUG
-            let pipe = Pipe()
-            process.standardError = pipe
+                let pipe = Pipe()
+                process.standardError = pipe
             #endif
             process.launch()
             process.waitUntilExit()
             #if DEBUG
-            let read = pipe.fileHandleForReading
-            let data = read.readDataToEndOfFile()
-            let s = String(data: data, encoding: .utf8)
-            NSLog("result \(String(describing: s))")
+                let read = pipe.fileHandleForReading
+                let data = read.readDataToEndOfFile()
+                let s = String(data: data, encoding: .utf8)
+                NSLog("result \(String(describing: s))")
             #endif
         }
 
@@ -80,7 +83,9 @@ extension McBopomofoInputMethodController: KeyHandlerDelegate {
         }
     }
 
-    func keyHandler(_ keyHandler: KeyHandler, didRequestWriteUserPhraseWith state: InputState) -> Bool {
+    func keyHandler(_ keyHandler: KeyHandler, didRequestWriteUserPhraseWith state: InputState)
+        -> Bool
+    {
         guard let state = state as? InputState.Marking else {
             return false
         }
@@ -92,7 +97,9 @@ extension McBopomofoInputMethodController: KeyHandlerDelegate {
         return true
     }
 
-    func keyHandler(_ keyHandler: KeyHandler, didRequestBoostScoreForPhrase phrase: String, reading: String) -> Bool {
+    func keyHandler(
+        _ keyHandler: KeyHandler, didRequestBoostScoreForPhrase phrase: String, reading: String
+    ) -> Bool {
         let phraseToWrite = "\(phrase) \(reading)"
         let result = LanguageModelManager.writeUserPhrase(phraseToWrite)
         if result {
@@ -101,7 +108,9 @@ extension McBopomofoInputMethodController: KeyHandlerDelegate {
         return result
     }
 
-    func keyHandler(_ keyHandler: KeyHandler, didRequestExcludePhrase phrase: String, reading: String) -> Bool {
+    func keyHandler(
+        _ keyHandler: KeyHandler, didRequestExcludePhrase phrase: String, reading: String
+    ) -> Bool {
         let phraseToWrite = "\(phrase) \(reading)"
         let result = LanguageModelManager.removeUserPhrase(phraseToWrite)
         if result {

--- a/Source/InputMethodController+KeyHandlerDelegate.swift
+++ b/Source/InputMethodController+KeyHandlerDelegate.swift
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+import Cocoa
+import InputMethodKit
+import CandidateUI
+
+extension McBopomofoInputMethodController: KeyHandlerDelegate {
+    func candidateController(for keyHandler: KeyHandler) -> Any {
+        gCurrentCandidateController ?? .vertical
+    }
+
+    func keyHandler(_ keyHandler: KeyHandler, didSelectCandidateAt index: Int, candidateController controller: Any) {
+        if index < 0 {
+            return
+        }
+        if let controller = controller as? CandidateController {
+            self.candidateController(controller, didSelectCandidateAtIndex: UInt(index))
+        }
+    }
+
+    private func runUserPhraseHookIfEnabled(text: String) {
+        if !Preferences.addPhraseHookEnabled {
+            return
+        }
+
+        func run(_ script: String, arguments: [String]) {
+            let process = Process()
+            process.launchPath = script
+            process.arguments = arguments
+            // Some user may sign the git commits with gpg, and gpg is often
+            // installed by homebrew, so we add the path of homebrew here.
+            process.environment = ["PATH": "/opt/homebrew/bin:/usr/bin:/usr/local/bin:/bin"]
+
+            let path = LanguageModelManager.dataFolderPath
+            if #available(macOS 10.13, *) {
+                process.currentDirectoryURL = URL(fileURLWithPath: path)
+            } else {
+                FileManager.default.changeCurrentDirectoryPath(path)
+            }
+
+            #if DEBUG
+            let pipe = Pipe()
+            process.standardError = pipe
+            #endif
+            process.launch()
+            process.waitUntilExit()
+            #if DEBUG
+            let read = pipe.fileHandleForReading
+            let data = read.readDataToEndOfFile()
+            let s = String(data: data, encoding: .utf8)
+            NSLog("result \(String(describing: s))")
+            #endif
+        }
+
+        let script = Preferences.addPhraseHookPath
+
+        DispatchQueue.global().async {
+            run("/bin/sh", arguments: [script, text])
+        }
+    }
+
+    func keyHandler(_ keyHandler: KeyHandler, didRequestWriteUserPhraseWith state: InputState) -> Bool {
+        guard let state = state as? InputState.Marking else {
+            return false
+        }
+        if !state.validToWrite {
+            return false
+        }
+        LanguageModelManager.writeUserPhrase(state.userPhrase)
+        runUserPhraseHookIfEnabled(text: state.selectedText)
+        return true
+    }
+
+    func keyHandler(_ keyHandler: KeyHandler, didRequestBoostScoreForPhrase phrase: String, reading: String) -> Bool {
+        let phraseToWrite = "\(phrase) \(reading)"
+        let result = LanguageModelManager.writeUserPhrase(phraseToWrite)
+        if result {
+            runUserPhraseHookIfEnabled(text: phrase)
+        }
+        return result
+    }
+
+    func keyHandler(_ keyHandler: KeyHandler, didRequestExcludePhrase phrase: String, reading: String) -> Bool {
+        let phraseToWrite = "\(phrase) \(reading)"
+        let result = LanguageModelManager.removeUserPhrase(phraseToWrite)
+        if result {
+            runUserPhraseHookIfEnabled(text: phrase)
+        }
+        return result
+    }
+
+    func keyHandlerDidRequestReloadLanguageModel(_ keyHandler: KeyHandler) -> Bool {
+        LanguageModelManager.loadUserPhrases(enableForPlainBopomofo: false)
+        return true
+    }
+
+}

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -21,15 +21,15 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+import CandidateUI
 import Cocoa
 import InputMethodKit
-import CandidateUI
 import NotifierUI
-import TooltipUI
 import OpenCCBridge
+import TooltipUI
 
-private extension Bool {
-    var state: NSControl.StateValue {
+extension Bool {
+    fileprivate var state: NSControl.StateValue {
         self ? .on : .off
     }
 }
@@ -38,7 +38,7 @@ private let kMinKeyLabelSize: CGFloat = 10
 
 internal var gCurrentCandidateController: CandidateController?
 
-internal extension CandidateController {
+extension CandidateController {
     static let horizontal = HorizontalCandidateController()
     static let vertical = VerticalCandidateController()
 }
@@ -64,45 +64,73 @@ class McBopomofoInputMethodController: IMKInputController {
     override func menu() -> NSMenu! {
         let menu = NSMenu(title: "Input Method Menu")
 
-        let chineseConversionItem = menu.addItem(withTitle: NSLocalizedString("Chinese Conversion", comment: ""), action: #selector(toggleChineseConverter(_:)), keyEquivalent: "g")
+        let chineseConversionItem = menu.addItem(
+            withTitle: NSLocalizedString("Chinese Conversion", comment: ""),
+            action: #selector(toggleChineseConverter(_:)), keyEquivalent: "g")
         chineseConversionItem.keyEquivalentModifierMask = [.command, .control]
         chineseConversionItem.state = Preferences.chineseConversionEnabled.state
 
-        let halfWidthPunctuationItem = menu.addItem(withTitle: NSLocalizedString("Use Half-Width Punctuations", comment: ""), action: #selector(toggleHalfWidthPunctuation(_:)), keyEquivalent: "h")
+        let halfWidthPunctuationItem = menu.addItem(
+            withTitle: NSLocalizedString("Use Half-Width Punctuations", comment: ""),
+            action: #selector(toggleHalfWidthPunctuation(_:)), keyEquivalent: "h")
         halfWidthPunctuationItem.keyEquivalentModifierMask = [.command, .control]
         halfWidthPunctuationItem.state = Preferences.halfWidthPunctuationEnabled.state
-        let associatedPhrasesItem = menu.addItem(withTitle: NSLocalizedString("Associated Phrases", comment: ""), action: #selector(toggleAssociatedPhrasesEnabled(_:)), keyEquivalent: "")
+        let associatedPhrasesItem = menu.addItem(
+            withTitle: NSLocalizedString("Associated Phrases", comment: ""),
+            action: #selector(toggleAssociatedPhrasesEnabled(_:)), keyEquivalent: "")
         associatedPhrasesItem.state = Preferences.associatedPhrasesEnabled.state
 
         let inputMode = keyHandler.inputMode
         let optionKeyPressed = NSEvent.modifierFlags.contains(.option)
         if inputMode == .bopomofo && optionKeyPressed {
-            let phaseReplacementItem = menu.addItem(withTitle: NSLocalizedString("Use Phrase Replacement", comment: ""), action: #selector(togglePhraseReplacement(_:)), keyEquivalent: "")
+            let phaseReplacementItem = menu.addItem(
+                withTitle: NSLocalizedString("Use Phrase Replacement", comment: ""),
+                action: #selector(togglePhraseReplacement(_:)), keyEquivalent: "")
             phaseReplacementItem.state = Preferences.phraseReplacementEnabled.state
         }
 
         menu.addItem(NSMenuItem.separator())
-        menu.addItem(withTitle: NSLocalizedString("User Phrases", comment: ""), action: nil, keyEquivalent: "")
+        menu.addItem(
+            withTitle: NSLocalizedString("User Phrases", comment: ""), action: nil,
+            keyEquivalent: "")
 
         if inputMode == .plainBopomofo {
-            if (Preferences.enableUserPhrasesInPlainBopomofo) {
-                menu.addItem(withTitle: NSLocalizedString("Edit User Phrases", comment: ""), action: #selector(openUserPhrasesPlainBopomofo(_:)), keyEquivalent: "")
+            if Preferences.enableUserPhrasesInPlainBopomofo {
+                menu.addItem(
+                    withTitle: NSLocalizedString("Edit User Phrases", comment: ""),
+                    action: #selector(openUserPhrasesPlainBopomofo(_:)), keyEquivalent: "")
             }
-            menu.addItem(withTitle: NSLocalizedString("Edit Excluded Phrases", comment: ""), action: #selector(openExcludedPhrasesPlainBopomofo(_:)), keyEquivalent: "")
+            menu.addItem(
+                withTitle: NSLocalizedString("Edit Excluded Phrases", comment: ""),
+                action: #selector(openExcludedPhrasesPlainBopomofo(_:)), keyEquivalent: "")
         } else {
-            menu.addItem(withTitle: NSLocalizedString("Edit User Phrases", comment: ""), action: #selector(openUserPhrases(_:)), keyEquivalent: "")
-            menu.addItem(withTitle: NSLocalizedString("Edit Excluded Phrases", comment: ""), action: #selector(openExcludedPhrasesMcBopomofo(_:)), keyEquivalent: "")
+            menu.addItem(
+                withTitle: NSLocalizedString("Edit User Phrases", comment: ""),
+                action: #selector(openUserPhrases(_:)), keyEquivalent: "")
+            menu.addItem(
+                withTitle: NSLocalizedString("Edit Excluded Phrases", comment: ""),
+                action: #selector(openExcludedPhrasesMcBopomofo(_:)), keyEquivalent: "")
             if optionKeyPressed {
-                menu.addItem(withTitle: NSLocalizedString("Edit Phrase Replacement Table", comment: ""), action: #selector(openPhraseReplacementMcBopomofo(_:)), keyEquivalent: "")
+                menu.addItem(
+                    withTitle: NSLocalizedString("Edit Phrase Replacement Table", comment: ""),
+                    action: #selector(openPhraseReplacementMcBopomofo(_:)), keyEquivalent: "")
             }
         }
 
-        menu.addItem(withTitle: NSLocalizedString("Reload User Phrases", comment: ""), action: #selector(reloadUserPhrases(_:)), keyEquivalent: "")
+        menu.addItem(
+            withTitle: NSLocalizedString("Reload User Phrases", comment: ""),
+            action: #selector(reloadUserPhrases(_:)), keyEquivalent: "")
         menu.addItem(NSMenuItem.separator())
 
-        menu.addItem(withTitle: NSLocalizedString("McBopomofo Preferences", comment: ""), action: #selector(showPreferences(_:)), keyEquivalent: "")
-        menu.addItem(withTitle: NSLocalizedString("Check for Updates…", comment: ""), action: #selector(checkForUpdate(_:)), keyEquivalent: "")
-        menu.addItem(withTitle: NSLocalizedString("About McBopomofo…", comment: ""), action: #selector(showAbout(_:)), keyEquivalent: "")
+        menu.addItem(
+            withTitle: NSLocalizedString("McBopomofo Preferences", comment: ""),
+            action: #selector(showPreferences(_:)), keyEquivalent: "")
+        menu.addItem(
+            withTitle: NSLocalizedString("Check for Updates…", comment: ""),
+            action: #selector(checkForUpdate(_:)), keyEquivalent: "")
+        menu.addItem(
+            withTitle: NSLocalizedString("About McBopomofo…", comment: ""),
+            action: #selector(showAbout(_:)), keyEquivalent: "")
         return menu
     }
 
@@ -112,7 +140,8 @@ class McBopomofoInputMethodController: IMKInputController {
         UserDefaults.standard.synchronize()
 
         // Override the keyboard layout. Use US if not set.
-        (client as? IMKTextInput)?.overrideKeyboard(withKeyboardNamed: Preferences.basisKeyboardLayout)
+        (client as? IMKTextInput)?.overrideKeyboard(
+            withKeyboardNamed: Preferences.basisKeyboardLayout)
         // reset the state
         currentClient = client
 
@@ -134,7 +163,8 @@ class McBopomofoInputMethodController: IMKInputController {
         if keyHandler.inputMode != newInputMode {
             UserDefaults.standard.synchronize()
             // Remember to override the keyboard layout again -- treat this as an activate event.
-            (client as? IMKTextInput)?.overrideKeyboard(withKeyboardNamed: Preferences.basisKeyboardLayout)
+            (client as? IMKTextInput)?.overrideKeyboard(
+                withKeyboardNamed: Preferences.basisKeyboardLayout)
             keyHandler.clear()
             keyHandler.inputMode = newInputMode
             self.handle(state: .Empty(), client: client)
@@ -184,9 +214,11 @@ class McBopomofoInputMethodController: IMKInputController {
 
             let includeShift = Preferences.functionKeyKeyboardLayoutOverrideIncludeShiftKey
             let notShift = NSEvent.ModifierFlags(rawValue: ~(NSEvent.ModifierFlags.shift.rawValue))
-            if event.modifierFlags.contains(notShift) ||
-                       (event.modifierFlags.contains(.shift) && includeShift) {
-                (client as? IMKTextInput)?.overrideKeyboard(withKeyboardNamed: functionKeyKeyboardLayoutID)
+            if event.modifierFlags.contains(notShift)
+                || (event.modifierFlags.contains(.shift) && includeShift)
+            {
+                (client as? IMKTextInput)?.overrideKeyboard(
+                    withKeyboardNamed: functionKeyKeyboardLayoutID)
                 return false
             }
             (client as? IMKTextInput)?.overrideKeyboard(withKeyboardNamed: basisKeyboardLayoutID)
@@ -194,14 +226,16 @@ class McBopomofoInputMethodController: IMKInputController {
         }
 
         var textFrame = NSRect.zero
-        let attributes: [AnyHashable: Any]? = (client as? IMKTextInput)?.attributes(forCharacterIndex: 0, lineHeightRectangle: &textFrame)
-        let useVerticalMode = (attributes?["IMKTextOrientation"] as? NSNumber)?.intValue == 0 || false
+        let attributes: [AnyHashable: Any]? = (client as? IMKTextInput)?.attributes(
+            forCharacterIndex: 0, lineHeightRectangle: &textFrame)
+        let useVerticalMode =
+            (attributes?["IMKTextOrientation"] as? NSNumber)?.intValue == 0 || false
         let input = KeyHandlerInput(event: event, isVerticalMode: useVerticalMode)
 
         let result = keyHandler.handle(input: input, state: state) { newState in
             self.handle(state: newState, client: client)
         } errorCallback: {
-            if (Preferences.beepUponInputError) {
+            if Preferences.beepUponInputError {
                 NSSound.beep()
             }
         }
@@ -216,7 +250,10 @@ class McBopomofoInputMethodController: IMKInputController {
 
     @objc func toggleChineseConverter(_ sender: Any?) {
         let enabled = Preferences.toggleChineseConversionEnabled()
-        NotifierController.notify(message: enabled ? NSLocalizedString("Chinese conversion on", comment: "") : NSLocalizedString("Chinese conversion off", comment: ""))
+        NotifierController.notify(
+            message: enabled
+                ? NSLocalizedString("Chinese conversion on", comment: "")
+                : NSLocalizedString("Chinese conversion off", comment: ""))
         if let currentClient = currentClient {
             keyHandler.clear()
             self.handle(state: InputState.Empty(), client: currentClient)
@@ -225,7 +262,10 @@ class McBopomofoInputMethodController: IMKInputController {
 
     @objc func toggleHalfWidthPunctuation(_ sender: Any?) {
         let enabled = Preferences.toggleHalfWidthPunctuationEnabled()
-        NotifierController.notify(message: enabled ? NSLocalizedString("Half-Width Punctuation On", comment: "") : NSLocalizedString("Half-Width Punctuation Off", comment: ""))
+        NotifierController.notify(
+            message: enabled
+                ? NSLocalizedString("Half-Width Punctuation On", comment: "")
+                : NSLocalizedString("Half-Width Punctuation Off", comment: ""))
         if let currentClient = currentClient {
             keyHandler.clear()
             self.handle(state: InputState.Empty(), client: currentClient)
@@ -266,7 +306,8 @@ class McBopomofoInputMethodController: IMKInputController {
     }
 
     @objc func reloadUserPhrases(_ sender: Any?) {
-        LanguageModelManager.loadUserPhrases(enableForPlainBopomofo: Preferences.enableUserPhrasesInPlainBopomofo)
+        LanguageModelManager.loadUserPhrases(
+            enableForPlainBopomofo: Preferences.enableUserPhrasesInPlainBopomofo)
         LanguageModelManager.loadUserPhraseReplacement()
     }
 
@@ -342,7 +383,8 @@ extension McBopomofoInputMethodController {
         if buffer.isEmpty {
             return
         }
-        (client as? IMKTextInput)?.insertText(buffer, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
+        (client as? IMKTextInput)?.insertText(
+            buffer, replacementRange: NSRange(location: NSNotFound, length: NSNotFound))
     }
 
     private func handle(state: InputState.Deactivated, previous: InputState, client: Any?) {
@@ -360,11 +402,13 @@ extension McBopomofoInputMethodController {
             commit(text: previous.composingBuffer, client: client)
         }
 
-        if let _ = previous as? InputState.Big5 {
-            client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(0, 0))
+        if previous as? InputState.Big5 != nil {
+            client.setMarkedText(
+                "", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(0, 0))
         }
-        if let _ = previous as? InputState.ChineseNumber {
-            client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(0, 0))
+        if previous as? InputState.ChineseNumber != nil {
+            client.setMarkedText(
+                "", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(0, 0))
         }
 
         // Unlike the Empty state handler, we don't call client.setMarkedText() here:
@@ -384,10 +428,14 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
-    private func handle(state: InputState.EmptyIgnoringPreviousState, previous: InputState, client: Any!) {
+    private func handle(
+        state: InputState.EmptyIgnoringPreviousState, previous: InputState, client: Any!
+    ) {
         gCurrentCandidateController?.visible = false
         hideTooltip()
 
@@ -395,7 +443,9 @@ extension McBopomofoInputMethodController {
             return
         }
 
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
     private func handle(state: InputState.Committing, previous: InputState, client: Any?) {
@@ -410,7 +460,9 @@ extension McBopomofoInputMethodController {
         if !poppedText.isEmpty {
             commit(text: poppedText, client: client)
         }
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
     private func handle(state: InputState.Inputting, previous: InputState, client: Any?) {
@@ -423,9 +475,13 @@ extension McBopomofoInputMethodController {
 
         // the selection range is where the cursor is, with the length being 0 and replacement range NSNotFound,
         // i.e. the client app needs to take care of where to put this composing buffer
-        client.setMarkedText(state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         if !state.tooltip.isEmpty {
-            show(tooltip: state.tooltip, composingBuffer: state.composingBuffer, cursorIndex: state.cursorIndex, client: client)
+            show(
+                tooltip: state.tooltip, composingBuffer: state.composingBuffer,
+                cursorIndex: state.cursorIndex, client: client)
         }
     }
 
@@ -438,12 +494,16 @@ extension McBopomofoInputMethodController {
 
         // the selection range is where the cursor is, with the length being 0 and replacement range NSNotFound,
         // i.e. the client app needs to take care of where to put this composing buffer
-        client.setMarkedText(state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
 
         if state.tooltip.isEmpty {
             hideTooltip()
         } else {
-            show(tooltip: state.tooltip, composingBuffer: state.composingBuffer, cursorIndex: state.markerIndex, client: client)
+            show(
+                tooltip: state.tooltip, composingBuffer: state.composingBuffer,
+                cursorIndex: state.markerIndex, client: client)
         }
     }
 
@@ -456,7 +516,9 @@ extension McBopomofoInputMethodController {
 
         // the selection range is where the cursor is, with the length being 0 and replacement range NSNotFound,
         // i.e. the client app needs to take care of where to put this composing buffer
-        client.setMarkedText(state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.attributedString, selectionRange: NSMakeRange(Int(state.cursorIndex), 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         show(candidateWindowWith: state, client: client)
     }
 
@@ -472,22 +534,32 @@ extension McBopomofoInputMethodController {
         // i.e. the client app needs to take care of where to put this composing buffer
         switch previousState {
         case let previousState as InputState.ChoosingCandidate:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         case let previousState as InputState.Inputting:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         default:
             break
         }
         show(candidateWindowWith: state, client: client)
     }
 
-    private func handle(state: InputState.AssociatedPhrasesPlain, previous: InputState, client: Any?) {
+    private func handle(
+        state: InputState.AssociatedPhrasesPlain, previous: InputState, client: Any?
+    ) {
         hideTooltip()
         guard let client = client as? IMKTextInput else {
             gCurrentCandidateController?.visible = false
             return
         }
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         show(candidateWindowWith: state, client: client)
     }
 
@@ -502,7 +574,9 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         show(candidateWindowWith: state, client: client)
     }
 
@@ -517,7 +591,9 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText("", selectionRange: NSMakeRange(0, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            "", selectionRange: NSMakeRange(0, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         show(candidateWindowWith: state, client: client)
     }
 
@@ -532,7 +608,9 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText(state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
     private func handle(state: InputState.EnclosedNumber, previous: InputState, client: Any?) {
@@ -546,7 +624,9 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText(state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
     private func handle(state: InputState.Big5, previous: InputState, client: Any?) {
@@ -560,7 +640,9 @@ extension McBopomofoInputMethodController {
         if let previous = previous as? InputState.NotEmpty {
             commit(text: previous.composingBuffer, client: client)
         }
-        client.setMarkedText(state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+        client.setMarkedText(
+            state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 
     private func handle(state: InputState.SelectingDictionary, previous: InputState, client: Any?) {
@@ -575,9 +657,15 @@ extension McBopomofoInputMethodController {
 
         switch previousState {
         case let previousState as InputState.ChoosingCandidate:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         case let previousState as InputState.Marking:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         default:
             break
         }
@@ -596,9 +684,15 @@ extension McBopomofoInputMethodController {
         // i.e. the client app needs to take care of where to put this composing buffer
         switch previousState {
         case let previousState as InputState.ChoosingCandidate:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         case let previousState as InputState.Marking:
-            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+            client.setMarkedText(
+                previousState.attributedString,
+                selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0),
+                replacementRange: NSMakeRange(NSNotFound, NSNotFound))
         default:
             break
         }
@@ -611,19 +705,6 @@ extension McBopomofoInputMethodController {
             gCurrentCandidateController?.visible = false
             return
         }
-//        let previousState = state.previousState
-        // the selection range is where the cursor is, with the length being 0 and replacement range NSNotFound,
-        // i.e. the client app needs to take care of where to put this composing buffer
-
-//        switch previousState {
-//        case let previousState as InputState.ChoosingCandidate:
-//            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
-//        case let previousState as InputState.Marking:
-//            client.setMarkedText(previousState.attributedString, selectionRange: NSMakeRange(Int(previousState.cursorIndex), 0), replacementRange: NSMakeRange(NSNotFound, NSNotFound))
-//        default:
-//            break
-//        }
-
         show(candidateWindowWith: state, client: client)
     }
 }
@@ -683,16 +764,17 @@ extension McBopomofoInputMethodController {
             gCurrentCandidateController = .vertical
         }
 
-        gCurrentCandidateController?.tooltip = switch state {
-        case let state as InputState.SelectingDictionary:
-            String(format:NSLocalizedString("Look up %@", comment: ""), state.selectedPhrase)
-        case let state as InputState.AssociatedPhrases:
-            String(format:NSLocalizedString("%@…", comment: ""), state.prefixValue)
-        case let state as InputState.CustomMenu:
-            state.title
-        default:
-            ""
-        }
+        gCurrentCandidateController?.tooltip =
+            switch state {
+            case let state as InputState.SelectingDictionary:
+                String(format: NSLocalizedString("Look up %@", comment: ""), state.selectedPhrase)
+            case let state as InputState.AssociatedPhrases:
+                String(format: NSLocalizedString("%@…", comment: ""), state.prefixValue)
+            case let state as InputState.CustomMenu:
+                state.title
+            default:
+                ""
+            }
 
         // set the attributes for the candidate panel (which uses NSAttributedString)
         let textSize = Preferences.candidateListTextSize
@@ -705,11 +787,15 @@ extension McBopomofoInputMethodController {
             return NSFont.systemFont(ofSize: size)
         }
 
-        gCurrentCandidateController?.keyLabelFont = font(name: Preferences.candidateKeyLabelFontName, size: keyLabelSize)
-        gCurrentCandidateController?.candidateFont = font(name: Preferences.candidateTextFontName, size: textSize)
+        gCurrentCandidateController?.keyLabelFont = font(
+            name: Preferences.candidateKeyLabelFontName, size: keyLabelSize)
+        gCurrentCandidateController?.candidateFont = font(
+            name: Preferences.candidateTextFontName, size: textSize)
 
         let candidateKeys = Preferences.candidateKeys
-        let keyLabels = candidateKeys.count >= 4 ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
+        let keyLabels =
+            candidateKeys.count >= 4
+            ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
         let shouldUseShift = {
             if let state = state as? InputState.AssociatedPhrases {
                 return state.useShiftKey
@@ -741,14 +827,22 @@ extension McBopomofoInputMethodController {
         }
 
         while lineHeightRect.origin.x == 0 && lineHeightRect.origin.y == 0 && cursor >= 0 {
-            (client as? IMKTextInput)?.attributes(forCharacterIndex: cursor, lineHeightRectangle: &lineHeightRect)
+            (client as? IMKTextInput)?.attributes(
+                forCharacterIndex: cursor, lineHeightRectangle: &lineHeightRect)
             cursor -= 1
         }
 
         if useVerticalMode {
-            gCurrentCandidateController?.set(windowTopLeftPoint: NSMakePoint(lineHeightRect.origin.x + lineHeightRect.size.width + 4.0, lineHeightRect.origin.y - 4.0), bottomOutOfScreenAdjustmentHeight: lineHeightRect.size.height + 4.0)
+            gCurrentCandidateController?.set(
+                windowTopLeftPoint: NSMakePoint(
+                    lineHeightRect.origin.x + lineHeightRect.size.width + 4.0,
+                    lineHeightRect.origin.y - 4.0),
+                bottomOutOfScreenAdjustmentHeight: lineHeightRect.size.height + 4.0)
         } else {
-            gCurrentCandidateController?.set(windowTopLeftPoint: NSMakePoint(lineHeightRect.origin.x, lineHeightRect.origin.y - 4.0), bottomOutOfScreenAdjustmentHeight: lineHeightRect.size.height + 4.0)
+            gCurrentCandidateController?.set(
+                windowTopLeftPoint: NSMakePoint(
+                    lineHeightRect.origin.x, lineHeightRect.origin.y - 4.0),
+                bottomOutOfScreenAdjustmentHeight: lineHeightRect.size.height + 4.0)
         }
     }
 
@@ -759,10 +853,12 @@ extension McBopomofoInputMethodController {
             cursor -= 1
         }
         while lineHeightRect.origin.x == 0 && lineHeightRect.origin.y == 0 && cursor >= 0 {
-            (client as? IMKTextInput)?.attributes(forCharacterIndex: cursor, lineHeightRectangle: &lineHeightRect)
+            (client as? IMKTextInput)?.attributes(
+                forCharacterIndex: cursor, lineHeightRectangle: &lineHeightRect)
             cursor -= 1
         }
-        McBopomofoInputMethodController.tooltipController.show(tooltip: tooltip, at: lineHeightRect.origin)
+        McBopomofoInputMethodController.tooltipController.show(
+            tooltip: tooltip, at: lineHeightRect.origin)
     }
 
     private func hideTooltip() {

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -545,7 +545,8 @@ class InputState: NSObject {
         @objc private(set) var useShiftKey: Bool = false
 
         @objc init(
-            previousState: NotEmpty, prefixCursorIndex: Int, prefixReading: String, prefixValue: String,
+            previousState: NotEmpty, prefixCursorIndex: Int, prefixReading: String,
+            prefixValue: String,
             selectedIndex: Int, candidates: [Candidate], useVerticalMode: Bool, useShiftKey: Bool
         ) {
             self.previousState = previousState
@@ -736,6 +737,54 @@ class InputState: NSObject {
 
         func candidate(at index: Int) -> String {
             menu[index]
+        }
+
+    }
+
+    @objc(InputStateCustomMenuEntry)
+    class CustomMenuEntry: NSObject {
+        @objc var title: String
+        @objc var callback: () -> (Void)
+
+        @objc init(title: String, callback: @escaping () -> (Void)) {
+            self.title = title
+            self.callback = callback
+        }
+    }
+
+    /// Represents that the user is choosing information about selected
+    /// characters.
+    @objc(InputStateCustomMenu)
+    class CustomMenu: NotEmpty, CandidateProvider {
+        @objc private(set) var previousState: NotEmpty
+        @objc private(set) var title: String
+        @objc private(set) var entries: [CustomMenuEntry]
+        @objc private(set) var selectedIndex: Int = 0
+        
+        @objc init(
+            composingBuffer: String,
+            cursorIndex: UInt,
+            title: String,
+            entries: [CustomMenuEntry],
+            previousState: NotEmpty,
+            selectedIndex: Int
+        ) {
+            self.title = title
+            self.entries = entries
+            self.previousState = previousState
+            self.selectedIndex = selectedIndex
+            super.init(
+                composingBuffer: composingBuffer,
+                cursorIndex: cursorIndex
+            )
+        }
+
+        var candidateCount: Int {
+            entries.count
+        }
+
+        func candidate(at index: Int) -> String {
+            entries[index].title
         }
 
     }

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -38,6 +38,9 @@ extern InputMode InputModePlainBopomofo;
 - (id)candidateControllerForKeyHandler:(KeyHandler *)keyHandler;
 - (void)keyHandler:(KeyHandler *)keyHandler didSelectCandidateAtIndex:(NSInteger)index candidateController:(id)controller;
 - (BOOL)keyHandler:(KeyHandler *)keyHandler didRequestWriteUserPhraseWithState:(InputState *)state;
+- (BOOL)keyHandler:(KeyHandler *)keyHandler didRequestBoostScoreForPhrase:(NSString *)phrase reading:(NSString *)reading;
+- (BOOL)keyHandler:(KeyHandler *)keyHandler didRequestExcludePhrase:(NSString *)phrase reading:(NSString *)reading;
+- (BOOL)keyHandlerDidRequestReloadLanguageModel:(KeyHandler *)keyHandler;
 @end
 
 @interface KeyHandler : NSObject

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1363,7 +1363,23 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         } else if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
             InputStateChoosingCandidate *currentState = (InputStateChoosingCandidate *)state;
             NSInteger index = gCurrentCandidateController.selectedCandidateIndex;
-            NSString *selectedPhrase = currentState.candidates[index].displayText;
+            InputStateCandidate *candidate = currentState.candidates[index];
+            NSString *reading = candidate.reading;
+            NSArray *invalidPrefixArray = @[
+                @"_half_punctuation_",
+                @"_ctrl_punctuation_",
+                @"_letter_",
+                @"_number_",
+                @"_punctuation_",
+            ];
+            for (NSString *invalidPrefix in invalidPrefixArray) {
+                if ([reading hasPrefix:invalidPrefix]) {
+                    errorCallback();
+                    return YES;
+                }
+            }
+
+            NSString *selectedPhrase = candidate.displayText;
             InputStateSelectingDictionary *newState = [[InputStateSelectingDictionary alloc] initWithPreviousState:currentState selectedString:selectedPhrase selectedIndex:index];
             stateCallback(newState);
             return YES;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -323,38 +323,38 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     InputState *state = inState;
     UniChar charCode = input.charCode;
     McBopomofoEmacsKey emacsKey = input.emacsKey;
-    
+
     // MARK: Handle Selecting Feature
     if ([state isKindOfClass:[InputStateSelectingFeature class]] ||
         [state isKindOfClass:[InputStateSelectingDateMacro class]]) {
         return [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
-    
+
     // MARK: Handle Big5 Input
     if ([state isKindOfClass:[InputStateBig5 class]]) {
         return [self _handleBig5State:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
-    
+
     // MARK: Handle Chinese Number Input
     if ([state isKindOfClass:[InputStateChineseNumber class]]) {
         return [self _handleNumberState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
-    
+
     if ([state isKindOfClass:[InputStateEnclosedNumber class]]) {
         return [self _handleEnclosedNumberState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
-    
+
     // if the inputText is empty, it's a function key combination, we ignore it
     if (!input.inputText.length) {
         return NO;
     }
-    
+
     // if the composing buffer is empty and there's no reading, and there is some function key combination, we ignore it
     BOOL isFunctionKey = (input.isCommandHold || input.isOptionHold || input.isNumericPad) || input.isControlHotKey;
     if (![state isKindOfClass:[InputStateNotEmpty class]] && ![state isKindOfClass:[InputStateAssociatedPhrasesPlain class]] && !([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) && isFunctionKey) {
         return NO;
     }
-    
+
     // Caps Lock processing : if Caps Lock is on, temporarily disable bopomofo.
     if (charCode == 8 || charCode == 13 || input.isAbsorbedArrowKey || input.isExtraChooseCandidateKey || input.isCursorForward || input.isCursorBackward) {
         // do nothing if backspace is pressed -- we ignore the key
@@ -363,24 +363,24 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         [self clear];
         InputStateEmpty *emptyState = [[InputStateEmpty alloc] init];
         stateCallback(emptyState);
-        
+
         // first commit everything in the buffer.
         if (input.isShiftHold) {
             return NO;
         }
-        
+
         // if ASCII but not printable, don't use insertText:replacementRange: as many apps don't handle non-ASCII char insertions.
         if (charCode < 0x80 && !isprint(charCode)) {
             return NO;
         }
-        
+
         // when shift is pressed, don't do further processing, since it outputs capital letter anyway.
         InputStateCommitting *committingState = [[InputStateCommitting alloc] initWithPoppedText:input.inputText.lowercaseString];
         stateCallback(committingState);
         stateCallback(emptyState);
         return YES;
     }
-    
+
     if (input.isNumericPad && !Preferences.selectCandidateWithNumericKeypad) {
         if (!input.isLeft && !input.isRight && !input.isDown && !input.isUp && charCode != 32 && isprint(charCode)) {
             [self clear];
@@ -392,7 +392,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
     }
-    
+
     // MARK: Handle Associated Phrases
     if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
         BOOL result = [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
@@ -402,7 +402,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         state = [[InputStateEmpty alloc] init];
         stateCallback(state);
     }
-    
+
     if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
         BOOL result = [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
         if (result) {
@@ -415,12 +415,12 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
     }
-    
+
     // MARK: Handle Candidates
     if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
         return [self _handleCandidateState:state input:input stateCallback:stateCallback errorCallback:errorCallback];
     }
-    
+
     // MARK: Handle Other States with Menu
     if ([state isKindOfClass:[InputStateSelectingDictionary class]] ||
         [state isKindOfClass:[InputStateShowingCharInfo class]] ||
@@ -663,8 +663,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             stateCallback(empty);
             return YES;
         }
-        if (Preferences.shiftEnterEnabled &&
-            _inputMode == InputModeBopomofo && input.isShiftHold &&
+        if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold &&
             [state isKindOfClass:[InputStateInputting class]]) {
             return [self handleAssociatedPhraseWithState:(InputStateInputting *)state useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:NO];
         }
@@ -1356,7 +1355,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         stateCallback(newState);
         return YES;
     }
-    
+
     NSArray *invalidPrefixArray = @[
         @"_half_punctuation_",
         @"_ctrl_punctuation_",
@@ -1365,8 +1364,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         @"_punctuation_",
     ];
 
-    if (_inputMode == InputModeBopomofo &&
-        ([input.inputText isEqualToString:@"+"] || [input.inputText isEqualToString:@"="])) {
+    if (_inputMode == InputModeBopomofo && ([input.inputText isEqualToString:@"="] || [input.inputText isEqualToString:@"+"])) {
         if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
             InputStateChoosingCandidate *currentState = (InputStateChoosingCandidate *)state;
             NSInteger index = gCurrentCandidateController.selectedCandidateIndex;
@@ -1382,24 +1380,34 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 errorCallback();
                 return YES;
             }
+            __weak __typeof__(self) weakSelf = self;
             NSArray *entries = @[
-                [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost",
-                @"") callback:^{
-                    stateCallback(currentState);
+                [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"") callback:^{
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    InputStateChoosingCandidate *newState = [strongSelf _buildCandidateStateFromInputtingState:inputting useVerticalMode:currentState.useVerticalMode];
+                    stateCallback(newState);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{
                     stateCallback(currentState);
+                    gCurrentCandidateController.selectedCandidateIndex = index;
                 }],
-                ];
-            NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?",@""), candidate.value];
+            ];
+            NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             InputStateCustomMenu *confirm = [[InputStateCustomMenu alloc] initWithComposingBuffer:[currentState composingBuffer] cursorIndex:[currentState cursorIndex] title:title entries:entries previousState:currentState selectedIndex:index];
             stateCallback(confirm);
             return YES;
         }
     }
 
-    if (_inputMode == InputModeBopomofo && [input.inputText isEqualToString:@"+"]) {
+    if (_inputMode == InputModeBopomofo && ([input.inputText isEqualToString:@"-"] || [input.inputText isEqualToString:@"_"])) {
         if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
             InputStateChoosingCandidate *currentState = (InputStateChoosingCandidate *)state;
             NSInteger index = gCurrentCandidateController.selectedCandidateIndex;
@@ -1415,24 +1423,33 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 errorCallback();
                 return YES;
             }
+            __weak __typeof__(self) weakSelf = self;
             NSArray *entries = @[
-                [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Lower",
+                [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude",
                 @"") callback:^{
-                    stateCallback(currentState);
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    InputStateChoosingCandidate *newState = [strongSelf _buildCandidateStateFromInputtingState:inputting useVerticalMode:currentState.useVerticalMode];
+                    stateCallback(newState);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{
                     stateCallback(currentState);
                 }],
-                ];
-            NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to lower the score of the phrase \"%@\"?",@""), candidate.value];
+            ];
+            NSString *title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             InputStateCustomMenu *confirm = [[InputStateCustomMenu alloc] initWithComposingBuffer:[currentState composingBuffer] cursorIndex:[currentState cursorIndex] title:title entries:entries previousState:currentState selectedIndex:index];
             stateCallback(confirm);
             return YES;
         }
     }
 
-    
     if (_inputMode == InputModeBopomofo && [input.inputText isEqualToString:@"?"]) {
         if ([state isKindOfClass:[InputStateShowingCharInfo class]] ||
             [state isKindOfClass:[InputStateSelectingDictionary class]]) {
@@ -1475,15 +1492,14 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             stateCallback(newState);
             gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
             gCurrentCandidateController.selectedCandidateIndex = selectedIndex;
-        }
-        else if ([state isKindOfClass:[InputStateCustomMenu class]]) {
-           InputStateCustomMenu *current = (InputStateCustomMenu *)state;
-           NSInteger selectedIndex = current.selectedIndex;
-           InputStateNotEmpty *newState = current.previousState;
-           stateCallback(newState);
-           gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
-           gCurrentCandidateController.selectedCandidateIndex = selectedIndex;
-       } else if ([state isKindOfClass:[InputStateSelectingFeature class]]) {
+        } else if ([state isKindOfClass:[InputStateCustomMenu class]]) {
+            InputStateCustomMenu *current = (InputStateCustomMenu *)state;
+            NSInteger selectedIndex = current.selectedIndex;
+            InputStateNotEmpty *newState = current.previousState;
+            stateCallback(newState);
+            gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
+            gCurrentCandidateController.selectedCandidateIndex = selectedIndex;
+        } else if ([state isKindOfClass:[InputStateSelectingFeature class]]) {
             [self clear];
             InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
             stateCallback(empty);
@@ -1536,9 +1552,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             entry.callback();
             return YES;
         }
-        
-        if (Preferences.shiftEnterEnabled &&
-            _inputMode == InputModeBopomofo && input.isShiftHold) {
+
+        if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold) {
             if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
                 InputStateChoosingCandidate *current = (InputStateChoosingCandidate *)state;
                 NSInteger selectedCandidateIndex = gCurrentCandidateController.selectedCandidateIndex;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1391,8 +1391,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                    InputStateChoosingCandidate *newState = [strongSelf _buildCandidateStateFromInputtingState:inputting useVerticalMode:currentState.useVerticalMode];
-                    stateCallback(newState);
+                    stateCallback(inputting);
+//                    InputStateCommitting *committing = [[InputStateCommitting alloc] init];
+//                    stateCallback(committing);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{
@@ -1435,8 +1436,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                    InputStateChoosingCandidate *newState = [strongSelf _buildCandidateStateFromInputtingState:inputting useVerticalMode:currentState.useVerticalMode];
-                    stateCallback(newState);
+                    stateCallback(inputting);
+//                    InputStateCommitting *committing = [[InputStateCommitting alloc] init];
+//                    stateCallback(committing);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1392,8 +1392,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
-//                    InputStateCommitting *committing = [[InputStateCommitting alloc] init];
-//                    stateCallback(committing);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{
@@ -1437,8 +1435,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
-//                    InputStateCommitting *committing = [[InputStateCommitting alloc] init];
-//                    stateCallback(committing);
                 }],
                 [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
                 @"") callback:^{
@@ -1548,12 +1544,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 return NO;
             }
         }
-        if ([state isKindOfClass:[InputStateCustomMenu class]]) {
-            InputStateCustomMenu *customMenu = (InputStateCustomMenu *)state;
-            InputStateCustomMenuEntry *entry = customMenu.entries[gCurrentCandidateController.selectedCandidateIndex];
-            entry.callback();
-            return YES;
-        }
+
 
         if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold) {
             if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {

--- a/Source/LanguageModelManager.h
+++ b/Source/LanguageModelManager.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)checkIfUserPhraseExist:(NSString *)userPhrase key:(NSString *)key NS_SWIFT_NAME(checkIfExist(userPhrase:key:));
 + (BOOL)writeUserPhrase:(NSString *)userPhrase;
++ (BOOL)removeUserPhrase:(NSString *)userPhrase;
 
 + (nullable NSString *)readingFor:(NSString *)phrase;
 

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -317,6 +317,7 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
         NSArray *lineComponents = [trimmed componentsSeparatedByString:@" "];
         if (lineComponents.count != 2) {
             [mutableString appendString:line];
+            [mutableString appendString:@"\n"];
             continue;
         }
         if ([lineComponents[0] isEqualToString:exactPhrase] &&
@@ -325,6 +326,7 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
             continue;
         }
         [mutableString appendString:line];
+        [mutableString appendString:@"\n"];
     }
     if (result) {
         NSError *writeError;

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -331,7 +331,7 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     if (result) {
         NSError *writeError;
         [mutableString writeToURL:[NSURL fileURLWithPath:path] atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
-        if (error != nil) {
+        if (writeError != nil) {
             return NO;
         }
         return YES;

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -98,9 +98,8 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
 + (void)loadUserPhrasesWithPlainBopomofoEnabled:(BOOL)userPhraseForPlainBopomofo
 {
     gLanguageModelMcBopomofo.loadUserPhrases([self userPhrasesDataPathMcBopomofo].UTF8String, [self excludedPhrasesDataPathMcBopomofo].UTF8String);
-    gLanguageModelPlainBopomofo.loadUserPhrases(userPhraseForPlainBopomofo ?
-                                                [self userPhrasesDataPathPlainBopomofo].UTF8String : NULL,
-                                                [self excludedPhrasesDataPathPlainBopomofo].UTF8String);
+    gLanguageModelPlainBopomofo.loadUserPhrases(userPhraseForPlainBopomofo ? [self userPhrasesDataPathPlainBopomofo].UTF8String : NULL,
+        [self excludedPhrasesDataPathPlainBopomofo].UTF8String);
 }
 
 + (void)loadUserPhraseReplacement
@@ -216,15 +215,44 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     return NO;
 }
 
-+ (BOOL)writeUserPhrase:(NSString *)userPhrase
++ (BOOL)_checkIfPhrase:(NSString *)phrase existAtPath:(NSString *)path
 {
-    if (![self checkIfUserLanguageModelFilesExist]) {
+    NSString *exactPhrase = nil;
+    NSString *key = nil;
+    NSArray *components = [phrase componentsSeparatedByString:@" "];
+    if (components.count != 2) {
         return NO;
     }
+    exactPhrase = components[0];
+    key = components[1];
 
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        return NO;
+    }
+    NSError *error = nil;
+    NSString *content = [[NSString alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] encoding:NSUTF8StringEncoding error:&error];
+    if (error != nil) {
+        return NO;
+    }
+    NSArray *lines = [content componentsSeparatedByString:@"\n"];
+    for (NSString *line in lines) {
+        NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        NSArray *lineComponents = [trimmed componentsSeparatedByString:@" "];
+        if (lineComponents.count != 2) {
+            continue;
+            ;
+        }
+        if ([lineComponents[0] isEqualToString:exactPhrase] &&
+            [lineComponents[1] isEqualToString:key]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
++ (BOOL)_writePhrase:(NSString *)phrase atEndOfPath:(NSString *)path
+{
     BOOL addLineBreakAtFront = NO;
-    NSString *path = [self userPhrasesDataPathMcBopomofo];
-
     if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
         NSError *error = nil;
         NSDictionary *attr = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:&error];
@@ -242,27 +270,114 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
             }
         }
     }
-
     NSMutableString *currentMarkedPhrase = [NSMutableString string];
     if (addLineBreakAtFront) {
         [currentMarkedPhrase appendString:@"\n"];
     }
-    [currentMarkedPhrase appendString:userPhrase];
+    [currentMarkedPhrase appendString:phrase];
     [currentMarkedPhrase appendString:@"\n"];
 
     NSFileHandle *writeFile = [NSFileHandle fileHandleForUpdatingAtPath:path];
     if (!writeFile) {
         return NO;
     }
+
     [writeFile seekToEndOfFile];
     NSData *data = [currentMarkedPhrase dataUsingEncoding:NSUTF8StringEncoding];
     [writeFile writeData:data];
     [writeFile closeFile];
+    return YES;
+}
+
++ (BOOL)_removePhrase:(NSString *)phrase atPath:(NSString *)path
+{
+    NSString *exactPhrase = nil;
+    NSString *key = nil;
+    NSArray *components = [phrase componentsSeparatedByString:@" "];
+    if (components.count != 2) {
+        return NO;
+    }
+    exactPhrase = components[0];
+    key = components[1];
+
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        return NO;
+    }
+    NSError *error = nil;
+    NSString *content = [[NSString alloc] initWithContentsOfURL:[NSURL fileURLWithPath:path] encoding:NSUTF8StringEncoding error:&error];
+    if (error != nil) {
+        return NO;
+    }
+    NSArray *lines = [content componentsSeparatedByString:@"\n"];
+
+    BOOL result = NO;
+    NSMutableString *mutableString = [NSMutableString string];
+    for (NSString *line in lines) {
+        NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        NSArray *lineComponents = [trimmed componentsSeparatedByString:@" "];
+        if (lineComponents.count != 2) {
+            [mutableString appendString:line];
+            continue;
+        }
+        if ([lineComponents[0] isEqualToString:exactPhrase] &&
+            [lineComponents[1] isEqualToString:key]) {
+            result = YES;
+            continue;
+        }
+        [mutableString appendString:line];
+    }
+    if (result) {
+        NSError *writeError;
+        [mutableString writeToURL:[NSURL fileURLWithPath:path] atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
+        if (error != nil) {
+            return NO;
+        }
+        return YES;
+    }
+
+    return NO;
+}
+
++ (BOOL)writeUserPhrase:(NSString *)userPhrase
+{
+    if (![self checkIfUserLanguageModelFilesExist]) {
+        return NO;
+    }
+
+    NSString *excludePath = [self excludedPhrasesDataPathMcBopomofo];
+    [self _removePhrase:userPhrase atPath:excludePath];
+
+    NSString *includePath = [self userPhrasesDataPathMcBopomofo];
+    if ([self _checkIfPhrase:userPhrase existAtPath:includePath]) {
+        return NO;
+    }
+    BOOL result = [self _writePhrase:userPhrase atEndOfPath:includePath];
 
     //  We use FSEventStream to monitor the change of the user phrase folder,
     //  so we don't have to load data here.
     //  [self loadUserPhrases];
-    return YES;
+    return result;
+}
+
++ (BOOL)removeUserPhrase:(NSString *)userPhrase
+{
+    if (![self checkIfUserLanguageModelFilesExist]) {
+        return NO;
+    }
+
+    NSString *includePath = [self userPhrasesDataPathMcBopomofo];
+    [self _removePhrase:userPhrase atPath:includePath];
+
+    NSString *excludePath = [self excludedPhrasesDataPathMcBopomofo];
+    if ([self _checkIfPhrase:userPhrase existAtPath:excludePath]) {
+        return NO;
+    }
+    BOOL result = [self _writePhrase:userPhrase atEndOfPath:excludePath];
+
+    //  We use FSEventStream to monitor the change of the user phrase folder,
+    //  so we don't have to load data here.
+    //  [self loadUserPhrases];
+    return result;
 }
 
 + (NSString *)dataFolderPath
@@ -324,11 +439,12 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
     gLanguageModelMcBopomofo.setPhraseReplacementEnabled(phraseReplacementEnabled);
 }
 
-+ (nullable NSString *)readingFor:(NSString *)phrase {
++ (nullable NSString *)readingFor:(NSString *)phrase
+{
     if (!gLanguageModelMcBopomofo.isDataModelLoaded()) {
         [self loadDataModel:InputModeBopomofo];
     }
-    
+
     std::string reading = gLanguageModelMcBopomofo.getReading(phrase.UTF8String);
     return !reading.empty() ? @(reading.c_str()) : nil;
 }

--- a/Source/LanguageModelManager.mm
+++ b/Source/LanguageModelManager.mm
@@ -240,7 +240,6 @@ static void LTLoadAssociatedPhrases(McBopomofo::McBopomofoLM& lm)
         NSArray *lineComponents = [trimmed componentsSeparatedByString:@" "];
         if (lineComponents.count != 2) {
             continue;
-            ;
         }
         if ([lineComponents[0] isEqualToString:exactPhrase] &&
             [lineComponents[1] isEqualToString:key]) {

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -124,3 +124,14 @@
 "Character Information" = "Character Information";
 
 "Enclosed Numbers" = "Enclosed Numbers";
+
+"Boost" = "Boost";
+
+"Cancel" = "Cancel";
+
+"Exclude" = "Exclude";
+
+"Do you want to boost the score of the phrase \"%@\"?" = "Do you want to boost the score of the phrase \"%@\"?";
+
+"Do you want to exclude the phrase \"%@\"?" = "Do you want to exclude the phrase \"%@\"?";
+

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -122,3 +122,13 @@
 "Character Information" = "字元資訊";
 
 "Enclosed Numbers" = "標題數字";
+
+"Boost" = "增加權重";
+
+"Cancel" = "取消";
+
+"Exclude" = "排除";
+
+"Do you want to boost the score of the phrase \"%@\"?" = "您想要提升 \"%@\" 這個詞彙的權重嗎？";
+
+"Do you want to exclude the phrase \"%@\"?" = "您想要從詞庫中排除 \"%@\" 這個詞彙嗎？";


### PR DESCRIPTION
The PR introdces two new keys when the input method is in the "choosing candidate" state.

- The "+" key on a candidate to boost the score of a phrase in the candidate list.
- The "-" key on a candidate to exclude the phrase.

The feature may solve #648.

In the case of #648, a user want to override the score of "舊家" and let the score of it to be larger then the combination of "就" and "家". A user can use the "+" key on "舊家", then the phrase would be added to the user phrases text file and the score becomes boosted. 

A demo video is attached.

https://github.com/user-attachments/assets/c609e202-220b-4aae-8092-fb696255b018

