### PR TITLE
Prevents applying the boost and exclude keys on the macros and other converted candidates.

### DIFF
--- a/McBopomofoTests/DictionaryServiceTests.swift
+++ b/McBopomofoTests/DictionaryServiceTests.swift
@@ -44,8 +44,9 @@ final class DictionaryServiceTests {
         for index in 0..<count {
             var callbackCalled = false
             let choosing = InputState.ChoosingCandidate(
-                composingBuffer: "hi", cursorIndex: 0,
-                candidates: [InputState.Candidate(reading: "", value: "", displayText: "")],
+                composingBuffer: "hi",
+                cursorIndex: 0,
+                candidates: [InputState.Candidate(reading: "", value: "", displayText: "", originalValue: "")],
                 useVerticalMode: false)
             let selecting = InputState.SelectingDictionary(
                 previousState: choosing, selectedString: "你", selectedIndex: 0)

--- a/McBopomofoTests/DictionaryServiceTests.swift
+++ b/McBopomofoTests/DictionaryServiceTests.swift
@@ -46,11 +46,12 @@ final class DictionaryServiceTests {
             let choosing = InputState.ChoosingCandidate(
                 composingBuffer: "hi",
                 cursorIndex: 0,
-                candidates: [InputState.Candidate(reading: "", value: "", displayText: "", originalValue: "")],
-                useVerticalMode: false)
+                candidates: [InputState.Candidate(reading: "", value: "", displayText: "", rawValue: "")],
+                useVerticalMode: false
+            )
             let selecting = InputState.SelectingDictionary(
                 previousState: choosing, selectedString: "你", selectedIndex: 0)
-
+            
             if DictionaryServices.shared.shouldSkipTest(withServiceAtIndex: index) {
                 continue
             }

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -238,7 +238,6 @@ McBopomofoLM::filterAndTransformUnigrams(
   std::vector<Formosa::Gramambular2::LanguageModel::Unigram> results;
 
   for (auto&& unigram : unigrams) {
-    std::vector<std::string> annotations;
     // excludedValues filters out the unigrams with the original value.
     // insertedValues filters out the ones with the converted value
     const std::string& originalValue = unigram.value();
@@ -247,6 +246,7 @@ McBopomofoLM::filterAndTransformUnigrams(
     }
 
     std::string value = originalValue;
+    std::vector<std::string> annotations;
     if (phraseReplacementEnabled_) {
       std::string replacement = phraseReplacement_.valueForKey(value);
       if (!replacement.empty()) {

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -240,24 +240,22 @@ McBopomofoLM::filterAndTransformUnigrams(
   for (auto&& unigram : unigrams) {
     // excludedValues filters out the unigrams with the original value.
     // insertedValues filters out the ones with the converted value
-    const std::string& originalValue = unigram.value();
-    if (excludedValues.find(originalValue) != excludedValues.end()) {
+    const std::string& rawValue = unigram.value();
+    if (excludedValues.find(rawValue) != excludedValues.end()) {
       continue;
     }
 
-    std::string value = originalValue;
-    std::vector<std::string> annotations;
+    std::string value = rawValue;
+
     if (phraseReplacementEnabled_) {
       std::string replacement = phraseReplacement_.valueForKey(value);
       if (!replacement.empty()) {
-        annotations.emplace_back("replacement applied");
         value = replacement;
       }
     }
     if (macroConverter_ != nullptr) {
       std::string replacement = macroConverter_(value);
       if (value != replacement) {
-        annotations.emplace_back("macro expanded");
         value = replacement;
       }
     }
@@ -271,12 +269,11 @@ McBopomofoLM::filterAndTransformUnigrams(
     if (externalConverterEnabled_ && externalConverter_ != nullptr) {
       std::string replacement = externalConverter_(value);
       if (value != replacement) {
-        annotations.emplace_back("external converter applied");
         value = replacement;
       }
     }
     if (insertedValues.find(value) == insertedValues.end()) {
-      results.emplace_back(value, unigram.score(), originalValue, annotations);
+      results.emplace_back(value, unigram.score(), rawValue);
       insertedValues.insert(value);
     }
   }

--- a/Source/Engine/gramambular2/language_model.h
+++ b/Source/Engine/gramambular2/language_model.h
@@ -45,14 +45,25 @@ class LanguageModel {
   // usually a log probability from a language model.
   class Unigram {
    public:
-    explicit Unigram(std::string val = "", double sc = 0)
-        : value_(std::move(val)), score_(sc) {}
+    explicit Unigram(std::string val = "",
+                     double sc = 0,
+                     std::string originalValue = "",
+                     std::vector<std::string> annotations = std::vector<std::string>()
+                     )
+        : value_(std::move(val)),
+          score_(sc),
+          originalValue_(std::move(originalValue)),
+          annotations_(std::move(annotations)){}
 
     [[nodiscard]] const std::string& value() const { return value_; }
+    [[nodiscard]] const std::string& originalValue() const { return originalValue_; }
+    [[nodiscard]] const std::vector<std::string>& annotations() const { return annotations_; }
     [[nodiscard]] double score() const { return score_; }
 
    private:
     std::string value_;
+    std::string originalValue_;
+    std::vector<std::string> annotations_;
     double score_;
   };
 };

--- a/Source/Engine/gramambular2/language_model.h
+++ b/Source/Engine/gramambular2/language_model.h
@@ -45,25 +45,17 @@ class LanguageModel {
   // usually a log probability from a language model.
   class Unigram {
    public:
-    explicit Unigram(std::string val = "",
-                     double sc = 0,
-                     std::string originalValue = "",
-                     std::vector<std::string> annotations = std::vector<std::string>()
-                     )
-        : value_(std::move(val)),
-          score_(sc),
-          originalValue_(std::move(originalValue)),
-          annotations_(std::move(annotations)){}
+    explicit Unigram(std::string val = "", double sc = 0,
+                     std::string rawValue = "")
+        : value_(std::move(val)), score_(sc), rawValue_(std::move(rawValue)) {}
 
     [[nodiscard]] const std::string& value() const { return value_; }
-    [[nodiscard]] const std::string& originalValue() const { return originalValue_; }
-    [[nodiscard]] const std::vector<std::string>& annotations() const { return annotations_; }
+    [[nodiscard]] const std::string& rawValue() const { return rawValue_; }
     [[nodiscard]] double score() const { return score_; }
 
    private:
     std::string value_;
-    std::string originalValue_;
-    std::vector<std::string> annotations_;
+    std::string rawValue_;
     double score_;
   };
 };

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -306,7 +306,7 @@ std::vector<ReadingGrid::Candidate> ReadingGrid::candidatesAt(size_t loc) {
 
   for (const NodeInSpan& nodeInSpan : nodes) {
     for (const LanguageModel::Unigram& unigram : nodeInSpan.node->unigrams()) {
-      result.emplace_back(nodeInSpan.node->reading(), unigram.value());
+        result.emplace_back(nodeInSpan.node->reading(), unigram.value(), unigram.originalValue());
     }
   }
   return result;

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -306,7 +306,7 @@ std::vector<ReadingGrid::Candidate> ReadingGrid::candidatesAt(size_t loc) {
 
   for (const NodeInSpan& nodeInSpan : nodes) {
     for (const LanguageModel::Unigram& unigram : nodeInSpan.node->unigrams()) {
-        result.emplace_back(nodeInSpan.node->reading(), unigram.value(), unigram.originalValue());
+        result.emplace_back(nodeInSpan.node->reading(), unigram.value(), unigram.rawValue());
     }
   }
   return result;

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -183,10 +183,11 @@ class ReadingGrid {
   WalkResult walk();
 
   struct Candidate {
-    Candidate(std::string r, std::string v)
-        : reading(std::move(r)), value(std::move(v)) {}
+    Candidate(std::string r, std::string v, std::string ov = "")
+        : reading(std::move(r)), value(std::move(v)), originalValue(std::move(ov)) {}
     const std::string reading;
     const std::string value;
+    const std::string originalValue;
   };
 
   // Returns all candidate values at the location. If spans are not empty and

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -183,11 +183,11 @@ class ReadingGrid {
   WalkResult walk();
 
   struct Candidate {
-    Candidate(std::string r, std::string v, std::string ov = "")
-        : reading(std::move(r)), value(std::move(v)), originalValue(std::move(ov)) {}
+    Candidate(std::string r, std::string v, std::string rv = "")
+        : reading(std::move(r)), value(std::move(v)), rawValue(std::move(rv)) {}
     const std::string reading;
     const std::string value;
-    const std::string originalValue;
+    const std::string rawValue;
   };
 
   // Returns all candidate values at the location. If spans are not empty and

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -484,13 +484,13 @@ class InputState: NSObject {
         /// The value of a candidate may differ from its original value. For example,
         /// if a user turns on Chinese conversion, or a candidate is a macro, the
         /// original value would be converted to another value.
-        @objc private(set) var originalValue: String
+        @objc private(set) var rawValue: String
 
-        @objc init(reading: String, value: String, displayText: String, originalValue: String) {
+        @objc init(reading: String, value: String, displayText: String, rawValue: String) {
             self.reading = reading
             self.value = value
             self.displayText = displayText
-            self.originalValue = originalValue
+            self.rawValue = rawValue
         }
     }
 

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -479,11 +479,18 @@ class InputState: NSObject {
         @objc private(set) var reading: String
         @objc private(set) var value: String
         @objc private(set) var displayText: String
+        /// The original value of a candidate.
+        ///
+        /// The value of a candidate may differ from its original value. For example,
+        /// if a user turns on Chinese conversion, or a candidate is a macro, the
+        /// original value would be converted to another value.
+        @objc private(set) var originalValue: String
 
-        @objc init(reading: String, value: String, displayText: String) {
+        @objc init(reading: String, value: String, displayText: String, originalValue: String) {
             self.reading = reading
             self.value = value
             self.displayText = displayText
+            self.originalValue = originalValue
         }
     }
 
@@ -760,7 +767,7 @@ class InputState: NSObject {
         @objc private(set) var title: String
         @objc private(set) var entries: [CustomMenuEntry]
         @objc private(set) var selectedIndex: Int = 0
-        
+
         @objc init(
             composingBuffer: String,
             cursorIndex: UInt,

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1404,9 +1404,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     stateCallback(inputting);
                 }];
                 [entries addObject:boost];
-                title =[NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
+                title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             } else if (isMinusKey) {
-                InputStateCustomMenuEntry *exlude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude",
+                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude",
                 @"") callback:^{
                     __strong __typeof(weakSelf) strongSelf = weakSelf;
                     if (!strongSelf) {
@@ -1418,7 +1418,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
                 }];
-                [entries addObject:exlude];
+                [entries addObject:exclude];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             }
             InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1373,7 +1373,12 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             InputStateCandidate *candidate = currentState.candidates[index];
             NSString *reading = candidate.reading;
 
-            if (![candidate.value isEqualToString:candidate.originalValue]) {
+            // The vlalue of a candidate might be an expanced input macro, and
+            // we should not let the users to boost or exclude such candidates.
+            //
+            // In other words, we should forbid the candidates whose value
+            // is not equal to the raw value.
+            if (![candidate.value isEqualToString:candidate.rawValue]) {
                 return YES;
             }
 
@@ -1392,7 +1397,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             NSMutableArray *entries = [[NSMutableArray alloc] init];
             NSString *title = @"";
             if (isPlusKey) {
-                InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"") callback:^{
+                InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"")
+                                                                                           callback:^{
                     __strong __typeof(weakSelf) strongSelf = weakSelf;
                     if (!strongSelf) {
                         return;
@@ -1406,8 +1412,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 [entries addObject:boost];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             } else if (isMinusKey) {
-                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude",
-                @"") callback:^{
+                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"") callback:^{
                     __strong __typeof(weakSelf) strongSelf = weakSelf;
                     if (!strongSelf) {
                         return;
@@ -1421,8 +1426,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 [entries addObject:exclude];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             }
-            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel",
-            @"") callback:^{
+            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") callback:^{
                 stateCallback(currentState);
                 gCurrentCandidateController.selectedCandidateIndex = index;
             }];
@@ -1433,7 +1437,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
     }
-
 
     if (_inputMode == InputModeBopomofo && [input.inputText isEqualToString:@"?"]) {
         if ([state isKindOfClass:[InputStateShowingCharInfo class]] ||
@@ -1531,7 +1534,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 return NO;
             }
         }
-
 
         if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold) {
             if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
@@ -2227,10 +2229,10 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
         NSString *r = @(c.reading.c_str());
         NSString *v = @(c.value.c_str());
-        NSString *ov = @(c.originalValue.c_str());
+        NSString *rv = @(c.rawValue.c_str());
         NSString *dt = @(displayText.c_str());
 
-        InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:r value:v displayText:dt originalValue:ov];
+        InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:r value:v displayText:dt rawValue:rv];
         [candidatesArray addObject:candidate];
     }
 
@@ -2315,7 +2317,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
             NSString *candidateReading = @(combinedReading.c_str());
             NSString *candidateValue = @(valueWithoutPrefix.c_str());
-            InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:candidateValue originalValue:candidateValue];
+            InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:candidateValue rawValue:candidateValue];
             [array addObject:candidate];
         }
         InputStateAssociatedPhrasesPlain *associatedPhrases = [[InputStateAssociatedPhrasesPlain alloc] initWithCandidates:array useVerticalMode:useVerticalMode];
@@ -2363,7 +2365,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             displayText = [[OpenCCBridge sharedInstance] convertToSimplified:displayText];
         }
 
-        InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:displayText originalValue:candidateValue];
+        InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:displayText rawValue:candidateValue];
         [array addObject:candidate];
     }
     InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:state prefixCursorIndex:prefixCursorIndex prefixReading:reading prefixValue:value selectedIndex:candidateIndex candidates:array useVerticalMode:useVerticalMode useShiftKey:useShiftKey];


### PR DESCRIPTION
#649 introduces two new keys to boost and exclude a candidate. However, these keys should not be applied to converted (by Chinese converter or macro converter) candate.

The PR fixes the issue.  