### PR TITLE
feat: Add option to use HL keys to move cursor in candidate window

### DIFF
--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -340,12 +340,12 @@
                     <rect key="frame" x="229" y="302" width="212" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Moving cursor is not allowed" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bmM-mL-c3L" id="ymc-ph-WCL">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="FKG-wO-hnA">
                             <items>
                                 <menuItem title="Moving cursor is not allowed" state="on" id="bmM-mL-c3L"/>
-                                <menuItem title="JK keys moves the cursor" tag="1" id="K0k-rP-lGt"/>
-                                <menuItem title="HL keys moves the cursor" tag="2" id="eou-CZ-8G2"/>
+                                <menuItem title="JK keys move the cursor" tag="1" id="K0k-rP-lGt"/>
+                                <menuItem title="HL keys move the cursor" tag="2" id="eou-CZ-8G2"/>
                             </items>
                         </menu>
                     </popUpButtonCell>

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -40,7 +40,7 @@
             <rect key="frame" x="0.0" y="0.0" width="477" height="576"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
                     <rect key="frame" x="44" y="534" width="176" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bopomofo Keyboard Layout:" id="VTD-h6-q9r">
                         <font key="font" metaFont="system"/>
@@ -59,7 +59,7 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="mjl-uI-U8T"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
                     <rect key="frame" x="23" y="502" width="197" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric Keyboard Layout:" id="cTl-dv-9gx">
                         <font key="font" metaFont="system"/>
@@ -77,7 +77,7 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="Z1u-Xj-5q7"/>
                     </connections>
                 </button>
-                <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
+                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
                     <rect key="frame" x="231" y="438" width="221" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="19" id="yz7-87-p3i"/>
@@ -96,7 +96,7 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="dwv-UP-fcW"/>
                     </connections>
                 </comboBox>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
                     <rect key="frame" x="123" y="443" width="97" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Selection Keys:" id="5RC-uF-JMe">
                         <font key="font" metaFont="system"/>
@@ -134,7 +134,7 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="uBc-h3-Lqq"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
                     <rect key="frame" x="68" y="385" width="152" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Candidate Phrase:" id="Old-PI-MEs">
                         <font key="font" metaFont="system"/>
@@ -142,7 +142,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
                     <rect key="frame" x="91" y="272" width="129" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate List Style:" id="Xj4-f5-50V">
                         <font key="font" metaFont="system"/>
@@ -150,7 +150,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
                     <rect key="frame" x="91" y="223" width="129" height="17"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
@@ -224,7 +224,7 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="Jra-P0-jp5"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
                     <rect key="frame" x="100" y="178" width="120" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
@@ -257,7 +257,7 @@
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="YP4-Tc-T1I"/>
                     </connections>
                 </matrix>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
                     <rect key="frame" x="161" y="96" width="59" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
@@ -300,18 +300,6 @@
                         <binding destination="32" name="selectedTag" keyPath="values.SelectPhraseAfterCursorAsCandidate" id="CKd-Sk-Koh"/>
                     </connections>
                 </matrix>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UiH-9a-GF7">
-                    <rect key="frame" x="230" y="296" width="221" height="32"/>
-                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Z7n-dF-oDt">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <string key="title">Allow moving cursor by JK keys 
-when selecting candidats</string>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="32" name="value" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="RLp-ue-39w"/>
-                    </connections>
-                </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="cRR-T6-aMw">
                     <rect key="frame" x="230" y="56" width="159" height="18"/>
                     <buttonCell key="cell" type="check" title="Beep upon input error" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="rnd-fr-0dm">
@@ -332,7 +320,7 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.ShiftEnterEnabled" id="RyW-HU-SUL"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
                     <rect key="frame" x="111" y="130" width="109" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter Key:" id="H9E-f1-tBt">
                         <font key="font" metaFont="system"/>
@@ -340,6 +328,31 @@ when selecting candidats</string>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MdX-1s-2eC">
+                    <rect key="frame" x="41" y="308" width="178" height="19"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="When Selecting Candidates:" id="wkY-8D-tZm">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xg9-aU-XIb">
+                    <rect key="frame" x="229" y="302" width="212" height="25"/>
+                    <popUpButtonCell key="cell" type="push" title="Moving cursor is not allowed" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bmM-mL-c3L" id="ymc-ph-WCL">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="FKG-wO-hnA">
+                            <items>
+                                <menuItem title="Moving cursor is not allowed" state="on" id="bmM-mL-c3L"/>
+                                <menuItem title="JK keys moves the cursor" tag="1" id="K0k-rP-lGt"/>
+                                <menuItem title="HL keys moves the cursor" tag="2" id="eou-CZ-8G2"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <connections>
+                        <binding destination="32" name="selectedTag" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="WWQ-b8-RSl"/>
+                    </connections>
+                </popUpButton>
             </subviews>
             <constraints>
                 <constraint firstItem="Frc-9z-VZe" firstAttribute="leading" secondItem="wIs-KO-qx1" secondAttribute="leading" id="0Rp-83-rb3"/>
@@ -361,25 +374,29 @@ when selecting candidats</string>
                 <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="eBz-xC-fkE" secondAttribute="top" id="GQr-IE-mPN"/>
                 <constraint firstAttribute="trailing" secondItem="iZs-U3-CJx" secondAttribute="trailing" constant="18" id="ICX-nN-t2a"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cRR-T6-aMw" secondAttribute="trailing" id="IFF-rS-TcJ"/>
-                <constraint firstItem="UiH-9a-GF7" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="Iej-bp-7J3"/>
                 <constraint firstItem="3oc-Wl-pem" firstAttribute="top" secondItem="AvT-mU-HNg" secondAttribute="top" id="J26-55-kji"/>
                 <constraint firstItem="s4T-Mw-U2e" firstAttribute="top" secondItem="Frc-9z-VZe" secondAttribute="bottom" constant="10" id="L59-Rf-SnT"/>
                 <constraint firstItem="bhe-DC-FkH" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="26" id="L7s-Xm-LXg"/>
                 <constraint firstItem="Nma-j4-skB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="LCh-b8-xXg"/>
-                <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="UiH-9a-GF7" secondAttribute="bottom" constant="8" id="O2s-wX-T0t"/>
+                <constraint firstItem="MdX-1s-2eC" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="249" id="MUz-ux-dkD"/>
                 <constraint firstItem="Frc-9z-VZe" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="Obg-X1-fuW"/>
                 <constraint firstItem="7dj-MJ-a2i" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="PEC-Iz-UZG"/>
                 <constraint firstItem="iZs-U3-CJx" firstAttribute="top" secondItem="s4T-Mw-U2e" secondAttribute="bottom" constant="44" id="QWR-rt-HEb"/>
                 <constraint firstAttribute="bottom" secondItem="7dj-MJ-a2i" secondAttribute="bottom" constant="35" id="R07-SD-4Sq"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MdX-1s-2eC" secondAttribute="trailing" constant="20" symbolic="YES" id="SHb-0g-p9j"/>
                 <constraint firstItem="AvT-mU-HNg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="SLf-GY-58Y"/>
                 <constraint firstItem="dsc-GH-nO2" firstAttribute="baseline" secondItem="PLL-ab-6cC" secondAttribute="baseline" constant="-1" id="SQm-8T-VHe"/>
+                <constraint firstItem="xg9-aU-XIb" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="SeC-uj-klg"/>
                 <constraint firstItem="PLL-ab-6cC" firstAttribute="leading" secondItem="dsc-GH-nO2" secondAttribute="trailing" constant="16" id="Thh-Bk-4FJ"/>
                 <constraint firstAttribute="trailing" secondItem="Frc-9z-VZe" secondAttribute="trailing" constant="13" id="U3T-Ij-i1M"/>
                 <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="Up9-ed-0dG"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xg9-aU-XIb" secondAttribute="trailing" constant="20" symbolic="YES" id="VJP-WJ-nox"/>
                 <constraint firstItem="AvT-mU-HNg" firstAttribute="top" secondItem="Pdz-c8-G89" secondAttribute="bottom" constant="10" id="VgD-h8-weo"/>
                 <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="Sp0-2u-7hi" secondAttribute="trailing" id="W0h-NP-ex7"/>
+                <constraint firstItem="MdX-1s-2eC" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="43" id="WpY-bP-1L3"/>
                 <constraint firstItem="bhe-DC-FkH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="YEV-YT-uQf"/>
                 <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="eBz-xC-fkE" secondAttribute="trailing" constant="14" id="Zb9-zd-PG9"/>
+                <constraint firstItem="xg9-aU-XIb" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="250" id="aLK-qU-Jrg"/>
                 <constraint firstItem="s4T-Mw-U2e" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Sp0-2u-7hi" secondAttribute="trailing" constant="8" symbolic="YES" id="ayv-gh-1Fj"/>
                 <constraint firstItem="1UT-Vk-jJp" firstAttribute="trailing" secondItem="JFW-qA-UTv" secondAttribute="trailing" id="bir-NM-ZOw"/>
                 <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="9Hh-po-xMG" secondAttribute="top" id="ct4-Cq-2I5"/>
@@ -395,7 +412,6 @@ when selecting candidats</string>
                 <constraint firstItem="JFW-qA-UTv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="mvx-tv-OTK"/>
                 <constraint firstItem="Nma-j4-skB" firstAttribute="top" secondItem="8Kb-9o-Czh" secondAttribute="bottom" constant="13" id="neE-LS-Pux"/>
                 <constraint firstItem="cRR-T6-aMw" firstAttribute="leading" secondItem="s4T-Mw-U2e" secondAttribute="leading" id="nnM-01-4Rz"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UiH-9a-GF7" secondAttribute="trailing" constant="20" symbolic="YES" id="o1i-nV-wKE"/>
                 <constraint firstItem="8Kb-9o-Czh" firstAttribute="top" secondItem="buv-Na-btc" secondAttribute="top" id="oN5-et-AMb"/>
                 <constraint firstItem="fxC-25-09x" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="qNg-rI-AXH"/>
                 <constraint firstItem="3oc-Wl-pem" firstAttribute="trailing" secondItem="JFW-qA-UTv" secondAttribute="trailing" id="qPV-Ay-cu0"/>
@@ -423,7 +439,7 @@ when selecting candidats</string>
             <rect key="frame" x="0.0" y="0.0" width="477" height="214"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
                     <rect key="frame" x="74" y="178" width="163" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Chinese Conversion Style:" id="cMO-Ss-Jar">
                         <font key="font" metaFont="system"/>
@@ -466,7 +482,7 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.Big5InputEnabled" id="0sV-29-JVt"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
                     <rect key="frame" x="134" y="130" width="103" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + Enter Key:" id="lrz-7F-6e5">
                         <font key="font" metaFont="system"/>
@@ -474,7 +490,7 @@ when selecting candidats</string>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
                     <rect key="frame" x="156" y="100" width="81" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + `  Key:" id="F6Q-1k-YTn">
                         <font key="font" metaFont="system"/>
@@ -482,7 +498,7 @@ when selecting candidats</string>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
                     <rect key="frame" x="101" y="72" width="136" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="132" id="TLl-fl-TAQ"/>
@@ -503,7 +519,7 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.RepeatedPunctuationToSelectCandidateEnabled" id="lgT-7e-2ai"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
                     <rect key="frame" x="241" y="22" width="219" height="42"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="215" id="748-J5-BGk"/>
@@ -566,7 +582,7 @@ when selecting candidats</string>
             <rect key="frame" x="0.0" y="0.0" width="477" height="329"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
                     <rect key="frame" x="18" y="293" width="137" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="User Phrase Location:" id="Sc6-Rd-pOy">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -594,7 +610,7 @@ when selecting candidats</string>
                         <action selector="changeCustomUserPhraseLocationEnabledAction:" target="-2" id="fUI-Z1-8Cg"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
                     <rect key="frame" x="111" y="256" width="306" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="6kS-fE-Kz7">
                         <font key="font" metaFont="system"/>
@@ -606,7 +622,7 @@ when selecting candidats</string>
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="liS-L1-RTD"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
                     <rect key="frame" x="20" y="174" width="439" height="28"/>
                     <textFieldCell key="cell" id="Vz3-KS-1rk">
                         <font key="font" metaFont="smallSystem"/>
@@ -639,7 +655,7 @@ when selecting candidats</string>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5ce-rm-tsn">
                     <rect key="frame" x="20" y="151" width="433" height="5"/>
                 </box>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
                     <rect key="frame" x="18" y="117" width="437" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="After Adding a New Phrase:" id="wGR-0A-cqv">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -657,7 +673,7 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookEnabled" id="DFg-tK-bEf"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
                     <rect key="frame" x="62" y="57" width="391" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Sbq-JE-A4U">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -668,7 +684,7 @@ when selecting candidats</string>
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookPath" id="IJd-KL-Ytn"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
                     <rect key="frame" x="20" y="57" width="36" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Path:" id="ZY3-98-BrK">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -676,7 +692,7 @@ when selecting candidats</string>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
                     <rect key="frame" x="20" y="20" width="439" height="28"/>
                     <textFieldCell key="cell" title="You can run a script to use git to backup your phrases. The script will run in the folder of your user phrases folder." id="byk-Br-x2Z">
                         <font key="font" metaFont="smallSystem"/>

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1335,24 +1335,20 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     BOOL isCursorMovingLeft = NO;
     BOOL isCursorMovingRight = NO;
     if (input.isShiftHold) {
-        if (input.isLeft) {
-            isCursorMovingLeft = YES;
-        } else if (input.isRight) {
-            isCursorMovingRight = YES;
-        }
-    }
-    else if (Preferences.allowMovingCursorWhenChoosingCandidates == MovingCursorKeyUseJK) {
-        if ([input.inputText isEqualToString:@"j"]) {
-            isCursorMovingLeft = YES;
-        } else if ([input.inputText isEqualToString:@"k"]) {
-            isCursorMovingRight = YES;
-        }
-    }
-    else if (Preferences.allowMovingCursorWhenChoosingCandidates == MovingCursorKeyUseHL) {
-        if ([input.inputText isEqualToString:@"h"]) {
-            isCursorMovingLeft = YES;
-        } else if ([input.inputText isEqualToString:@"l"]) {
-            isCursorMovingRight = YES;
+        isCursorMovingLeft = input.isLeft;
+        isCursorMovingRight = input.isRight;
+    } else {
+        switch (Preferences.allowMovingCursorWhenChoosingCandidates) {
+            case MovingCursorKeyUseJK:
+                isCursorMovingLeft = [input.inputText isEqualToString:@"j"];
+                isCursorMovingRight = [input.inputText isEqualToString:@"k"];
+                break;
+            case MovingCursorKeyUseHL:
+                isCursorMovingLeft = [input.inputText isEqualToString:@"h"];
+                isCursorMovingRight = [input.inputText isEqualToString:@"l"];
+                break;
+            default:
+                break;
         }
     }
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1329,10 +1329,35 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     BOOL cancelCandidateKey = (charCode == 27) || (charCode == 8) || input.isDelete;
 
-    BOOL isCursorMovingKey = (Preferences.allowMovingCursorWhenChoosingCandidates && ([input.inputText isEqualToString:@"j"] || [input.inputText isEqualToString:@"k"])) || (input.isShiftHold && (input.isLeft || input.isRight));
+    NSLog(@"Preferences.allowMovingCursorWhenChoosingCandidates %ld", static_cast<long>(Preferences.allowMovingCursorWhenChoosingCandidates));
+    NSLog(@"input.inputText:%@", input.inputText);
 
-    if ([state isKindOfClass:[InputStateChoosingCandidate class]] && isCursorMovingKey) {
-        if ([input.inputText isEqualToString:@"j"] || (input.isLeft && input.isShiftHold)) {
+    BOOL isCursorMovingLeft = NO;
+    BOOL isCursorMovingRight = NO;
+    if (input.isShiftHold) {
+        if (input.isLeft) {
+            isCursorMovingLeft = YES;
+        } else if (input.isRight) {
+            isCursorMovingRight = YES;
+        }
+    }
+    else if (Preferences.allowMovingCursorWhenChoosingCandidates == MovingCursorKeyUseJK) {
+        if ([input.inputText isEqualToString:@"j"]) {
+            isCursorMovingLeft = YES;
+        } else if ([input.inputText isEqualToString:@"k"]) {
+            isCursorMovingRight = YES;
+        }
+    }
+    else if (Preferences.allowMovingCursorWhenChoosingCandidates == MovingCursorKeyUseHL) {
+        if ([input.inputText isEqualToString:@"h"]) {
+            isCursorMovingLeft = YES;
+        } else if ([input.inputText isEqualToString:@"l"]) {
+            isCursorMovingRight = YES;
+        }
+    }
+
+    if ([state isKindOfClass:[InputStateChoosingCandidate class]] && (isCursorMovingLeft || isCursorMovingRight) ) {
+        if (isCursorMovingLeft) {
             size_t cursor = _grid->cursor();
             if (cursor > 0) {
                 cursor--;
@@ -1341,7 +1366,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 errorCallback();
                 return YES;
             }
-        } else if ([input.inputText isEqualToString:@"k"] || (input.isRight && input.isShiftHold)) {
+        } else if (isCursorMovingRight) {
             size_t cursor = _grid->cursor();
             if (cursor < _grid->length()) {
                 cursor++;

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -253,6 +253,7 @@ class Preferences: NSObject {
         Preferences.addPhraseHookPath = Preferences.addPhraseHookPath
         Preferences.beepUponInputError = Preferences.beepUponInputError
         Preferences.enableUserPhrasesInPlainBopomofo = Preferences.enableUserPhrasesInPlainBopomofo
+        Preferences.allowMovingCursorWhenChoosingCandidates = Preferences.allowMovingCursorWhenChoosingCandidates
     }
 
     @EnumUserDefault(key: kKeyboardLayoutPreferenceKey, defaultValue: KeyboardLayout.standard)
@@ -378,11 +379,19 @@ class Preferences: NSObject {
             }
         }
     }
+}
 
+@objc enum MovingCursorKey: Int {
+    case disabled = 0
+    case useJK = 1
+    case useHL = 2
+}
+
+extension Preferences {
     /// Whether allows moving the cursor by J/K keys, when the candidate
     /// window is presented.
-    @UserDefault(key: kAllowMovingCursorWhenChoosingCandidates, defaultValue: false)
-    @objc static var allowMovingCursorWhenChoosingCandidates: Bool
+    @EnumUserDefault(key: kAllowMovingCursorWhenChoosingCandidates, defaultValue: .disabled)
+    @objc static var allowMovingCursorWhenChoosingCandidates: MovingCursorKey
 }
 
 extension Preferences {

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -381,6 +381,8 @@ class Preferences: NSObject {
     }
 }
 
+/// An enumeration representing keys used for moving the cursor in the
+/// application.
 @objc enum MovingCursorKey: Int {
     case disabled = 0
     case useJK = 1
@@ -388,7 +390,7 @@ class Preferences: NSObject {
 }
 
 extension Preferences {
-    /// Whether allows moving the cursor by J/K keys, when the candidate
+    /// Whether allows moving the cursor by J/K or H/L keys, when the candidate
     /// window is presented.
     @EnumUserDefault(key: kAllowMovingCursorWhenChoosingCandidates, defaultValue: .disabled)
     @objc static var allowMovingCursorWhenChoosingCandidates: MovingCursorKey

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -62,7 +62,7 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KRC-Qj-X94">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KRC-Qj-X94">
                     <rect key="frame" x="78" y="490" width="92" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="注音鍵盤配置：" id="pgD-ZY-ctk">
                         <font key="font" metaFont="system"/>
@@ -81,7 +81,7 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="bhg-HS-4r8"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tK-14-8hw">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0tK-14-8hw">
                     <rect key="frame" x="27" y="363" width="143" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字時，候選詞起點在：" id="NxU-Db-NGM">
                         <font key="font" metaFont="system"/>
@@ -89,7 +89,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KMh-qe-ZAb">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KMh-qe-ZAb">
                     <rect key="frame" x="65" y="263" width="105" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="候選詞呈現方式：" id="bgn-gs-kBm">
                         <font key="font" metaFont="system"/>
@@ -97,7 +97,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-hI-9WY">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-hI-9WY">
                     <rect key="frame" x="65" y="205" width="105" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字窗文字大小：" id="Rqe-kZ-F9v">
                         <font key="font" metaFont="system"/>
@@ -162,7 +162,7 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="9Y3-nN-WmY"/>
                     </connections>
                 </button>
-                <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gtY-jT-2F6">
+                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gtY-jT-2F6">
                     <rect key="frame" x="185" y="409" width="216" height="23"/>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="SQ9-Pr-yQD">
                         <font key="font" metaFont="system"/>
@@ -178,7 +178,7 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="cHc-ww-yZG"/>
                     </connections>
                 </comboBox>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-3w-gC1">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8MO-3w-gC1">
                     <rect key="frame" x="117" y="415" width="53" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字鍵：" id="8xt-it-NRD">
                         <font key="font" metaFont="system"/>
@@ -196,7 +196,7 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="HMq-t1-4Cz"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c1b-KP-F28">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c1b-KP-F28">
                     <rect key="frame" x="65" y="460" width="105" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="英數字鍵盤配置：" id="LAM-Fg-sIT">
                         <font key="font" metaFont="system"/>
@@ -220,7 +220,7 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="g9O-jR-PLB"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMU-k1-QG3">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMU-k1-QG3">
                     <rect key="frame" x="73" y="168" width="96" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + 字母鍵：" id="v98-LJ-zGS">
                         <font key="font" metaFont="system"/>
@@ -228,7 +228,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IxA-64-q7d">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IxA-64-q7d">
                     <rect key="frame" x="114" y="94" width="56" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC 鍵：" id="q86-sV-OE5">
                         <font key="font" metaFont="system"/>
@@ -261,16 +261,6 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="IRV-VT-5Ou"/>
                     </connections>
                 </matrix>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wKx-MS-U5F">
-                    <rect key="frame" x="182" y="294" width="191" height="18"/>
-                    <buttonCell key="cell" type="check" title="選字時可以使用 JK 移動游標" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="saB-TA-BmG">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="32" name="value" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="Fv0-vl-b3w"/>
-                    </connections>
-                </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="oya-hD-nIE">
                     <rect key="frame" x="182" y="55" width="155" height="18"/>
                     <buttonCell key="cell" type="check" title="輸入錯誤時發出警示聲" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="N4o-lx-RYS">
@@ -329,7 +319,7 @@
                         <binding destination="32" name="value" keyPath="values.ShiftEnterEnabled" id="bWH-2f-yxL"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DoZ-iC-eqs">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DoZ-iC-eqs">
                     <rect key="frame" x="63" y="122" width="106" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter 鍵：" id="Nl4-BO-gM9">
                         <font key="font" metaFont="system"/>
@@ -337,13 +327,40 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YWl-mS-2Wx">
+                    <rect key="frame" x="41" y="288" width="133" height="16"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="PdE-3m-X9E"/>
+                    </constraints>
+                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="選字時可以移動游標：" id="pqK-7Z-ehF">
+                        <font key="font" size="13" name=".PingFangUITextTC-Regular"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IHs-uV-EyH">
+                    <rect key="frame" x="181" y="283" width="167" height="25"/>
+                    <popUpButtonCell key="cell" type="push" title="不使用" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="eGy-zp-bhw" id="8kw-Sg-bV9">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="6Dk-0j-FLJ">
+                            <items>
+                                <menuItem title="不使用" state="on" id="eGy-zp-bhw"/>
+                                <menuItem title="使用 JK 按鍵移動游標" tag="1" id="6UI-TJ-YRv"/>
+                                <menuItem title="使用 HL 按鍵移動游標" tag="2" id="cRU-pe-7kl"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <connections>
+                        <binding destination="32" name="selectedTag" keyPath="values.AllowMovingCursorWhenChoosingCandidates" id="FRZ-Rb-ZDz"/>
+                    </connections>
+                </popUpButton>
             </subviews>
             <constraints>
                 <constraint firstItem="KMh-qe-ZAb" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="67" id="0rf-so-wfh"/>
                 <constraint firstItem="uuQ-a9-JKn" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="20" symbolic="YES" id="2OQ-NX-qoC"/>
                 <constraint firstItem="eKe-P1-HOz" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="2lN-cZ-5Jx"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="BSi-pH-F8f" secondAttribute="trailing" id="2yn-Ax-joJ"/>
-                <constraint firstItem="wKx-MS-U5F" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="215" id="3ag-FV-ctk"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="KMh-qe-ZAb" secondAttribute="trailing" constant="-1" id="3yc-oT-xcR"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="42V-Bi-KIT"/>
                 <constraint firstItem="sMU-k1-QG3" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="75" id="4Gd-VR-LGd"/>
@@ -351,6 +368,7 @@
                 <constraint firstItem="KOq-SU-0dw" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="417" id="6Ru-Ut-7B2"/>
                 <constraint firstItem="Bc3-oU-EWC" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="342" id="74r-s5-xtV"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="KRC-Qj-X94" secondAttribute="trailing" constant="-1" id="9Ic-Y6-yXH"/>
+                <constraint firstItem="YWl-mS-2Wx" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="43" id="Cg1-Dw-Abj"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YF3-dA-BAc" secondAttribute="trailing" constant="20" symbolic="YES" id="Ct2-om-mnr"/>
                 <constraint firstItem="8MO-3w-gC1" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="95" id="DXw-BE-TSW"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qLt-o2-oPl" secondAttribute="trailing" constant="20" symbolic="YES" id="EEe-W9-qXU"/>
@@ -359,10 +377,10 @@
                 <constraint firstAttribute="trailing" secondItem="qLt-o2-oPl" secondAttribute="trailing" constant="68" id="GTh-kw-ZeN"/>
                 <constraint firstItem="0tK-14-8hw" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="147" id="HJ5-yO-O4E"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0tK-14-8hw" secondAttribute="trailing" constant="20" symbolic="YES" id="HLI-RV-711"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wKx-MS-U5F" secondAttribute="trailing" constant="20" symbolic="YES" id="I4f-8r-gKg"/>
                 <constraint firstItem="ovb-PR-Z2o" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="147" id="I5T-1A-LXi"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="IxA-64-q7d" secondAttribute="trailing" constant="-1" id="JEd-SA-eaY"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="80" id="KR1-CB-ioR"/>
+                <constraint firstItem="IHs-uV-EyH" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="LjA-Eo-HeM"/>
                 <constraint firstItem="pjw-8M-CEh" firstAttribute="top" secondItem="eKe-P1-HOz" secondAttribute="bottom" constant="8" symbolic="YES" id="Mrl-iC-L3h"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IxA-64-q7d" secondAttribute="trailing" constant="20" symbolic="YES" id="OXv-HY-nwn"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="trailing" secondItem="gtY-jT-2F6" secondAttribute="trailing" id="Oa7-Lh-Mmw"/>
@@ -379,21 +397,23 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hvF-32-Zw1" secondAttribute="trailing" constant="20" symbolic="YES" id="TCY-t3-hPS"/>
                 <constraint firstItem="tDv-b3-Mrm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="DoZ-iC-eqs" secondAttribute="trailing" constant="8" symbolic="YES" id="TYc-JO-4rD"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8MO-3w-gC1" secondAttribute="trailing" constant="20" symbolic="YES" id="U9v-8G-T8K"/>
+                <constraint firstItem="KMh-qe-ZAb" firstAttribute="top" secondItem="YWl-mS-2Wx" secondAttribute="bottom" constant="9" id="UGy-4h-9eR"/>
                 <constraint firstAttribute="trailing" secondItem="tDv-b3-Mrm" secondAttribute="trailing" constant="137" id="USg-iD-9aF"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="20" symbolic="YES" id="Vcd-VH-A59"/>
                 <constraint firstItem="2Nx-PK-HCb" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="VkM-rY-Yrp"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IHs-uV-EyH" secondAttribute="trailing" constant="20" symbolic="YES" id="XV9-im-EHc"/>
                 <constraint firstItem="Bc3-oU-EWC" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="Yd2-5c-nzb"/>
                 <constraint firstItem="ovb-PR-Z2o" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="ZF0-YL-jPa"/>
                 <constraint firstItem="eKe-P1-HOz" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="247" id="ZGK-6n-Jek"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="c1b-KP-F28" secondAttribute="trailing" constant="20" symbolic="YES" id="ZRO-Pr-5SH"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="top" secondItem="c1b-KP-F28" secondAttribute="top" id="aCs-sA-maV"/>
-                <constraint firstItem="wKx-MS-U5F" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="csP-G9-vQQ"/>
                 <constraint firstItem="KMh-qe-ZAb" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="247" id="d6k-6W-NG6"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="centerX" secondItem="hlp-hI-9WY" secondAttribute="centerX" constant="-1" id="dqa-vM-3jZ"/>
                 <constraint firstItem="YF3-dA-BAc" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="e5G-Du-eTU"/>
                 <constraint firstItem="oya-hD-nIE" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="eCx-8M-T6p"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6eT-rC-gVz" secondAttribute="trailing" id="eor-Aj-Jk9"/>
                 <constraint firstItem="IxA-64-q7d" firstAttribute="top" secondItem="DoZ-iC-eqs" secondAttribute="bottom" constant="12" id="fxn-7m-Tax"/>
+                <constraint firstItem="IHs-uV-EyH" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="219" id="hlG-T4-jOY"/>
                 <constraint firstItem="IxA-64-q7d" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="116" id="ihq-6K-4O0"/>
                 <constraint firstItem="2Nx-PK-HCb" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="123" id="iss-rc-oRY"/>
                 <constraint firstItem="c1b-KP-F28" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="67" id="jEX-fy-dEL"/>
@@ -404,6 +424,7 @@
                 <constraint firstAttribute="trailing" secondItem="pjw-8M-CEh" secondAttribute="trailing" constant="20" symbolic="YES" id="nmI-LZ-kdZ"/>
                 <constraint firstItem="hvF-32-Zw1" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="476" id="nz6-rf-rCd"/>
                 <constraint firstAttribute="trailing" secondItem="6eT-rC-gVz" secondAttribute="trailing" constant="38" id="oNu-3J-5fh"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YWl-mS-2Wx" secondAttribute="trailing" constant="20" symbolic="YES" id="oY6-bi-K9l"/>
                 <constraint firstItem="KOq-SU-0dw" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="pGP-cf-yJD"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="95" id="pNV-tW-L84"/>
                 <constraint firstItem="BSi-pH-F8f" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="20" symbolic="YES" id="sDa-gA-chB"/>
@@ -425,7 +446,7 @@
             <rect key="frame" x="0.0" y="0.0" width="436" height="208"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cks-CZ-m7g">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cks-CZ-m7g">
                     <rect key="frame" x="60" y="172" width="118" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="中文簡繁轉換模式：" id="bX9-g7-U8G">
                         <font key="font" metaFont="system"/>
@@ -458,7 +479,7 @@
                         <binding destination="32" name="selectedTag" keyPath="values.ChineseConversionStyle" id="l0X-2P-QrT"/>
                     </connections>
                 </matrix>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YR5-r0-KVo">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YR5-r0-KVo">
                     <rect key="frame" x="65" y="125" width="113" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + Enter 按鍵：" id="euS-8m-1LM">
                         <font key="font" metaFont="system"/>
@@ -466,7 +487,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QYl-R0-PIq">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QYl-R0-PIq">
                     <rect key="frame" x="91" y="98" width="87" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + ` 按鍵：" id="ezl-df-SwH">
                         <font key="font" metaFont="system"/>
@@ -516,7 +537,7 @@
                         <binding destination="32" name="value" keyPath="values.RepeatedPunctuationToSelectCandidateEnabled" id="adV-vU-QSD"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i1G-1y-ihS">
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i1G-1y-ihS">
                     <rect key="frame" x="182" y="17" width="236" height="48"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="232" id="W9j-gd-BG6"/>
@@ -527,7 +548,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mgj-mT-xZ6">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mgj-mT-xZ6">
                     <rect key="frame" x="113" y="70" width="69" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="65" id="fFl-lX-SN3"/>
@@ -572,7 +593,7 @@
             <rect key="frame" x="0.0" y="0.0" width="436" height="334"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
                     <rect key="frame" x="22" y="298" width="105" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="使用者詞彙位置：" id="ulY-l0-tqg">
                         <font key="font" metaFont="system"/>
@@ -598,7 +619,7 @@
                         </connections>
                     </popUpButtonCell>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aAf-VY-6CO">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aAf-VY-6CO">
                     <rect key="frame" x="90" y="261" width="291" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Ooe-Ve-njT">
                         <font key="font" metaFont="system"/>
@@ -610,7 +631,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="KRZ-JC-JCe"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
                     <rect key="frame" x="18" y="177" width="403" height="28"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="8wn-XD-VFx"/>
@@ -631,7 +652,7 @@
                         <action selector="openUserPhrasedFolderAction:" target="-2" id="FXB-pN-TqS"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="bHQ-bR-nHc">
+                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="bHQ-bR-nHc">
                     <rect key="frame" x="18" y="120" width="396" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="在手動加入使用者詞彙之後:" id="Yhg-pv-SyV">
                         <font key="font" metaFont="system"/>
@@ -649,7 +670,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookEnabled" id="aI7-Rc-u4x"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VKE-yo-TdG">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VKE-yo-TdG">
                     <rect key="frame" x="71" y="58" width="346" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="346" id="62p-rx-Sp1"/>
@@ -663,7 +684,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookPath" id="KtP-IE-zum"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="8ku-Pt-FIH">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="8ku-Pt-FIH">
                     <rect key="frame" x="21" y="60" width="44" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="路徑：" id="2Ox-BG-OqC">
                         <font key="font" metaFont="system"/>
@@ -685,7 +706,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="v3f-1L-haF"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="kxZ-N1-Oph">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="kxZ-N1-Oph">
                     <rect key="frame" x="19" y="20" width="399" height="28"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="NbE-2C-xvN"/>

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -328,12 +328,12 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YWl-mS-2Wx">
-                    <rect key="frame" x="41" y="288" width="133" height="16"/>
+                    <rect key="frame" x="41" y="288" width="130" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="PdE-3m-X9E"/>
                     </constraints>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="選字時可以移動游標：" id="pqK-7Z-ehF">
-                        <font key="font" size="13" name=".PingFangUITextTC-Regular"/>
+                        <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -342,7 +342,7 @@
                     <rect key="frame" x="181" y="283" width="167" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="不使用" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="eGy-zp-bhw" id="8kw-Sg-bV9">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
+                        <font key="font" metaFont="message"/>
                         <menu key="menu" id="6Dk-0j-FLJ">
                             <items>
                                 <menuItem title="不使用" state="on" id="eGy-zp-bhw"/>


### PR DESCRIPTION
This fixes #652

This commit introduces a new preference that allows users to use H and L keys to move the cursor left and right in the candidate window, as an alternative to the existing J and K keys. The preference is implemented as a dropdown menu in the preferences panel, with the options:

- Disabled
- Use JK keys
- Use HL keys The KeyHandler is updated to respect this new setting.