### PR TITLE
Fix phonetics for 癖

### DIFF
--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -8009,6 +8009,7 @@
 圮 ㄆㄧˇ pi3 qu3 big5
 崥 ㄆㄧˇ pi3 qu3 big5
 諀 ㄆㄧˇ pi3 qu3 big5
+癖 ㄆㄧˇ pi3 qu3 big5
 譬 ㄆㄧˋ pi4 qu4 big5
 闢 ㄆㄧˋ pi4 qu4 big5
 僻 ㄆㄧˋ pi4 qu4 big5


### PR DESCRIPTION
The concise dictionary prefers `癖 ㄆㄧˇ`

Ref: https://dict.concised.moe.edu.tw/search.jsp?md=1&word=%E7%99%96#searchL