### PR TITLE
ci: enable Claude Code Action inline review comments with suggestions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write # Required for posting inline review comments
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -40,11 +40,19 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # Enable inline review comments with suggestions for PR reviews
+          # When @claude is mentioned in PR comments, it will provide detailed inline feedback
+          prompt: |
+            Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+            1. **Start a review**: Use `mcp__github__create_pending_pull_request_review` to begin a pending review
+            2. **Get diff information**: Use `mcp__github__get_pull_request_diff` to understand the code changes and line numbers
+            3. **Add inline comments**: Use `mcp__github__add_comment_to_pending_review` for each specific piece of feedback on particular lines
+            4. **Submit the review**: Use `mcp__github__submit_pending_pull_request_review` with event type "COMMENT" (not "REQUEST_CHANGES") to publish all comments as a non-blocking review
+
+            When suggesting code changes, use GitHub's suggestion format with ```suggestion blocks so authors can apply changes directly.
+
+          # Enable GitHub MCP server tools for inline review comments
+          # See: https://github.com/anthropics/claude-code-action/issues/60
+          claude_args: "--allowedTools mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -54,5 +54,10 @@ jobs:
 
           # Enable GitHub MCP server tools for inline review comments
           # See: https://github.com/anthropics/claude-code-action/issues/60
-          claude_args: "--allowedTools mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_comment_to_pending_review,mcp__github__submit_pending_pull_request_review"
+          claude_args: >-
+            --allowedTools
+            mcp__github__create_pending_pull_request_review,
+            mcp__github__get_pull_request_diff,
+            mcp__github__add_comment_to_pending_review,
+            mcp__github__submit_pending_pull_request_review
 


### PR DESCRIPTION
### **User description**
This commit configures the Claude Code Action GitHub workflow to provide inline, line-specific review comments on pull requests with code suggestions that can be applied directly.

Changes:
- Upgraded permissions: pull-requests: read → write (required for posting inline review comments)
- Added structured prompt instructing Claude to use GitHub's review system:
  1. Create pending review
  2. Get PR diff for line numbers
  3. Add inline comments to specific lines
  4. Submit as non-blocking COMMENT review
- Configured GitHub MCP server tools via claude_args --allowedTools:
  - mcp__github__create_pending_pull_request_review
  - mcp__github__get_pull_request_diff
  - mcp__github__add_comment_to_pending_review (updated tool name from PR #363)
  - mcp__github__submit_pending_pull_request_review

This configuration is based on working examples from anthropics/claude-code-action#60 and aligns with the latest GitHub MCP server tool naming conventions (October 2025 consolidation).

Expected behavior: When @claude is mentioned in PR comments, it will now post inline comments with actionable code suggestions in GitHub's suggestion format, rather than just general comments.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Enable inline PR review comments via Claude

- Grant pull-requests write permission for reviews

- Add guided prompt for review workflow

- Configure allowed MCP GitHub tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  WF["claude.yml workflow"] -- "adds write permission" --> PERM["pull-requests: write"]
  WF -- "adds prompt" --> PRMPT["Guided review workflow"]
  WF -- "configures tools" --> TOOLS["MCP GitHub tools list"]
  PRMPT -- "start -> diff -> comments -> submit" --> FLOW["Inline review process"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>claude.yml</strong><dd><code>Configure Claude Action for inline PR reviews</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/claude.yml

<ul><li>Upgrade <code>pull-requests</code> permission to <code>write</code>.<br> <li> Add detailed prompt guiding inline review steps.<br> <li> Configure allowed MCP GitHub tools via <code>claude_args</code>.<br> <li> Document suggestion block usage and rationale in comments.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/709/files#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342e">+15/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

