### PR TITLE
Update CI workflow to package and upload artifact

### DIFF
--- a/.github/workflows/continuous-integration-workflow-xcode-latest.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-latest.yml
@@ -12,6 +12,13 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "^16.1.0"
+      - name: Get commit SHA
+        run: echo "SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - name: Update CFBundleVersion with commit SHA
+        run: |
+          echo "Updating CFBundleVersion to ${SHA}"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${SHA}" "Source/Installer/Installer-Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${SHA}" "Source/McBopomofo-Info.plist"
       - name: Build McBopomofoLMLibTest
         run: cmake -DENABLE_TEST=1 -S . -B build
         working-directory: Source/Engine
@@ -56,7 +63,7 @@ jobs:
       - name: Build McBopomofo
         run: xcodebuild -scheme McBopomofo -configuration Release build
       - name: Build McBopomofoInstaller
-        run: xcodebuild -scheme McBopomofoInstaller -configuration Release build
+        run: xcodebuild -scheme McBopomofoInstaller -configuration Release -derivedDataPath build
       - name: Test data files
         run: make check
         working-directory: Source/Data
@@ -67,4 +74,16 @@ jobs:
         if: github.event_name == 'push'
         uses: peter-evans/commit-comment@v3
         with:
-          body-path: 'codecov_comment.md' 
+          body-path: 'codecov_comment.md'
+      - name: Package McBopomofoInstaller
+        run: |
+          mkdir -p artifact
+          cp -R build/Build/Products/Release/McBopomofoInstaller.app artifact/
+          cd artifact
+          zip -r McBopomofo-Installer-${SHA}.zip McBopomofoInstaller.app
+          ls -lh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: McBopomofo-Installer-${{ env.SHA }}
+          path: artifact/McBopomofo-Installer-${{ env.SHA }}.zip


### PR DESCRIPTION
In #688 and #478, users who are not familiar with building from source may have to wait until the next McBopomofo release to get the issues fixed.

Since our CI runs a build for every push, packaging and uploading the build as an artifact could allow users to download it directly and test whether the reported issues have been resolved.

By the way, I noticed that even though it’s built with the release scheme, the unzipped McBopomofo-Installer is larger than the official release. I’m so curious what optimizations were applied in the official version XD

### Demo
https://github.com/ChiahongHong/McBopomofo/actions/runs/18755941747
<img width="700" src="https://github.com/user-attachments/assets/f8e87c0a-7030-4851-a174-fd14a64c796f" />

### Known Issue
Because the app is not code-signed, users will need to manually allow it in System Settings → Privacy & Security.
<img width="250" src="https://github.com/user-attachments/assets/8a4ab87e-90d8-4a92-8d87-6dfffe7d6dad" />
<img width="700" src="https://github.com/user-attachments/assets/c9528695-0059-4494-a464-799d50626f68" />

### Version Number
For now, I’m using the short commit SHA as `CFBundleVersion`. I would make changes if you have any suggestions.
<img width="700" src="https://github.com/user-attachments/assets/19f0a1e1-f546-4c76-947a-0e55e8d8969e" />
<img width="400" src="https://github.com/user-attachments/assets/26bd8793-8b47-420c-9e1e-8376b733e6aa" />