### PR TITLE
Add Roman numeral input support

### DIFF
--- a/.github/workflows/continuous-integration-workflow-xcode-latest.yml
+++ b/.github/workflows/continuous-integration-workflow-xcode-latest.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Test ChineseNumbers
         run: swift test --enable-code-coverage
         working-directory: Packages/ChineseNumbers
+      - name: Test RomanNumbers
+        run: swift test --enable-code-coverage
+        working-directory: Packages/RomanNumbers
       - name: Clean McBopomofo for testing
         run: xcodebuild -scheme McBopomofo -configuration Debug clean
       - name: Test McBopomofo

--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		D47F7DD3278C1263002F9DD7 /* UserOverrideModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D47F7DD2278C1263002F9DD7 /* UserOverrideModel.cpp */; };
 		D485D3B92796A8A000657FF3 /* PreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D485D3B82796A8A000657FF3 /* PreferencesTests.swift */; };
 		D485D3C02796CE3200657FF3 /* VersionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D485D3BF2796CE3200657FF3 /* VersionUpdateTests.swift */; };
+		D48F853E2EACDB6C00C2FDAB /* RomanNumbers in Frameworks */ = {isa = PBXBuildFile; productRef = D48F853D2EACDB6C00C2FDAB /* RomanNumbers */; };
 		D4A13D5A27A59F0B003BE359 /* InputMethodController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A13D5927A59D5C003BE359 /* InputMethodController.swift */; };
 		D4A8E43627A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A8E43527A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift */; };
 		D4C2A9872B4309D700113711 /* UTF8HelperTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4C2A9862B4309D700113711 /* UTF8HelperTest.mm */; };
@@ -215,6 +216,7 @@
 		D485D3B62796A8A000657FF3 /* McBopomofoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = McBopomofoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D485D3B82796A8A000657FF3 /* PreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTests.swift; sourceTree = "<group>"; };
 		D485D3BF2796CE3200657FF3 /* VersionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUpdateTests.swift; sourceTree = "<group>"; };
+		D48F853C2EACCDE900C2FDAB /* RomanNumbers */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = RomanNumbers; path = Packages/RomanNumbers; sourceTree = "<group>"; };
 		D495583A27A5C6C4006ADE1C /* LanguageModelManager+Privates.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "LanguageModelManager+Privates.h"; sourceTree = "<group>"; };
 		D4A13D5927A59D5C003BE359 /* InputMethodController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputMethodController.swift; sourceTree = "<group>"; };
 		D4A8E43527A9E982002F7A07 /* KeyHandlerPlainBopomofoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyHandlerPlainBopomofoTests.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 				D427F7A927905E90004A2160 /* TooltipUI in Frameworks */,
 				D4451AC92E688C6B00E8F5AB /* SystemCharacterInfo in Frameworks */,
 				D47D73C327A7200500255A50 /* FSEventStreamHelper in Frameworks */,
+				D48F853E2EACDB6C00C2FDAB /* RomanNumbers in Frameworks */,
 				D4E7917A2B52CDE500676A68 /* ChineseNumbers in Frameworks */,
 				D427F76A278C9E29004A2160 /* CandidateUI in Frameworks */,
 				D4C9CAB127AAC9690058DFEA /* NSStringUtils in Frameworks */,
@@ -459,6 +462,7 @@
 				D4E5EEE22E68A9B30068BC58 /* SystemCharacterInfo */,
 				D41B626A2B86EAD400583148 /* BopomofoBraille */,
 				D4E791782B52CDCF00676A68 /* ChineseNumbers */,
+				D48F853C2EACCDE900C2FDAB /* RomanNumbers */,
 				D427F768278C9D0D004A2160 /* CandidateUI */,
 				D427F7A727905E43004A2160 /* TooltipUI */,
 				D427F7AC27907B7E004A2160 /* NotifierUI */,
@@ -539,6 +543,7 @@
 				D4E791792B52CDE500676A68 /* ChineseNumbers */,
 				D41B626B2B86EAE900583148 /* BopomofoBraille */,
 				D4451AC82E688C6B00E8F5AB /* SystemCharacterInfo */,
+				D48F853D2EACDB6C00C2FDAB /* RomanNumbers */,
 			);
 			productName = McBopomofo;
 			productReference = 6A0D4EA215FC0D2D00ABF4B3 /* McBopomofo.app */;
@@ -1466,6 +1471,10 @@
 		D47D73C227A7200500255A50 /* FSEventStreamHelper */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = FSEventStreamHelper;
+		};
+		D48F853D2EACDB6C00C2FDAB /* RomanNumbers */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = RomanNumbers;
 		};
 		D4C9CAB027AAC9690058DFEA /* NSStringUtils */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Packages/ChineseNumbers/Tests/ChineseNumbersTests/ChineseNumbersTests.swift
+++ b/Packages/ChineseNumbers/Tests/ChineseNumbersTests/ChineseNumbersTests.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import XCTest
 @testable import ChineseNumbers
 

--- a/Packages/ChineseNumbers/Tests/ChineseNumbersTests/SuzhouTests.swift
+++ b/Packages/ChineseNumbers/Tests/ChineseNumbersTests/SuzhouTests.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import XCTest
 
 @testable import ChineseNumbers

--- a/Packages/RomanNumbers/.gitignore
+++ b/Packages/RomanNumbers/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/RomanNumbers/Package.swift
+++ b/Packages/RomanNumbers/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "RomanNumbers",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "RomanNumbers",
+            targets: ["RomanNumbers"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "RomanNumbers"
+        ),
+        .testTarget(
+            name: "RomanNumbersTests",
+            dependencies: ["RomanNumbers"]
+        ),
+    ]
+)

--- a/Packages/RomanNumbers/README.md
+++ b/Packages/RomanNumbers/README.md
@@ -1,0 +1,81 @@
+# RomanNumbers
+
+RomanNumbers is a Swift package that converts decimal numbers into Roman
+numerals. It powers parts of the McBopomofo input method project where formatted
+Roman numerals are needed in Swift and Objective-C contexts.
+
+## Features
+
+- Supports integer values from 0 through 3999
+- Offers three output styles via `RomanNumbersStyle`: `alphabets`,
+  `fullWidthUpper` (Unicode U+2160–U+216F), and `fullWidthLower` (Unicode
+  U+2170–U+217F)
+- Accepts either `Int` input or decimal text strings
+- Throws descriptive errors (`RomanNumbersErrors`) when the source value is out of range or invalid
+- Marked with `@objc` so the conversion APIs are reachable from Objective-C code
+
+## Installation
+
+Add RomanNumbers to the `dependencies` section of your `Package.swift`:
+
+```swift
+.dependencies([
+    .package(path: "Packages/RomanNumbers")
+])
+```
+
+Then link the library from a target:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "RomanNumbers", package: "RomanNumbers")
+    ]
+)
+```
+
+If you vend the package from another repository, replace the `.package` path
+with the appropriate `.package(url: "...", from: "...")` declaration.
+
+## Usage
+
+```swift
+import RomanNumbers
+
+let number = 2025
+let standard = try RomanNumbers.convert(input: number)
+let upperFullWidth = try RomanNumbers.convert(input: number, style: .fullWidthUpper)
+let lowerFromText = try RomanNumbers.convert(string: "3999", style: .fullWidthLower)
+
+print(standard)        // "MMXXV"
+print(upperFullWidth)  // Unicode Roman numeral letters in the U+2160 block
+print(lowerFromText)   // Unicode Roman numeral letters in the U+2170 block
+```
+
+## Error Handling
+
+`RomanNumbers.convert` throws values of `RomanNumbersErrors`:
+
+- `tooLarge`: the input exceeds 3999
+- `tooSmall`: the input is negative
+- `invalidInput`: the string argument cannot be parsed as an integer
+
+These errors conform to `LocalizedError`, providing human-readable descriptions
+suitable for UI presentation.
+
+## Testing
+
+Run the package tests with:
+
+```bash
+swift test
+```
+
+The suite exercises every conversion style and covers edge cases for the
+supported numeric range.
+
+## License
+
+RomanNumbers ships as part of McBopomofo. Refer to the repository's root
+`LICENSE` file for licensing terms.

--- a/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
+++ b/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import Foundation
 
 @objc

--- a/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
+++ b/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
@@ -9,9 +9,9 @@ public enum RomanNumbersErrors: Int, Error, LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .tooLarge:
-            "Cannot be larger then 3999"
+            "Cannot be larger than 3999"
         case .tooSmall:
-            "Cannot be less then 0"
+            "Cannot be less than 0"
         case .invalidInput:
             "Input is not a valid integer"
         }

--- a/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
+++ b/Packages/RomanNumbers/Sources/RomanNumbers/RomanNumbers.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+@objc
+public enum RomanNumbersErrors: Int, Error, LocalizedError {
+    case tooLarge
+    case tooSmall
+    case invalidInput
+
+    public var errorDescription: String? {
+        switch self {
+        case .tooLarge:
+            "Cannot be larger then 3999"
+        case .tooSmall:
+            "Cannot be less then 0"
+        case .invalidInput:
+            "Input is not a valid integer"
+        }
+    }
+}
+
+@objc public enum RomanNumbersStyle: Int {
+    case alphabets
+    case fullWidthUpper
+    case fullWidthLower
+}
+
+struct DigitsMap {
+    let digits: [String]
+    let tens: [String]
+    let hundreds: [String]
+    let thousands: [String]
+}
+
+extension RomanNumbersStyle {
+    var digitsMap: DigitsMap {
+        switch self {
+        case .alphabets:
+            DigitsMap(
+                digits: ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX"],
+                tens: ["", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC"],
+                hundreds: ["", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM"],
+                thousands: ["", "M", "MM", "MMM"])
+        case .fullWidthUpper:
+            DigitsMap(
+                digits: ["", "Ⅰ", "Ⅱ", "Ⅲ", "Ⅳ", "Ⅴ", "Ⅵ", "Ⅶ", "Ⅷ", "Ⅸ"],
+                tens: ["", "Ⅹ", "ⅩⅩ", "ⅩⅩⅩ", "ⅩⅬ", "Ⅼ", "ⅬⅩ", "ⅬⅩⅩ", "ⅬⅩⅩⅩ", "ⅩⅭ"],
+                hundreds: ["", "Ⅽ", "ⅭⅭ", "ⅭⅭⅭ", "ⅭⅮ", "Ⅾ", "ⅮⅭ", "ⅮⅭⅭ", "ⅮⅭⅭⅭ", "ⅭⅯ"],
+                thousands: ["", "Ⅿ", "ⅯⅯ", "ⅯⅯⅯ"])
+        case .fullWidthLower:
+            DigitsMap(
+                digits: ["", "ⅰ", "ⅱ", "ⅲ", "ⅳ", "ⅴ", "ⅵ", "ⅶ", "ⅷ", "ⅸ"],
+                tens: ["", "ⅹ", "ⅹⅹ", "ⅹⅹⅹ", "ⅹⅼ", "ⅼ", "ⅼⅹ", "ⅼⅹⅹ", "ⅼⅹⅹⅹ", "ⅹⅽ"],
+                hundreds: ["", "ⅽ", "ⅽⅽ", "ⅽⅽⅽ", "ⅽⅾ", "ⅾ", "ⅾⅽ", "ⅾⅽⅽ", "ⅾⅽⅽⅽ", "ⅽⅿ"],
+                thousands: ["", "ⅿ", "ⅿⅿ", "ⅿⅿⅿ"])
+        }
+    }
+}
+
+@objc
+public class RomanNumbers: NSObject {
+    @objc(convertWithInt:style:error:)
+    public static func convert(input: Int, style: RomanNumbersStyle = .alphabets) throws -> String {
+        if input > 3999 {
+            throw RomanNumbersErrors.tooLarge
+        }
+        if input < 0 {
+            throw RomanNumbersErrors.tooSmall
+        }
+
+        if style == .fullWidthUpper {
+            switch input {
+            case 11:
+                return "Ⅺ"
+            case 12:
+                return "Ⅻ"
+            default:
+                break
+            }
+        }
+
+        if style == .fullWidthLower {
+            switch input {
+            case 11:
+                return "ⅺ"
+            case 12:
+                return "ⅻ"
+            default:
+                break
+            }
+
+        }
+
+        let thou = input / 1000
+        let hund = (input % 1000) / 100
+        let ten = (input % 100) / 10
+        let digit = input % 10
+
+        let map = style.digitsMap
+
+        let result = map.thousands[thou] + map.hundreds[hund] + map.tens[ten] + map.digits[digit]
+        return result
+    }
+
+    @objc(convertWithString:style:error:)
+    public static func convert(string: String, style: RomanNumbersStyle = .alphabets) throws
+        -> String
+    {
+        guard let number = Int(string) else {
+            throw RomanNumbersErrors.invalidInput
+        }
+        return try convert(input: number, style: style)
+    }
+}

--- a/Packages/RomanNumbers/Tests/RomanNumbersTests/RomanNumbersTests.swift
+++ b/Packages/RomanNumbers/Tests/RomanNumbersTests/RomanNumbersTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import RomanNumbers
+
+@Suite("RomanNumbersTests")
+struct RomanNumbersTests {
+
+    @Test("Test alphabets",  arguments: [
+        ("0", ""),
+        ("1", "I"),
+        ("3999", "MMMCMXCIX"),
+        ("2000", "MM"),
+        ("2025", "MMXXV")
+    ]) func test(input: String, expected: String ) async throws {
+        let output = try RomanNumbers.convert(string: input)
+        #expect(output == expected)
+    }
+
+    @Test("Test Upper cased",  arguments: [
+        ("0", ""),
+        ("1", "Ⅰ"),
+        ("3999", "ⅯⅯⅯⅭⅯⅩⅭⅨ"),
+        ("2000", "ⅯⅯ"),
+        ("2025", "ⅯⅯⅩⅩⅤ")
+    ]) func testUpperCase(input: String, expected: String ) async throws {
+        let output = try RomanNumbers.convert(string: input, style: .fullWidthUpper)
+        #expect(output == expected)
+    }
+
+    @Test("Test Lower cased",  arguments: [
+        ("0", ""),
+        ("1", "ⅰ"),
+        ("3999", "ⅿⅿⅿⅽⅿⅹⅽⅸ"),
+        ("2000", "ⅿⅿ"),
+        ("2025", "ⅿⅿⅹⅹⅴ")
+    ]) func testLowerCase(input: String, expected: String ) async throws {
+        let output = try RomanNumbers.convert(string: input, style: .fullWidthLower)
+        #expect(output == expected)
+    }
+
+}

--- a/Packages/RomanNumbers/Tests/RomanNumbersTests/RomanNumbersTests.swift
+++ b/Packages/RomanNumbers/Tests/RomanNumbersTests/RomanNumbersTests.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import Testing
 @testable import RomanNumbers
 

--- a/Source/Base.lproj/Localizable.strings
+++ b/Source/Base.lproj/Localizable.strings
@@ -132,3 +132,9 @@
 "Do you want to boost the score of the phrase \"%@\"?" = "Do you want to boost the score of the phrase \"%@\"?";
 
 "Do you want to exclude the phrase \"%@\"?" = "Do you want to exclude the phrase \"%@\"?";
+
+"Roman Numbers (Alphabets)" = "Roman Numbers (Alphabets)";
+
+"Roman Numbers (Full-width Upper Case)" = "Roman Numbers (Full-width Upper Case)";
+
+"Roman Numbers (Full-width Lower Case)" = "Roman Numbers (Full-width Lower Case)";

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24128" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24128"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="401" y="295" width="475" height="567"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1049"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="475" height="567"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -36,12 +36,12 @@
             <point key="canvasLocation" x="138" y="349"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="32"/>
-        <view autoresizesSubviews="NO" misplaced="YES" id="YEO-Nr-Xri">
+        <view autoresizesSubviews="NO" id="YEO-Nr-Xri">
             <rect key="frame" x="0.0" y="0.0" width="478" height="576"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
-                    <rect key="frame" x="46" y="534" width="176" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
+                    <rect key="frame" x="45" y="534" width="176" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bopomofo Keyboard Layout:" id="VTD-h6-q9r">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -49,7 +49,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cb1-du-5Jn">
-                    <rect key="frame" x="229" y="492" width="224" height="25"/>
+                    <rect key="frame" x="232" y="492" width="216" height="24"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="n2z-u9-T3b">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -62,8 +62,8 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="mjl-uI-U8T"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
-                    <rect key="frame" x="25" y="496" width="197" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
+                    <rect key="frame" x="24" y="496" width="197" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric Keyboard Layout:" id="cTl-dv-9gx">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -71,7 +71,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Nma-j4-skB">
-                    <rect key="frame" x="230" y="410" width="206" height="18"/>
+                    <rect key="frame" x="232" y="411" width="202" height="16"/>
                     <buttonCell key="cell" type="check" title="Space key chooses candidate" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="07b-85-YOF">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -80,8 +80,8 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="Z1u-Xj-5q7"/>
                     </connections>
                 </button>
-                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
-                    <rect key="frame" x="231" y="437" width="221" height="23"/>
+                <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
+                    <rect key="frame" x="232" y="435" width="217" height="24"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="217" id="MSj-4R-AdD"/>
                     </constraints>
@@ -99,8 +99,8 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="dwv-UP-fcW"/>
                     </connections>
                 </comboBox>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
-                    <rect key="frame" x="125" y="443" width="97" height="16"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
+                    <rect key="frame" x="124" y="443" width="97" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Selection Keys:" id="5RC-uF-JMe">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -108,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
-                    <rect key="frame" x="229" y="526" width="118" height="25"/>
+                    <rect key="frame" x="232" y="526" width="124" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Standard" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="PTu-Ks-u1l" id="tPE-G4-rho">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -128,7 +128,7 @@
                     </popUpButtonCell>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
-                    <rect key="frame" x="230" y="95" width="229" height="18"/>
+                    <rect key="frame" x="232" y="96" width="225" height="16"/>
                     <buttonCell key="cell" type="check" title="ESC key clears entire input buffer" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="04m-pr-CAi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -137,24 +137,24 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="uBc-h3-Lqq"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
-                    <rect key="frame" x="70" y="385" width="152" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
+                    <rect key="frame" x="69" y="385" width="152" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Candidate Phrase:" id="Old-PI-MEs">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
-                    <rect key="frame" x="94" y="272" width="129" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
+                    <rect key="frame" x="93" y="272" width="129" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate List Style:" id="Xj4-f5-50V">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
-                    <rect key="frame" x="94" y="224" width="128" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
+                    <rect key="frame" x="93" y="224" width="128" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -187,7 +187,7 @@
                     </connections>
                 </matrix>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
-                    <rect key="frame" x="229" y="217" width="56" height="25"/>
+                    <rect key="frame" x="232" y="217" width="62" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="64X-UF-Vz6" id="Bsy-hs-5q4">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -209,13 +209,13 @@
                     </connections>
                 </popUpButton>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="wIs-KO-qx1">
-                    <rect key="frame" x="20" y="475" width="439" height="5"/>
+                    <rect key="frame" x="20" y="475" width="438" height="5"/>
                 </box>
                 <box horizontalHuggingPriority="234" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
-                    <rect key="frame" x="20" y="206" width="446" height="5"/>
+                    <rect key="frame" x="20" y="206" width="445" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
-                    <rect key="frame" x="230" y="338" width="192" height="18"/>
+                    <rect key="frame" x="232" y="339" width="188" height="16"/>
                     <buttonCell key="cell" type="check" title="Move cursor after selection" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="SK6-0h-omu">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -224,8 +224,8 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="Jra-P0-jp5"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
-                    <rect key="frame" x="102" y="178" width="120" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
+                    <rect key="frame" x="101" y="178" width="120" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -257,8 +257,8 @@
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="YP4-Tc-T1I"/>
                     </connections>
                 </matrix>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
-                    <rect key="frame" x="163" y="96" width="59" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
+                    <rect key="frame" x="162" y="96" width="59" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -291,7 +291,7 @@
                     </connections>
                 </matrix>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="cRR-T6-aMw">
-                    <rect key="frame" x="230" y="56" width="159" height="18"/>
+                    <rect key="frame" x="232" y="57" width="155" height="16"/>
                     <buttonCell key="cell" type="check" title="Beep upon input error" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="rnd-fr-0dm">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -301,7 +301,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PLL-ab-6cC">
-                    <rect key="frame" x="230" y="129" width="190" height="18"/>
+                    <rect key="frame" x="232" y="130" width="186" height="16"/>
                     <buttonCell key="cell" type="check" title="Trigger associated phrases" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="AOR-n6-Tmp">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -310,16 +310,16 @@
                         <binding destination="32" name="value" keyPath="values.ShiftEnterEnabled" id="RyW-HU-SUL"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
-                    <rect key="frame" x="113" y="130" width="109" height="16"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
+                    <rect key="frame" x="112" y="130" width="109" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter Key:" id="H9E-f1-tBt">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MdX-1s-2eC">
-                    <rect key="frame" x="46" y="311" width="175" height="16"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MdX-1s-2eC">
+                    <rect key="frame" x="45" y="311" width="175" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="When Selecting Candidates:" id="wkY-8D-tZm">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -327,7 +327,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xg9-aU-XIb">
-                    <rect key="frame" x="229" y="302" width="212" height="25"/>
+                    <rect key="frame" x="232" y="302" width="218" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Moving cursor is not allowed" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bmM-mL-c3L" id="ymc-ph-WCL">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -344,7 +344,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
-                    <rect key="frame" x="230" y="34" width="222" height="18"/>
+                    <rect key="frame" x="232" y="35" width="218" height="16"/>
                     <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="W90-DF-5t4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -436,7 +436,7 @@
             <rect key="frame" x="0.0" y="0.0" width="478" height="214"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
                     <rect key="frame" x="74" y="178" width="163" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Chinese Conversion Style:" id="cMO-Ss-Jar">
                         <font key="font" metaFont="system"/>
@@ -445,9 +445,9 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xwt-fe-fQG">
-                    <rect key="frame" x="243" y="156" width="216" height="38"/>
+                    <rect key="frame" x="243" y="156" width="218" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    <size key="cellSize" width="216" height="18"/>
+                    <size key="cellSize" width="218" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
                     <buttonCell key="prototype" type="radio" title="Radio" imagePosition="left" alignment="left" inset="2" id="ojf-1B-dTG">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -470,7 +470,7 @@
                     </connections>
                 </matrix>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NGh-Dn-Qpf">
-                    <rect key="frame" x="242" y="99" width="128" height="18"/>
+                    <rect key="frame" x="246" y="100" width="124" height="16"/>
                     <buttonCell key="cell" type="check" title="Input Big 5 Code" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9wE-js-xtM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -479,7 +479,7 @@
                         <binding destination="32" name="value" keyPath="values.Big5InputEnabled" id="0sV-29-JVt"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
                     <rect key="frame" x="134" y="130" width="103" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + Enter Key:" id="lrz-7F-6e5">
                         <font key="font" metaFont="system"/>
@@ -487,7 +487,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
                     <rect key="frame" x="156" y="100" width="81" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + `  Key:" id="F6Q-1k-YTn">
                         <font key="font" metaFont="system"/>
@@ -495,7 +495,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
                     <rect key="frame" x="102" y="72" width="136" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="132" id="TLl-fl-TAQ"/>
@@ -507,7 +507,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I7Q-TH-9oP">
-                    <rect key="frame" x="242" y="71" width="217" height="18"/>
+                    <rect key="frame" x="246" y="72" width="213" height="16"/>
                     <buttonCell key="cell" type="check" title="Repeated key to next candidate" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sze-kb-iDT">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -516,7 +516,7 @@
                         <binding destination="32" name="value" keyPath="values.RepeatedPunctuationToSelectCandidateEnabled" id="lgT-7e-2ai"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
                     <rect key="frame" x="241" y="22" width="219" height="42"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="215" id="748-J5-BGk"/>
@@ -528,7 +528,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sHq-Tf-8nD">
-                    <rect key="frame" x="242" y="122" width="221" height="25"/>
+                    <rect key="frame" x="247" y="122" width="212" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Off" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bAf-tJ-tnK" id="dl4-pi-p7L">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -579,7 +579,7 @@
             <rect key="frame" x="0.0" y="0.0" width="477" height="329"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
                     <rect key="frame" x="18" y="293" width="137" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="User Phrase Location:" id="Sc6-Rd-pOy">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -588,7 +588,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z8D-qk-sAN">
-                    <rect key="frame" x="17" y="252" width="86" height="25"/>
+                    <rect key="frame" x="20" y="252" width="92" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Default" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="avu-Uo-JGI" id="Kln-Ca-WBd">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -607,8 +607,8 @@
                         <action selector="changeCustomUserPhraseLocationEnabledAction:" target="-2" id="fUI-Z1-8Cg"/>
                     </connections>
                 </popUpButton>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
-                    <rect key="frame" x="111" y="256" width="306" height="21"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
+                    <rect key="frame" x="124" y="252" width="293" height="25"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="6kS-fE-Kz7">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -619,8 +619,8 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="liS-L1-RTD"/>
                     </connections>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
-                    <rect key="frame" x="20" y="174" width="439" height="28"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
+                    <rect key="frame" x="20" y="170" width="439" height="28"/>
                     <textFieldCell key="cell" id="Vz3-KS-1rk">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">You can specify the folder to store user phrases to the folder of Google Drive, DropBox and so on so you can backup the phrases.</string>
@@ -629,7 +629,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dY1-Wz-mrw">
-                    <rect key="frame" x="425" y="256" width="32" height="20"/>
+                    <rect key="frame" x="425" y="252" width="32" height="24"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSFolder" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="cyL-Sf-xhj">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -640,7 +640,7 @@
                     </connections>
                 </button>
                 <button horizontalHuggingPriority="249" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="OKJ-84-kIv">
-                    <rect key="frame" x="111" y="231" width="346" height="21"/>
+                    <rect key="frame" x="124" y="227" width="333" height="21"/>
                     <buttonCell key="cell" type="bevel" title="Button" bezelStyle="rounded" imagePosition="overlaps" alignment="left" controlSize="small" imageScaling="proportionallyDown" inset="2" id="wCH-YR-bl5">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -650,10 +650,10 @@
                     </connections>
                 </button>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5ce-rm-tsn">
-                    <rect key="frame" x="20" y="151" width="433" height="5"/>
+                    <rect key="frame" x="20" y="147" width="433" height="5"/>
                 </box>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
-                    <rect key="frame" x="18" y="117" width="437" height="16"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
+                    <rect key="frame" x="18" y="113" width="437" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="After Adding a New Phrase:" id="wGR-0A-cqv">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -661,7 +661,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="LVc-PG-N32">
-                    <rect key="frame" x="18" y="86" width="251" height="18"/>
+                    <rect key="frame" x="20" y="83" width="249" height="16"/>
                     <buttonCell key="cell" type="check" title="Run a shell script" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="DaH-1b-AEw">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -670,8 +670,8 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookEnabled" id="DFg-tK-bEf"/>
                     </connections>
                 </button>
-                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
-                    <rect key="frame" x="62" y="57" width="391" height="21"/>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
+                    <rect key="frame" x="62" y="57" width="391" height="24"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Sbq-JE-A4U">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -681,15 +681,15 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookPath" id="IJd-KL-Ytn"/>
                     </connections>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
-                    <rect key="frame" x="20" y="57" width="36" height="16"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
+                    <rect key="frame" x="20" y="59" width="36" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Path:" id="ZY3-98-BrK">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
                     <rect key="frame" x="20" y="20" width="439" height="28"/>
                     <textFieldCell key="cell" title="You can run a script to use git to backup your phrases. The script will run in the folder of your user phrases folder." id="byk-Br-x2Z">
                         <font key="font" metaFont="smallSystem"/>

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -354,6 +354,8 @@ extension McBopomofoInputMethodController {
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.ChineseNumber:
             handle(state: newState, previous: previous, client: client)
+        case let newState as InputState.RomanNumber:
+            handle(state: newState, previous: previous, client: client)
         case let newState as InputState.EnclosedNumber:
             handle(state: newState, previous: previous, client: client)
         case let newState as InputState.Big5:
@@ -600,6 +602,22 @@ extension McBopomofoInputMethodController {
     }
 
     private func handle(state: InputState.ChineseNumber, previous: InputState, client: Any?) {
+        gCurrentCandidateController?.visible = false
+        hideTooltip()
+
+        guard let client = client as? IMKTextInput else {
+            return
+        }
+
+        if let previous = previous as? InputState.NotEmpty {
+            commit(text: previous.composingBuffer, client: client)
+        }
+        client.setMarkedText(
+            state.composingBuffer, selectionRange: NSMakeRange(state.composingBuffer.count, 0),
+            replacementRange: NSMakeRange(NSNotFound, NSNotFound))
+    }
+
+    private func handle(state: InputState.RomanNumber, previous: InputState, client: Any?) {
         gCurrentCandidateController?.visible = false
         hideTooltip()
 

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -137,7 +137,7 @@ class InputState: NSObject {
             ),
             (
                 NSLocalizedString("Roman Numbers (Alphabets)", comment: ""),
-                { .RomanNumber(style: .alphabet , number: "") }
+                { .RomanNumber(style: .alphabets , number: "") }
             ),
             (
                 NSLocalizedString("Roman Numbers (Full-width Upper Case)", comment: ""),
@@ -265,13 +265,13 @@ class InputState: NSObject {
     class RomanNumber: InputState {
         @objc(InputStateRomanNumberStyle)
         enum Style: Int {
-            case alphabet = 0
+            case alphabets = 0
             case fullWidthUpper = 1
             case fullWidthLower = 2
 
             var label: String {
                 switch self {
-                case .alphabet:
+                case .alphabets:
                     "羅馬數字 (字母)"
                 case .fullWidthUpper:
                     "羅馬數字 (大寫全型)"

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -274,9 +274,9 @@ class InputState: NSObject {
                 case .alphabets:
                     "羅馬數字 (字母)"
                 case .fullWidthUpper:
-                    "羅馬數字 (大寫全型)"
+                    "羅馬數字 (大寫全形)"
                 case .fullWidthLower:
-                    "羅馬數字 (小寫全型)"
+                    "羅馬數字 (小寫全形)"
                 }
             }
         }

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -135,6 +135,18 @@ class InputState: NSObject {
                 NSLocalizedString("Suzhou Numbers", comment: ""),
                 { .ChineseNumber(style: .suzhou, number: "") }
             ),
+            (
+                NSLocalizedString("Roman Numbers (Alphabets)", comment: ""),
+                { .RomanNumber(style: .alphabet , number: "") }
+            ),
+            (
+                NSLocalizedString("Roman Numbers (Full-width Upper Case)", comment: ""),
+                { .RomanNumber(style: .fullWidthUpper, number: "") }
+            ),
+            (
+                NSLocalizedString("Roman Numbers (Full-width Lower Case)", comment: ""),
+                { .RomanNumber(style: .fullWidthLower, number: "") }
+            ),
         ]
 
         override var description: String {
@@ -248,6 +260,44 @@ class InputState: NSObject {
             return "[\(style.label)] \(number)"
         }
     }
+
+    @objc(InputStateRomanNumber)
+    class RomanNumber: InputState {
+        @objc(InputStateRomanNumberStyle)
+        enum Style: Int {
+            case alphabet = 0
+            case fullWidthUpper = 1
+            case fullWidthLower = 2
+
+            var label: String {
+                switch self {
+                case .alphabet:
+                    "羅馬數字 (字母)"
+                case .fullWidthUpper:
+                    "羅馬數字 (大寫全型)"
+                case .fullWidthLower:
+                    "羅馬數字 (小寫全型)"
+                }
+            }
+        }
+
+        @objc private(set) var number: String
+        @objc private(set) var style: Style
+
+        @objc init(style: Style, number: String) {
+            self.style = style
+            self.number = number
+        }
+
+        override var description: String {
+            "<InputState.RomanNumber, style:\(style), number:\(number)>"
+        }
+
+        @objc public var composingBuffer: String {
+            return "[\(style.label)] \(number)"
+        }
+    }
+
 
     @objc(InputStateBig5)
     class Big5: InputState {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1987,8 +1987,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
+    const int MAX_ROMAN_NUMBER_LENGTH = 4;
     if (charCode >= '0' && charCode <= '9') {
-        if (numberState.number.length > 3) {
+        if (numberState.number.length >= MAX_ROMAN_NUMBER_LENGTH) {
             errorCallback();
             return YES;
         }

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1344,16 +1344,16 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         isCursorMovingRight = input.isRight;
     } else {
         switch (Preferences.allowMovingCursorWhenChoosingCandidates) {
-        case MovingCursorKeyUseJK:
-            isCursorMovingLeft = [input.inputText isEqualToString:@"j"];
-            isCursorMovingRight = [input.inputText isEqualToString:@"k"];
-            break;
-        case MovingCursorKeyUseHL:
-            isCursorMovingLeft = [input.inputText isEqualToString:@"h"];
-            isCursorMovingRight = [input.inputText isEqualToString:@"l"];
-            break;
-        default:
-            break;
+            case MovingCursorKeyUseJK:
+                isCursorMovingLeft = [input.inputText isEqualToString:@"j"];
+                isCursorMovingRight = [input.inputText isEqualToString:@"k"];
+                break;
+            case MovingCursorKeyUseHL:
+                isCursorMovingLeft = [input.inputText isEqualToString:@"h"];
+                isCursorMovingRight = [input.inputText isEqualToString:@"l"];
+                break;
+            default:
+                break;
         }
     }
 
@@ -1425,39 +1425,39 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             if (isPlusKey) {
                 InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"")
                                                                                            callback:^{
-                                                                                               __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                                                               if (!strongSelf) {
-                                                                                                   return;
-                                                                                               }
-                                                                                               [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
-                                                                                               [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                                                                                               [strongSelf _walk];
-                                                                                               InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                                                                                               stateCallback(inputting);
-                                                                                           }];
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    stateCallback(inputting);
+                }];
                 [entries addObject:boost];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             } else if (isMinusKey) {
                 InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"")
                                                                                              callback:^{
-                                                                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                                                                 if (!strongSelf) {
-                                                                                                     return;
-                                                                                                 }
-                                                                                                 [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
-                                                                                                 [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                                                                                                 [strongSelf _walk];
-                                                                                                 InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                                                                                                 stateCallback(inputting);
-                                                                                             }];
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    stateCallback(inputting);
+                }];
                 [entries addObject:exclude];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             }
             InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"")
                                                                                         callback:^{
-                                                                                            stateCallback(currentState);
-                                                                                            gCurrentCandidateController.selectedCandidateIndex = index;
-                                                                                        }];
+                stateCallback(currentState);
+                gCurrentCandidateController.selectedCandidateIndex = index;
+            }];
             [entries addObject:cancel];
 
             InputStateCustomMenu *confirm = [[InputStateCustomMenu alloc] initWithComposingBuffer:[currentState composingBuffer] cursorIndex:[currentState cursorIndex] title:title entries:entries previousState:currentState selectedIndex:index];
@@ -1602,16 +1602,16 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     isPageDown = charCode == 32 || input.isPageDown || input.emacsKey == McBopomofoEmacsKeyNextPage;
     isPageUp = input.isPageUp;
     switch (Preferences.allowMovingCursorWhenChoosingCandidates) {
-    case MovingCursorKeyUseJK:
-        isPageDown = isPageDown || [input.inputText isEqualToString:@"l"];
-        isPageUp = isPageUp || [input.inputText isEqualToString:@"h"];
-        break;
-    case MovingCursorKeyUseHL:
-        isPageDown = isPageDown || [input.inputText isEqualToString:@"k"];
-        isPageUp = isPageUp || [input.inputText isEqualToString:@"j"];
-        break;
-    default:
-        break;
+        case MovingCursorKeyUseJK:
+            isPageDown = isPageDown || [input.inputText isEqualToString:@"l"];
+            isPageUp = isPageUp || [input.inputText isEqualToString:@"h"];
+            break;
+        case MovingCursorKeyUseHL:
+            isPageDown = isPageDown || [input.inputText isEqualToString:@"k"];
+            isPageUp = isPageUp || [input.inputText isEqualToString:@"j"];
+            break;
+        default:
+            break;
     }
 
     if (isPageDown) {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1344,20 +1344,20 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         isCursorMovingRight = input.isRight;
     } else {
         switch (Preferences.allowMovingCursorWhenChoosingCandidates) {
-            case MovingCursorKeyUseJK:
-                isCursorMovingLeft = [input.inputText isEqualToString:@"j"];
-                isCursorMovingRight = [input.inputText isEqualToString:@"k"];
-                break;
-            case MovingCursorKeyUseHL:
-                isCursorMovingLeft = [input.inputText isEqualToString:@"h"];
-                isCursorMovingRight = [input.inputText isEqualToString:@"l"];
-                break;
-            default:
-                break;
+        case MovingCursorKeyUseJK:
+            isCursorMovingLeft = [input.inputText isEqualToString:@"j"];
+            isCursorMovingRight = [input.inputText isEqualToString:@"k"];
+            break;
+        case MovingCursorKeyUseHL:
+            isCursorMovingLeft = [input.inputText isEqualToString:@"h"];
+            isCursorMovingRight = [input.inputText isEqualToString:@"l"];
+            break;
+        default:
+            break;
         }
     }
 
-    if ([state isKindOfClass:[InputStateChoosingCandidate class]] && (isCursorMovingLeft || isCursorMovingRight) ) {
+    if ([state isKindOfClass:[InputStateChoosingCandidate class]] && (isCursorMovingLeft || isCursorMovingRight)) {
         if (isCursorMovingLeft) {
             size_t cursor = _grid->cursor();
             if (cursor > 0) {
@@ -1425,37 +1425,39 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             if (isPlusKey) {
                 InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"")
                                                                                            callback:^{
-                    __strong __typeof(weakSelf) strongSelf = weakSelf;
-                    if (!strongSelf) {
-                        return;
-                    }
-                    [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
-                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                    [strongSelf _walk];
-                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                    stateCallback(inputting);
-                }];
+                                                                                               __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                                                                               if (!strongSelf) {
+                                                                                                   return;
+                                                                                               }
+                                                                                               [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
+                                                                                               [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                                                                                               [strongSelf _walk];
+                                                                                               InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                                                                                               stateCallback(inputting);
+                                                                                           }];
                 [entries addObject:boost];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             } else if (isMinusKey) {
-                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"") callback:^{
-                    __strong __typeof(weakSelf) strongSelf = weakSelf;
-                    if (!strongSelf) {
-                        return;
-                    }
-                    [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
-                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                    [strongSelf _walk];
-                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                    stateCallback(inputting);
-                }];
+                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"")
+                                                                                             callback:^{
+                                                                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                                                                                 if (!strongSelf) {
+                                                                                                     return;
+                                                                                                 }
+                                                                                                 [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
+                                                                                                 [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                                                                                                 [strongSelf _walk];
+                                                                                                 InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                                                                                                 stateCallback(inputting);
+                                                                                             }];
                 [entries addObject:exclude];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             }
-            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") callback:^{
-                stateCallback(currentState);
-                gCurrentCandidateController.selectedCandidateIndex = index;
-            }];
+            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"")
+                                                                                        callback:^{
+                                                                                            stateCallback(currentState);
+                                                                                            gCurrentCandidateController.selectedCandidateIndex = index;
+                                                                                        }];
             [entries addObject:cancel];
 
             InputStateCustomMenu *confirm = [[InputStateCustomMenu alloc] initWithComposingBuffer:[currentState composingBuffer] cursorIndex:[currentState cursorIndex] title:title entries:entries previousState:currentState selectedIndex:index];
@@ -1600,16 +1602,16 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     isPageDown = charCode == 32 || input.isPageDown || input.emacsKey == McBopomofoEmacsKeyNextPage;
     isPageUp = input.isPageUp;
     switch (Preferences.allowMovingCursorWhenChoosingCandidates) {
-        case MovingCursorKeyUseJK:
-            isPageDown = isPageDown || [input.inputText isEqualToString:@"l"];
-            isPageUp = isPageUp || [input.inputText isEqualToString:@"h"];
-            break;
-        case MovingCursorKeyUseHL:
-            isPageDown = isPageDown || [input.inputText isEqualToString:@"k"];
-            isPageUp = isPageUp || [input.inputText isEqualToString:@"j"];
-            break;
-        default:
-            break;
+    case MovingCursorKeyUseJK:
+        isPageDown = isPageDown || [input.inputText isEqualToString:@"l"];
+        isPageUp = isPageUp || [input.inputText isEqualToString:@"h"];
+        break;
+    case MovingCursorKeyUseHL:
+        isPageDown = isPageDown || [input.inputText isEqualToString:@"k"];
+        isPageUp = isPageUp || [input.inputText isEqualToString:@"j"];
+        break;
+    default:
+        break;
     }
 
     if (isPageDown) {
@@ -1852,7 +1854,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (charCode == 13) {
-        if (!numberState.number.count) {
+        if (!numberState.number.length) {
             InputStateEmpty *empty = [[InputStateEmpty alloc] init];
             stateCallback(empty);
             return YES;
@@ -1924,9 +1926,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 }
 
 - (BOOL)_handleRomanNumberState:(InputState *)state
-                     input:(KeyHandlerInput *)input
-             stateCallback:(void (^)(InputState *))stateCallback
-             errorCallback:(void (^)(void))errorCallback;
+                          input:(KeyHandlerInput *)input
+                  stateCallback:(void (^)(InputState *))stateCallback
+                  errorCallback:(void (^)(void))errorCallback;
 {
     InputStateRomanNumber *numberState = (InputStateRomanNumber *)state;
     UniChar charCode = input.charCode;
@@ -1950,7 +1952,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (charCode == 13) {
-        if (!numberState.number.count) {
+        if (!numberState.number.length) {
             InputStateEmpty *empty = [[InputStateEmpty alloc] init];
             stateCallback(empty);
             return YES;
@@ -1959,17 +1961,17 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         RomanNumbersStyle style = RomanNumbersStyleAlphabets;
 
         switch (numberState.style) {
-            case InputStateRomanNumberStyleAlphabet:
-                style = RomanNumbersStyleAlphabets;
-                break;
-            case InputStateRomanNumberStyleFullWidthUpper:
-                style = RomanNumbersStyleFullWidthUpper;
-                break;
-            case InputStateRomanNumberStyleFullWidthLower:
-                style = RomanNumbersStyleFullWidthLower;
-                break;
-            default:
-                break;
+        case InputStateRomanNumberStyleAlphabets:
+            style = RomanNumbersStyleAlphabets;
+            break;
+        case InputStateRomanNumberStyleFullWidthUpper:
+            style = RomanNumbersStyleFullWidthUpper;
+            break;
+        case InputStateRomanNumberStyleFullWidthLower:
+            style = RomanNumbersStyleFullWidthLower;
+            break;
+        default:
+            break;
         }
 
         NSError *error = nil;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1992,7 +1992,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             errorCallback();
             return YES;
         }
-        NSString *appended = [NSString stringWithFormat:@"%@%c", numberState.number, toupper(charCode)];
+        NSString *appended = [NSString stringWithFormat:@"%@%c", numberState.number, charCode];
         InputStateRomanNumber *newState = [[InputStateRomanNumber alloc] initWithStyle:numberState.style number:appended];
         stateCallback(newState);
     } else {

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -135,3 +135,8 @@
 
 "Do you want to exclude the phrase \"%@\"?" = "Do you want to exclude the phrase \"%@\"?";
 
+"Roman Numbers (Alphabets)" = "Roman Numbers (Alphabets)";
+
+"Roman Numbers (Full-width Upper Case)" = "Roman Numbers (Full-width Upper Case)";
+
+"Roman Numbers (Full-width Lower Case)" = "Roman Numbers (Full-width Lower Case)";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -135,6 +135,6 @@
 
 "Roman Numbers (Alphabets)" = "羅馬數字 (字母)";
 
-"Roman Numbers (Full-width Upper Case)" = "羅馬數字 (大寫全型)";
+"Roman Numbers (Full-width Upper Case)" = "羅馬數字 (大寫全形)";
 
-"Roman Numbers (Full-width Lower Case)" = "羅馬數字 (小寫全型)";
+"Roman Numbers (Full-width Lower Case)" = "羅馬數字 (小寫全形)";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -132,3 +132,9 @@
 "Do you want to boost the score of the phrase \"%@\"?" = "您想要提升 \"%@\" 這個詞彙的權重嗎？";
 
 "Do you want to exclude the phrase \"%@\"?" = "您想要從詞庫中排除 \"%@\" 這個詞彙嗎？";
+
+"Roman Numbers (Alphabets)" = "羅馬數字 (字母)";
+
+"Roman Numbers (Full-width Upper Case)" = "羅馬數字 (大寫全型)";
+
+"Roman Numbers (Full-width Lower Case)" = "羅馬數字 (小寫全型)";


### PR DESCRIPTION
The PR adds Roman number input support. A user can launch the feature by pressing Ctrl + \

The PR supports three conversion styles

- Alphabets: Convert 2025 to MMXXV
- Full-width upper case: Convert 2025 to ⅯⅯⅩⅩⅤ
- Full-width lower case: Convert 2025 to ⅿⅿⅹⅹⅴ