### PR TITLE
fix(cmake): update CMakeLists.txt after KeyValueBlobReader refactor in PR #722

### DIFF
--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -10,8 +10,8 @@ add_subdirectory(Mandarin)
 add_library(McBopomofoLMLib
         AssociatedPhrasesV2.h
         AssociatedPhrasesV2.cpp
-        KeyValueBlobReader.h
-        KeyValueBlobReader.cpp
+        ByteBlockBackedDictionary.h
+        ByteBlockBackedDictionary.cpp
         McBopomofoLM.h
         McBopomofoLM.cpp
         MemoryMappedFile.h
@@ -59,7 +59,7 @@ if (ENABLE_TEST)
         # Test target declarations.
         add_executable(McBopomofoLMLibTest
                 AssociatedPhrasesV2Test.cpp
-                KeyValueBlobReaderTest.cpp
+                ByteBlockBackedDictionaryTest.cpp
                 McBopomofoLMTest.cpp
                 MemoryMappedFileTest.cpp
                 ParselessLMTest.cpp


### PR DESCRIPTION
### **User description**
## Summary

Fixes the CMake build failure caused by PR #722 where files were renamed but CMakeLists.txt was not updated.

## Problem

PR #722 (commit 18beb93) renamed several files:
- `KeyValueBlobReader.{h,cpp}` → `ByteBlockBackedDictionary.{h,cpp}`
- `KeyValueBlobReaderTest.cpp` → `ByteBlockBackedDictionaryTest.cpp`

The Xcode project file was updated correctly, but `Source/Engine/CMakeLists.txt` was not, causing GitHub Actions build failures:

```
CMake Error at CMakeLists.txt:10 (add_library):
  Cannot find source file: KeyValueBlobReader.h

CMake Error at CMakeLists.txt:60 (add_executable):
  Cannot find source file: KeyValueBlobReaderTest.cpp
```

## Changes

Updated `Source/Engine/CMakeLists.txt`:
- Lines 13-14: Replaced `KeyValueBlobReader.{h,cpp}` with `ByteBlockBackedDictionary.{h,cpp}` in `add_library()`
- Line 62: Replaced `KeyValueBlobReaderTest.cpp` with `ByteBlockBackedDictionaryTest.cpp` in `add_executable()`

## Test Plan

- [x] Updated CMakeLists.txt to reference correct filenames
- [ ] GitHub Actions workflows pass (will be verified by CI)

## References

- Related to PR #722 (Sync engine code with fcitx5-mcbopomofo)
- Fixes the build failure visible in https://github.com/openvanilla/McBopomofo/actions/runs/18994262573

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix CMake targets referencing renamed files

- Update library sources to new dictionary

- Update test sources to new filenames

- Restore CI build by correcting paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CMakeLists.txt (Engine)"] -- "replace sources" --> B["KeyValueBlobReader.* → ByteBlockBackedDictionary.*"]
  A -- "replace test source" --> C["KeyValueBlobReaderTest.cpp → ByteBlockBackedDictionaryTest.cpp"]
  B -- "fix build" --> D["McBopomofoLMLib"]
  C -- "fix build" --> E["McBopomofoLMLibTest"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Update CMake sources to renamed dictionary files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Engine/CMakeLists.txt

<ul><li>Replace <code>KeyValueBlobReader.{h,cpp}</code> with <br><code>ByteBlockBackedDictionary.{h,cpp}</code> in library sources.<br> <li> Replace <code>KeyValueBlobReaderTest.cpp</code> with <br><code>ByteBlockBackedDictionaryTest.cpp</code> in test executable.<br> <li> Ensure targets <code>McBopomofoLMLib</code> and <code>McBopomofoLMLibTest</code> have valid <br>sources.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/723/files#diff-26727d0b317c91e6de7871cd43032062a0b9f156744b6b06d8afd3d89e34d327">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

