### PR TITLE
ci: fix CodeQL build failures by using correct Python version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,11 +55,6 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: '3.12'
-
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,11 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
@@ -64,7 +69,7 @@ jobs:
     - name: Build project
       if: matrix.language == 'swift' || matrix.language == 'cpp'
       run: |
-        xcodebuild -scheme McBopomofoInstaller -configuration Debug build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
+        PYTHON=$(which python3) xcodebuild -scheme McBopomofoInstaller -configuration Debug build ARCHS=arm64 ONLY_ACTIVE_ARCH=YES
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/Source/Data/Makefile
+++ b/Source/Data/Makefile
@@ -1,3 +1,5 @@
+PYTHON ?= python3
+
 .PHONY: sort clean
 
 all: data.txt data-plain-bpmf.txt associated-phrases-v2.txt
@@ -5,12 +7,12 @@ all: data.txt data-plain-bpmf.txt associated-phrases-v2.txt
 install: all
 
 data-plain-bpmf.txt: curation/compilers/plain_bpmf_compiler.py BPMFBase.txt BPMFPunctuations.txt
-	python3 -m curation.compilers.plain_bpmf_compiler BPMFBase.txt BPMFPunctuations.txt data-plain-bpmf.txt
+	$(PYTHON) -m curation.compilers.plain_bpmf_compiler BPMFBase.txt BPMFPunctuations.txt data-plain-bpmf.txt
 
 data.txt: curation/compilers/main_compiler.py BPMFBase.txt BPMFMappings.txt BPMFPunctuations.txt \
           PhraseFreq.txt phrase.occ Symbols.txt Macros.txt\
           heterophony1.list heterophony2.list heterophony3.list
-	python3 -m curation.compilers.main_compiler \
+	$(PYTHON) -m curation.compilers.main_compiler \
 		--heterophony1 heterophony1.list \
 		--heterophony2 heterophony2.list \
 		--heterophony3 heterophony3.list \
@@ -23,10 +25,10 @@ data.txt: curation/compilers/main_compiler.py BPMFBase.txt BPMFMappings.txt BPMF
 		--output data.txt
 
 associated-phrases-v2.txt: data.txt curation/builders/phrase_deriver.py associated-punctuation.txt
-		python3 -m curation.builders.phrase_deriver $< $@ associated-punctuation.txt
+		$(PYTHON) -m curation.builders.phrase_deriver $< $@ associated-punctuation.txt
 
 PhraseFreq.txt: curation/builders/frequency_builder.py phrase.occ exclusion.txt
-	python3 -m curation.builders.frequency_builder
+	$(PYTHON) -m curation.builders.frequency_builder
 
 clean:
 	rm -f data.txt data-plain-bpmf.txt phrase.list
@@ -68,7 +70,7 @@ tidy:
 	@sed -i '' -e 's/1/˙/g;s/2/ˊ/g;s/3/ˇ/g;s/4/ˋ/g' BPMFMappings.txt
 
 _phrase.occ: phrase.list
-	@python3 scripts/count_occurrences.py phrase.list > tmp && mv tmp phrase.occ
+	@$(PYTHON) scripts/count_occurrences.py phrase.list > tmp && mv tmp phrase.occ
 
 phrase.list: BPMFBase.txt BPMFMappings.txt
 	awk 'length($$1)<4{print $$1}' BPMFBase.txt > tmp

--- a/Source/Data/Makefile
+++ b/Source/Data/Makefile
@@ -25,7 +25,7 @@ data.txt: curation/compilers/main_compiler.py BPMFBase.txt BPMFMappings.txt BPMF
 		--output data.txt
 
 associated-phrases-v2.txt: data.txt curation/builders/phrase_deriver.py associated-punctuation.txt
-		$(PYTHON) -m curation.builders.phrase_deriver $< $@ associated-punctuation.txt
+	$(PYTHON) -m curation.builders.phrase_deriver $< $@ associated-punctuation.txt
 
 PhraseFreq.txt: curation/builders/frequency_builder.py phrase.occ exclusion.txt
 	$(PYTHON) -m curation.builders.frequency_builder


### PR DESCRIPTION
### **User description**
## Summary

Fixes CodeQL Swift and C++ analysis failures caused by Python version mismatch.

## Problem

The CodeQL workflow was failing with these errors:
- `ExternalBuildToolExecution Data` (Python-related)
- `SwiftEmitModule normal arm64 Emitting module for SQLite` (cascading failure)
- Overall build failure with exit code 65

**Root cause**: 
1. The workflow sets up Python 3.12 via `actions/setup-python`
2. But `xcodebuild` doesn't inherit this Python in its environment
3. The Makefile uses hardcoded `python3` which resolves to Xcode's bundled Python 3.9
4. When PR #719 modernizes Python code with 3.10+ syntax, builds fail with the older Python

## Solution

This PR makes three key changes:

1. **Add Python 3.12 setup** to the CodeQL workflow
2. **Pass `PYTHON` environment variable** to xcodebuild: `PYTHON=$(which python3) xcodebuild ...`
3. **Update Makefile** to use `$(PYTHON)` variable instead of hardcoded `python3`

This ensures:
- CodeQL builds use Python 3.12 from GitHub Actions
- The Makefile respects the environment's Python version
- Backward compatibility is maintained (defaults to `python3` if not set)
- PR #719 will pass CodeQL checks once merged

## Testing

- Fixes https://github.com/openvanilla/McBopomofo/actions/runs/18998321918
- CI will validate this fix when the PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Ensure CodeQL uses Python 3.12

- Pass PYTHON env to xcodebuild

- Makefile uses configurable PYTHON variable

- Stabilize Swift/C++ CodeQL builds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GA["GitHub Actions workflow"]
  PY["actions/setup-python@v6 (3.12)"]
  XB["xcodebuild with PYTHON env"]
  MK["Makefile uses $(PYTHON)"]
  QL["CodeQL init/analyze"]

  GA -- "sets up" --> PY
  PY -- "provides python3 path" --> XB
  XB -- "invokes" --> MK
  MK -- "runs Python modules" --> QL
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codeql.yml</strong><dd><code>CodeQL workflow uses Python 3.12 and passes env</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/codeql.yml

<ul><li>Add Python 3.12 setup via actions/setup-python@v6.<br> <li> Export PYTHON to xcodebuild invocation.<br> <li> Keep manual build and CodeQL steps unchanged otherwise.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/724/files#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Makefile parameterizes Python executable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Data/Makefile

<ul><li>Introduce PYTHON variable with default python3.<br> <li> Replace hardcoded python3 with $(PYTHON) in targets.<br> <li> Update script invocations to respect overridable Python.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/724/files#diff-35351e0c1b929c2f31c01f02562bf35c39ade204c1d9fb7bbc9fcf051f74d18d">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

