### PR TITLE
Adds the feature to generate support report

### DIFF
--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		6AFF97F2253B299E007F1C49 /* NonModalAlertWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6AFF97F0253B299E007F1C49 /* NonModalAlertWindowController.xib */; };
 		B058C5272AC9DF51002EDD66 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */; };
 		B0781B352ACA2655003D9F75 /* ServicesMenu.strings in Resources */ = {isa = PBXBuildFile; fileRef = B0781B372ACA2655003D9F75 /* ServicesMenu.strings */; };
+		D40EFFA22EB669F900C1728A /* InfoCollector in Frameworks */ = {isa = PBXBuildFile; productRef = D40EFFA12EB669F900C1728A /* InfoCollector */; };
 		D41355D8278D74B5005E5CBD /* LanguageModelManager.mm in Sources */ = {isa = PBXBuildFile; fileRef = D41355D7278D7409005E5CBD /* LanguageModelManager.mm */; };
 		D41355DB278E6D17005E5CBD /* McBopomofoLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */; };
 		D41355DE278EA3ED005E5CBD /* UserPhrasesLM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D41355DC278EA3ED005E5CBD /* UserPhrasesLM.cpp */; };
@@ -177,6 +178,7 @@
 		B058C5262AC9DF51002EDD66 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
 		B0781B362ACA2655003D9F75 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ServicesMenu.strings; sourceTree = "<group>"; };
 		B0781B382ACA2659003D9F75 /* zh-Hant */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/ServicesMenu.strings"; sourceTree = "<group>"; };
+		D40EFFA02EB669BB00C1728A /* InfoCollector */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = InfoCollector; path = Packages/InfoCollector; sourceTree = "<group>"; };
 		D41355D6278D7409005E5CBD /* LanguageModelManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LanguageModelManager.h; sourceTree = "<group>"; };
 		D41355D7278D7409005E5CBD /* LanguageModelManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageModelManager.mm; sourceTree = "<group>"; };
 		D41355D9278E6D17005E5CBD /* McBopomofoLM.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = McBopomofoLM.cpp; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				D48F853E2EACDB6C00C2FDAB /* RomanNumbers in Frameworks */,
 				D4E7917A2B52CDE500676A68 /* ChineseNumbers in Frameworks */,
 				D427F76A278C9E29004A2160 /* CandidateUI in Frameworks */,
+				D40EFFA22EB669F900C1728A /* InfoCollector in Frameworks */,
 				D4C9CAB127AAC9690058DFEA /* NSStringUtils in Frameworks */,
 				D427F7AE27907B8A004A2160 /* NotifierUI in Frameworks */,
 				D41B626C2B86EAE900583148 /* BopomofoBraille in Frameworks */,
@@ -459,6 +462,7 @@
 		D427F766278C9CBD004A2160 /* Packages */ = {
 			isa = PBXGroup;
 			children = (
+				D40EFFA02EB669BB00C1728A /* InfoCollector */,
 				D4E5EEE22E68A9B30068BC58 /* SystemCharacterInfo */,
 				D41B626A2B86EAD400583148 /* BopomofoBraille */,
 				D4E791782B52CDCF00676A68 /* ChineseNumbers */,
@@ -544,6 +548,7 @@
 				D41B626B2B86EAE900583148 /* BopomofoBraille */,
 				D4451AC82E688C6B00E8F5AB /* SystemCharacterInfo */,
 				D48F853D2EACDB6C00C2FDAB /* RomanNumbers */,
+				D40EFFA12EB669F900C1728A /* InfoCollector */,
 			);
 			productName = McBopomofo;
 			productReference = 6A0D4EA215FC0D2D00ABF4B3 /* McBopomofo.app */;
@@ -1436,6 +1441,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D40EFFA12EB669F900C1728A /* InfoCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = InfoCollector;
+		};
 		D41B626B2B86EAE900583148 /* BopomofoBraille */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BopomofoBraille;

--- a/Packages/BopomofoBraille/README.md
+++ b/Packages/BopomofoBraille/README.md
@@ -2,17 +2,75 @@
 
 Copyright (c) 2022 and onwards The McBopomofo Authors.
 
-The package includes a converter that translates Taiwanese Bopomofo into
-Taiwanese Braille, and vice versa.
+BopomofoBraille is a Swift package that converts between Taiwanese Bopomofo (注
+音符號) and Taiwanese Braille (臺灣點字). It powers the Braille typing feature
+in McBopomofo’s Service menu and can also be embedded in standalone projects
+that need to translate between these two writing systems.
 
-The main class in the package is BopomofoBrailleConverter. You can use its
-methods directly. For example:
+## Installation
+
+Add the package dependency to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(path: "../Packages/BopomofoBraille"),
+],
+targets: [
+    .target(
+        name: "YourTarget",
+        dependencies: ["BopomofoBraille"]
+    ),
+]
+```
+
+When using the package outside of the McBopomofo repository, replace the local
+path with the corresponding Git URL and version requirement.
+
+## Usage
+
+The primary entry point is `BopomofoBrailleConverter`. It exposes two static
+conversion methods:
 
 ```swift
 let bpmf = "ㄓㄨㄥㄨㄣˊㄓㄨˋㄧㄣ"
-let convertedBraille = BopomofoBrailleConverter.convert(bopomofo: bpmf)
-let convertedBpmf = BopomofoBrailleConverter.convert(braille: convertedBraille)
+let braille = BopomofoBrailleConverter.convert(bopomofo: bpmf)
+
+let roundTrip = BopomofoBrailleConverter.convert(braille: braille)
+// roundTrip == bpmf
 ```
 
-The package helps implement the features in the Service menu, allowing users to
-input Taiwanese Braille by pressing the Ctrl and Enter keys.
+Both conversions preserve whitespace, punctuation, Latin letters, and digits
+according to the Taiwanese Braille standard. Invalid syllables fall back to
+spacing rules so that mixed-content strings remain legible.
+
+### Working With Individual Syllables
+
+`BopomofoSyllable` provides validation and direct access to the Braille for a
+single syllable:
+
+```swift
+let syllable = try BopomofoSyllable(rawValue: "ㄉㄧˋ")
+print(syllable.braille) // ⠙⠡⠐
+
+let reversed = try BopomofoSyllable(braille: "⠋⠪⠂")
+print(reversed.rawValue) // ㄊㄧㄠˊ
+```
+
+Specialised token types such as `Letter`, `Digit`, and punctuation helpers are
+exposed for callers that need finer control over parsing.
+
+## Testing
+
+Run the package test suite with:
+
+```bash
+swift test --package-path Packages/BopomofoBraille
+```
+
+The tests cover round-trip conversion, syllable validation, and edge cases for
+Latin letters, digits, and punctuation.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/CandidateUI/README.md
+++ b/Packages/CandidateUI/README.md
@@ -1,0 +1,152 @@
+# CandidateUI
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+CandidateUI provides the Cocoa candidate window implementation shared by the
+McBopomofo input method targets. It bundles a base `CandidateController` with
+ready-to-use horizontal and vertical variants that expose an Objective-C
+compatible delegate API, making it easy to embed the UI in IMK and AppKit based
+projects.
+
+## Features
+
+- Horizontal and vertical `NSWindowController` subclasses ready for IMK/AppKit
+  hosts
+- Delegate driven data source with optional readings and explanations
+- Configurable key labels, candidate fonts, tooltip text, and accessibility
+  notifications
+- Built-in pagination and highlight navigation helpers for keyboard control
+- Objective-C bridging annotations for seamless use from mixed Swift/ObjC code
+
+## Requirements
+
+- macOS 10.15 or later (AppKit based host process)
+- Swift 5.9 or newer (Xcode 15.3 or newer)
+- Interactions must occur on the main queue because the window is UI backed
+
+## Installation
+
+Add the package dependency to your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(path: "../Packages/CandidateUI"),
+],
+targets: [
+    .target(
+        name: "YourTarget",
+        dependencies: ["CandidateUI"]
+    ),
+]
+```
+
+When integrating outside the McBopomofo repository, replace the local path with
+the corresponding Git URL and version requirement.
+
+## Usage
+
+Choose either `HorizontalCandidateController` or `VerticalCandidateController`
+depending on the layout you want.
+
+### 1. Implement the delegate
+
+Adopt `CandidateControllerDelegate` to expose candidates, optional readings,
+and selection callbacks:
+
+```swift
+@MainActor
+final class DemoDelegate: NSObject, CandidateControllerDelegate {
+    private let entries = ["ZhuYin", "Input Method", "McBopomofo"]
+    private let readings = ["zhu4", "shu1", "mai4"]
+
+    func candidateCountForController(_ controller: CandidateController) -> UInt {
+        UInt(entries.count)
+    }
+
+    func candidateController(_ controller: CandidateController, candidateAtIndex index: UInt) -> String {
+        entries[Int(index)]
+    }
+
+    func candidateController(_ controller: CandidateController, readingAtIndex index: UInt) -> String? {
+        readings[Int(index)]
+    }
+
+    func candidateController(
+        _ controller: CandidateController,
+        requestExplanationFor candidate: String,
+        reading: String
+    ) -> String? {
+        nil
+    }
+
+    func candidateController(_ controller: CandidateController, didSelectCandidateAtIndex index: UInt) {
+        print("Selected candidate: \(entries[Int(index)])")
+    }
+}
+```
+
+### 2. Configure the controller
+
+Instantiate the controller on the main thread, assign the delegate, and adjust
+appearance hints. Call `reloadData()` after mutating underlying candidate data.
+
+```swift
+let controller = VerticalCandidateController()
+controller.delegate = DemoDelegate()
+controller.keyLabels = ["1", "2", "3"].map { CandidateKeyLabel(key: $0, displayedText: $0) }
+controller.keyLabelFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+controller.candidateFont = NSFont.systemFont(ofSize: 18)
+controller.tooltip = NSLocalizedString("Press arrow keys to browse candidates", comment: "Candidate window tooltip")
+controller.set(windowTopLeftPoint: NSPoint(x: 320, y: 400), bottomOutOfScreenAdjustmentHeight: 24)
+controller.visible = true
+```
+
+`set(windowTopLeftPoint:bottomOutOfScreenAdjustmentHeight:)` keeps the window
+visible by nudging it back on screen when it would otherwise cross a screen
+edge.
+
+### 3. React to keyboard events
+
+Use the navigation helpers to mirror the IMK key handling semantics:
+
+```swift
+@discardableResult
+func handleCandidateNavigation(event: NSEvent, controller: CandidateController) -> Bool {
+    guard let specialKey = event.specialKey else { return false }
+    switch specialKey {
+    case .rightArrow: return controller.showNextPage()
+    case .leftArrow: return controller.showPreviousPage()
+    case .downArrow: return controller.highlightNextCandidate()
+    case .upArrow: return controller.highlightPreviousCandidate()
+    default: return false
+    }
+}
+```
+
+For number keys, call `candidateIndexAtKeyLabelIndex(_:)` to translate the
+pressed label into a candidate index (`UInt.max` signals “not available”). When
+a new selection is confirmed, invoke the delegate’s
+`candidateController(_:didSelectCandidateAtIndex:)` method to commit the choice
+back to your input pipeline.
+
+### Objective-C integration
+
+All public controllers and protocols are annotated with `@objc`. Import the
+generated umbrella header (for example through `McBopomofo-Bridging-Header.h`)
+to drive the UI from Objective-C or Objective-C++ sources.
+
+## Testing
+
+Run the package tests with:
+
+```bash
+swift test --package-path Packages/CandidateUI
+```
+
+The test suite covers pagination, selection handling, and layout options for
+both horizontal and vertical controllers.
+
+## License
+
+This package is released under the MIT license. The full text is available in
+the source file headers.

--- a/Packages/ChineseNumbers/README.md
+++ b/Packages/ChineseNumbers/README.md
@@ -1,0 +1,101 @@
+# ChineseNumbers
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+ChineseNumbers converts decimal numbers into Traditional Chinese numeral
+strings. It ships with the McBopomofo input method project and exposes `@objc`
+entry points so the same conversion logic works in Swift and Objective-C
+codebases.
+
+## Features
+
+- Formats integer and decimal sections using lowercase (如「一二三」) or
+  uppercase (如「壹貳參」) digits via `ChineseNumbers.Case`
+- Supports large magnitudes through `載` by chunking the input into four-digit
+  sections (萬、億、兆、京…)
+- Emits the `點` separator for fractional values and preserves significant
+  trailing digits
+- Provides the `SuzhouNumbers` helper for 蘇州碼 output, including unit labels
+  and vertical digit preferences
+- Includes string utilities for trimming/padding zeros so callers can feed
+  pre-validated numeric text
+- Fully accessible from Objective-C thanks to `@objc` annotations and `NSObject`
+  inheritance
+
+## Installation
+
+Add ChineseNumbers to the `dependencies` section of your `Package.swift`:
+
+```swift
+.dependencies([
+    .package(path: "Packages/ChineseNumbers")
+])
+```
+
+Then link the library from a target:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(name: "ChineseNumbers", package: "ChineseNumbers")
+    ]
+)
+```
+
+If you vend the package from another repository, replace the `.package` path
+with the appropriate `.package(url: "…", from: "…")` declaration.
+
+## Usage
+
+```swift
+import ChineseNumbers
+
+let integerPart = "1234567890"
+let decimalPart = "050"
+
+let lowercase = ChineseNumbers.generate(
+    intPart: integerPart,
+    decPart: decimalPart,
+    digitCase: .lowercase
+) // "一十二億三千四百五十六萬七千八百九十點〇五"
+
+let uppercase = ChineseNumbers.generate(
+    intPart: integerPart,
+    decPart: decimalPart,
+    digitCase: .uppercase
+) // "壹拾貳億參仟肆佰伍拾陸萬柒仟捌佰玖拾點零伍"
+
+let suzhou = SuzhouNumbers.generate(
+    intPart: "123",
+    decPart: "40",
+    unit: "元",
+    preferInitialVertical: true
+)
+/*
+〡二〣〤
+百元
+*/
+```
+
+`ChineseNumbers.generate` expects pre-separated integer and decimal strings so
+you can source them from text fields without lossy floating-point conversion.
+`SuzhouNumbers.generate` alternates between vertical digits (〡〢〣) and
+horizontal strokes (一二三) based on the `preferInitialVertical` flag and
+appends the appropriate place name when multiple characters are produced.
+
+## Testing
+
+Run the package tests with:
+
+```bash
+swift test
+```
+
+The XCTest suite covers zero trimming, lowercase/uppercase conversions,
+fractional rendering, and Suzhou numeral generation.
+
+## License
+
+This package is released under the MIT license. The full text is available in
+the source file headers.

--- a/Packages/FSEventStreamHelper/README.md
+++ b/Packages/FSEventStreamHelper/README.md
@@ -1,0 +1,65 @@
+# FSEventStreamHelper
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+FSEventStreamHelper is a tiny macOS utility that wraps Core Services
+FSEventStream APIs with a Swift-friendly delegate interface. It watches a single
+path for file-system changes and forwards normalized event metadata to your
+delegate on the dispatch queue you provide.
+
+## Requirements
+
+- macOS 10.15 or later (relies on `FSEventStream`)
+- Swift 5.9 or later
+- A serial `DispatchQueue` for event delivery (you provide it when creating the
+  helper)
+
+## Usage
+
+```swift
+import FSEventStreamHelper
+
+final class DirectoryWatcher: FSEventStreamHelperDelegate {
+    private let helper: FSEventStreamHelper
+
+    init(path: String, queue: DispatchQueue = .main) {
+        helper = FSEventStreamHelper(path: path, queue: queue)
+        helper.delegate = self
+        _ = helper.start()
+    }
+
+    func helper(_ helper: FSEventStreamHelper, didReceive events: [FSEventStreamHelper.Event]) {
+        for event in events {
+            print("Changed", event.path, event.flags, event.id)
+        }
+    }
+
+    deinit {
+        helper.stop()
+    }
+}
+```
+
+### Event Details
+
+Each `Event` includes:
+
+- `path`: Absolute path that changed
+- `flags`: Raw `FSEventStreamEventFlags` for the change
+- `id`: Monotonic `FSEventStreamEventId` supplied by Core Services
+
+Call `start()` to begin watching and `stop()` to tear the stream down. `start()` returns `false` if the helper is already running or if the stream could not be created.
+
+## Integration Tips
+
+- Only one `FSEventStreamHelper` instance can watch a path at a time. Create
+  additional helpers for other directories.
+- Always balance `start()` with `stop()` (e.g., in `deinit`) to avoid leaking
+  the underlying stream.
+- The path argument must exist when `start()` runs. Create it ahead of time when
+  watching temporary directories.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/InfoCollector/.gitignore
+++ b/Packages/InfoCollector/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Packages/InfoCollector/Package.swift
+++ b/Packages/InfoCollector/Package.swift
@@ -1,13 +1,10 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "InfoCollector",
-    platforms: [
-        .macOS(.v13)
-    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Packages/InfoCollector/Package.swift
+++ b/Packages/InfoCollector/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "InfoCollector",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "InfoCollector",
+            targets: ["InfoCollector"]
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "InfoCollector"
+        ),
+        .testTarget(
+            name: "InfoCollectorTests",
+            dependencies: ["InfoCollector"]
+        ),
+    ]
+)

--- a/Packages/InfoCollector/README.md
+++ b/Packages/InfoCollector/README.md
@@ -1,0 +1,88 @@
+# InfoCollector
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+InfoCollector is a Swift package that gathers diagnostic information about the
+current macOS environment. McBopomofo uses it to build human-readable reports
+when helping users troubleshoot issues, and it can be embedded in other tools
+that need the same style of snapshot.
+
+## Features
+
+- Collects data asynchronously on the main actor and returns a single plain-text
+  report
+- Plugin architecture (`InfoCollectorPlugin`) that lets you add or swap data
+  sources without changing the core API
+- Ready-made collectors for hardware, language, and input-related settings:
+  - Machine model, CPU, memory size, and clock speed
+  - macOS version
+  - Preferred languages, locale, and regional metadata
+  - Attached keyboards reported by IOKit (vendor/product identifiers, transport, location)
+  - Enabled input sources from HIToolbox
+  - Default web browser via Launch Services
+  - Installed Safari version
+  - Host app version/build (reads the main bundle)
+
+## Requirements
+
+- Swift 5.9 or newer
+- macOS 10.15 or newer (uses AppKit, Carbon/HIToolbox, and IOKit APIs that are
+  unavailable on other platforms)
+
+## Usage
+
+### Async/Await
+
+```swift
+import InfoCollector
+
+@MainActor
+func printReport() async {
+    let report = await InfoCollector.generate()
+    print(report)
+}
+```
+
+### Callback-based
+
+```swift
+import InfoCollector
+
+InfoCollector.generate { report in
+    print(report)
+}
+```
+
+Both entry points schedule each plugin concurrently and concatenate their
+results into a single newline-separated string.
+
+## Extending with Custom Plugins
+
+```swift
+struct DiskSpaceCollector: InfoCollectorPlugin {
+    let name = "Disk space collector"
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        let available = /* compute available disk space */
+        callback(.success("- Free Disk: \(available)"))
+    }
+}
+```
+
+Register custom plugins by creating your own array and invoking them before or
+after calling the built-ins.
+
+## Testing
+
+Run the package tests with:
+
+```bash
+swift test
+```
+
+Tests require macOS because they exercise AppKit and IOKit-backed collectors.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+// MARK: -
+
+@objc
+public class InfoCollector: NSObject {
+    public static func generate(callback: @escaping (String) -> Void) {
+        let plugins: [InfoCollectorPlugin] = [
+            MachineModelCollectorPlugin(),
+            MacVersionCollectorPlugin(),
+            SystemLanguageSettingsCollectorPlugin(),
+            KeyboardTypeCollectorPlugin(),
+            ActiveInputSourceListCollectorPlugin(),
+            DefaultWebBrowserCollectorPlugin(),
+            SafaruVersionCollectorPlugin(),
+        ]
+
+        let group = DispatchGroup()
+        var string = ""
+        let lock = NSLock()
+
+        for plugin in plugins {
+            group.enter()
+            plugin.collect { result in
+                if case .success(let info) = result {
+                    lock.lock()
+                    string.append(info + "\n")
+                    lock.unlock()
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            callback(string)
+        }
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
@@ -1,9 +1,41 @@
-import Foundation
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
 
-// MARK: -
+import Foundation
 
 @objc
 public class InfoCollector: NSObject {
+    @MainActor
+    @available(iOS 13.0.0, macOS 10.15, *)
+    public static func generate() async -> String {
+        await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
+            InfoCollector.generate { string in
+                continuation.resume(returning: string)
+            }
+        }
+    }
+
+    @MainActor
     public static func generate(callback: @escaping (String) -> Void) {
         let plugins: [InfoCollectorPlugin] = [
             MachineModelCollectorPlugin(),
@@ -13,6 +45,7 @@ public class InfoCollector: NSObject {
             ActiveInputSourceListCollectorPlugin(),
             DefaultWebBrowserCollectorPlugin(),
             SafaruVersionCollectorPlugin(),
+            AppVersionCollectorPlugin(),
         ]
 
         let group = DispatchGroup()

--- a/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/InfoCollector.swift
@@ -25,7 +25,6 @@ import Foundation
 
 @objc
 public class InfoCollector: NSObject {
-    @MainActor
     @available(iOS 13.0.0, macOS 10.15, *)
     public static func generate() async -> String {
         await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
@@ -35,7 +34,6 @@ public class InfoCollector: NSObject {
         }
     }
 
-    @MainActor
     public static func generate(callback: @escaping (String) -> Void) {
         let plugins: [InfoCollectorPlugin] = [
             MachineModelCollectorPlugin(),
@@ -44,7 +42,7 @@ public class InfoCollector: NSObject {
             KeyboardTypeCollectorPlugin(),
             ActiveInputSourceListCollectorPlugin(),
             DefaultWebBrowserCollectorPlugin(),
-            SafaruVersionCollectorPlugin(),
+            SafariVersionCollectorPlugin(),
             AppVersionCollectorPlugin(),
         ]
 

--- a/Packages/InfoCollector/Sources/InfoCollector/InfoCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/InfoCollectorPlugin.swift
@@ -1,12 +1,12 @@
 protocol InfoCollectorPlugin {
     var name: String { get }
     func collect(callback: @escaping (Result<String, Error>) -> Void)
-    @available(iOS 13.0.0, *)
+    @available(iOS 13.0.0, macOS 10.15, *)
     func collect() async throws -> String
 }
 
 extension InfoCollectorPlugin {
-    @available(iOS 13.0.0, *)
+    @available(iOS 13.0.0, macOS 10.15, *)
     func collect() async throws -> String {
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<String, Error>) in

--- a/Packages/InfoCollector/Sources/InfoCollector/InfoCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/InfoCollectorPlugin.swift
@@ -1,0 +1,23 @@
+protocol InfoCollectorPlugin {
+    var name: String { get }
+    func collect(callback: @escaping (Result<String, Error>) -> Void)
+    @available(iOS 13.0.0, *)
+    func collect() async throws -> String
+}
+
+extension InfoCollectorPlugin {
+    @available(iOS 13.0.0, *)
+    func collect() async throws -> String {
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<String, Error>) in
+            collect { result in
+                switch result {
+                case .success(let string):
+                    continuation.resume(returning: string)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
@@ -37,35 +37,37 @@ struct ActiveInputSourceListCollectorPlugin: InfoCollectorPlugin {
             return nil
         }
 
-        // Use HIToolbox TIS APIs to get current and enabled input sources
-        // Build a query for enabled input sources
-        let keys: [CFString: Any] = [
-            kTISPropertyInputSourceIsEnabled: kCFBooleanTrue as CFBoolean,
-            kTISPropertyInputSourceIsSelectCapable: kCFBooleanTrue as CFBoolean,
-            kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource as CFString,
-        ]
-        let dict = keys as CFDictionary
-        var lines: [String] = []
-        // Enabled input sources
-        if let list = TISCreateInputSourceList(dict, false)?.takeRetainedValue()
-            as? [TISInputSource]
-        {
-            lines.append("- Enabled Input Sources:")
-            for src in list {
-                let name = getStringValue(src, kTISPropertyLocalizedName) ?? "<unknown>"
-                let sid = getStringValue(src, kTISPropertyInputSourceID) ?? ""
-                let category =
+        DispatchQueue.main.async {
+            // Use HIToolbox TIS APIs to get current and enabled input sources
+            // Build a query for enabled input sources
+            let keys: [CFString: Any] = [
+                kTISPropertyInputSourceIsEnabled: kCFBooleanTrue as CFBoolean,
+                kTISPropertyInputSourceIsSelectCapable: kCFBooleanTrue as CFBoolean,
+                kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource as CFString,
+            ]
+            let dict = keys as CFDictionary
+            var lines: [String] = []
+            // Enabled input sources
+            if let list = TISCreateInputSourceList(dict, false)?.takeRetainedValue()
+                as? [TISInputSource]
+            {
+                lines.append("- Enabled Input Sources:")
+                for src in list {
+                    let name = getStringValue(src, kTISPropertyLocalizedName) ?? "<unknown>"
+                    let sid = getStringValue(src, kTISPropertyInputSourceID) ?? ""
+                    let category =
                     getStringValue(
                         src,
                         kTISPropertyInputSourceCategory
                     ) ?? ""
-                lines.append("  - \(name) (\(sid)) [\(category)]")
+                    lines.append("  - \(name) (\(sid)) [\(category)]")
+                }
             }
-        }
 
-        if lines.isEmpty {
-            lines.append("No input sources found")
+            if lines.isEmpty {
+                lines.append("    No input sources found")
+            }
+            callback(.success(lines.joined(separator: "\n")))
         }
-        callback(.success(lines.joined(separator: "\n")))
     }
 }

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import AppKit
 import Carbon.HIToolbox
 import Foundation
@@ -9,7 +32,7 @@ struct ActiveInputSourceListCollectorPlugin: InfoCollectorPlugin {
         func getStringValue(_ source: TISInputSource, _ property: CFString) -> String? {
             if let valuePts = TISGetInputSourceProperty(source, property) {
                 let value = Unmanaged<CFString>.fromOpaque(valuePts).takeUnretainedValue()
-                return value as? String
+                return String(value)
             }
             return nil
         }
@@ -17,18 +40,12 @@ struct ActiveInputSourceListCollectorPlugin: InfoCollectorPlugin {
         // Use HIToolbox TIS APIs to get current and enabled input sources
         // Build a query for enabled input sources
         let keys: [CFString: Any] = [
-            kTISPropertyInputSourceIsEnabled: true as CFBoolean
+            kTISPropertyInputSourceIsEnabled: kCFBooleanTrue as CFBoolean,
+            kTISPropertyInputSourceIsSelectCapable: kCFBooleanTrue as CFBoolean,
+            kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource as CFString,
         ]
         let dict = keys as CFDictionary
         var lines: [String] = []
-
-        //        // Current input source
-        //        if let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() {
-        //            let currentName = getStringValue(current, kTISPropertyLocalizedName)
-        //            let currentID = getStringValue(current, kTISPropertyInputSourceID)
-        //            lines.append("- Current Input Source: \(currentName ?? "<unknown>") (\(currentID ?? ""))")
-        //        }
-
         // Enabled input sources
         if let list = TISCreateInputSourceList(dict, false)?.takeRetainedValue()
             as? [TISInputSource]
@@ -37,7 +54,11 @@ struct ActiveInputSourceListCollectorPlugin: InfoCollectorPlugin {
             for src in list {
                 let name = getStringValue(src, kTISPropertyLocalizedName) ?? "<unknown>"
                 let sid = getStringValue(src, kTISPropertyInputSourceID) ?? ""
-                let category = getStringValue(src, kTISPropertyInputSourceCategory) as? String ?? ""
+                let category =
+                    getStringValue(
+                        src,
+                        kTISPropertyInputSourceCategory
+                    ) ?? ""
                 lines.append("  - \(name) (\(sid)) [\(category)]")
             }
         }

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/ActiveInputSourceListCollectorPlugin.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Carbon.HIToolbox
+import Foundation
+
+struct ActiveInputSourceListCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "Active input sources collector" }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        func getStringValue(_ source: TISInputSource, _ property: CFString) -> String? {
+            if let valuePts = TISGetInputSourceProperty(source, property) {
+                let value = Unmanaged<CFString>.fromOpaque(valuePts).takeUnretainedValue()
+                return value as? String
+            }
+            return nil
+        }
+
+        // Use HIToolbox TIS APIs to get current and enabled input sources
+        // Build a query for enabled input sources
+        let keys: [CFString: Any] = [
+            kTISPropertyInputSourceIsEnabled: true as CFBoolean
+        ]
+        let dict = keys as CFDictionary
+        var lines: [String] = []
+
+        //        // Current input source
+        //        if let current = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() {
+        //            let currentName = getStringValue(current, kTISPropertyLocalizedName)
+        //            let currentID = getStringValue(current, kTISPropertyInputSourceID)
+        //            lines.append("- Current Input Source: \(currentName ?? "<unknown>") (\(currentID ?? ""))")
+        //        }
+
+        // Enabled input sources
+        if let list = TISCreateInputSourceList(dict, false)?.takeRetainedValue()
+            as? [TISInputSource]
+        {
+            lines.append("- Enabled Input Sources:")
+            for src in list {
+                let name = getStringValue(src, kTISPropertyLocalizedName) ?? "<unknown>"
+                let sid = getStringValue(src, kTISPropertyInputSourceID) ?? ""
+                let category = getStringValue(src, kTISPropertyInputSourceCategory) as? String ?? ""
+                lines.append("  - \(name) (\(sid)) [\(category)]")
+            }
+        }
+
+        if lines.isEmpty {
+            lines.append("No input sources found")
+        }
+        callback(.success(lines.joined(separator: "\n")))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/AppVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/AppVersionCollectorPlugin.swift
@@ -21,21 +21,23 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
-import Carbon
+import Foundation
 
-func osStatusToString(_ status: OSStatus) -> String {
-    let bigEndianValue = status.bigEndian
-    let data = withUnsafeBytes(of: bigEndianValue) { Data($0) }
+public struct AppVersionCollectorPlugin: InfoCollectorPlugin, Sendable {
+    var name: String { "App version collector" }
 
-    if let fourCharString = String(data: data, encoding: .ascii) {
-        return fourCharString
-    } else {
-        return "(\(String(format: "%08X", status)))"
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        let bundle = Bundle.main
+        let version =
+            bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "N/A"
+        let build =
+            bundle.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String ?? "N/A"
+
+        var result: [String] = []
+        result.append("- App Version: \(version)")
+        result.append("- App Build: \(build)")
+        let string = result.joined(separator: "\n")
+        callback(.success(string))
     }
-}
 
-func numberToHex<T: FixedWidthInteger>(_ number: T, withPrefix prefix: Bool = true) -> String {
-    let width = MemoryLayout<T>.size * 2
-    let formatString = prefix ? "%#0\(width + 2)X" : "%0\(width)X"
-    return String(format: formatString, number.littleEndian as! CVarArg)
 }

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/DefaultWebBrowserCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/DefaultWebBrowserCollectorPlugin.swift
@@ -1,0 +1,35 @@
+import AppKit
+
+struct DefaultWebBrowserCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "Default web browser collector" }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        // Prefer https; fall back to http if needed
+        if let appURL = LSCopyDefaultApplicationURLForURL(
+            URL(string: "https://apple.com")! as CFURL, .all, nil)?.takeRetainedValue() as URL?
+        {
+            let bundle = Bundle(url: appURL)
+            let displayName =
+                bundle?.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+                ?? bundle?.object(forInfoDictionaryKey: kCFBundleNameKey as String) as? String
+                ?? (appURL.deletingPathExtension().lastPathComponent)
+            let bundleID = bundle?.bundleIdentifier ?? "unknown.bundle.id"
+            callback(.success("- Default Browser: \(displayName) (\(bundleID))"))
+            return
+        }
+
+        // Fallback to Launch Services by role handler for http if the URL lookup fails
+        if let handlerCF = LSCopyDefaultHandlerForURLScheme("http" as CFString) {
+            let handler = handlerCF.takeRetainedValue() as String
+            let path = NSWorkspace.shared.urlForApplication(withBundleIdentifier: handler)
+            let displayName = path?.deletingPathExtension().lastPathComponent ?? handler
+            callback(.success("- Default Browser: \(displayName) (\(handler))"))
+            return
+        }
+
+        struct NoDefaultBrowserError: LocalizedError {
+            var errorDescription: String? { "No default browser configured" }
+        }
+        callback(.failure(NoDefaultBrowserError()))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/DefaultWebBrowserCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/DefaultWebBrowserCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import AppKit
 
 struct DefaultWebBrowserCollectorPlugin: InfoCollectorPlugin {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
@@ -112,9 +112,6 @@ struct KeyboardTypeCollectorPlugin: InfoCollectorPlugin {
             entry = IOIteratorNext(iter)
         }
 
-        if idx == 0 {
-            print("No keyboards found in IORegistry.")
-        }
         if lines.isEmpty {
             callback(.success(""))
         } else {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
@@ -1,0 +1,101 @@
+import Carbon
+import Foundation
+import IOKit
+import IOKit.hid
+
+struct KeyboardTypeCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "Keyboard type collector" }
+
+    func intValue(_ dict: CFDictionary, _ key: String) -> Int? {
+        // Access value as Any? once, then branch by runtime type without conditional CF downcast warnings
+        let anyValue = (dict as NSDictionary)[key]
+        if let intVal = anyValue as? Int { return intVal }
+        if let number = anyValue as? NSNumber { return number.intValue }
+        return nil
+    }
+
+    func strValue(_ dict: CFDictionary, _ key: String) -> String? {
+        (dict as NSDictionary)[key] as? String
+    }
+
+    func usagePage(from props: CFDictionary) -> Int? {
+        return intValue(props, kIOHIDPrimaryUsagePageKey as String)
+            ?? intValue(props, "PrimaryUsagePage")
+    }
+    func usage(from props: CFDictionary) -> Int? {
+        return intValue(props, kIOHIDPrimaryUsageKey as String) ?? intValue(props, "PrimaryUsage")
+    }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        let matching = IOServiceMatching("IOHIDDevice")
+        var iter: io_iterator_t = 0
+        let kr = IOServiceGetMatchingServices(kIOMasterPortDefault, matching, &iter)
+        guard kr == KERN_SUCCESS else {
+            callback(
+                .failure(
+                    NSError(
+                        domain: "KeyboardTypeCollectorPlugin", code: -1,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "IOServiceGetMatchingServices failed \(kr)"
+                        ])))
+            return
+
+        }
+        defer { IOObjectRelease(iter) }
+        var entry = IOIteratorNext(iter)
+        var idx = 0
+        var lines: [String] = []
+
+        while entry != 0 {
+            var props: Unmanaged<CFMutableDictionary>?
+            let r = IORegistryEntryCreateCFProperties(entry, &props, kCFAllocatorDefault, 0)
+            if r == KERN_SUCCESS, let dict = props?.takeRetainedValue() {
+                if let up = usagePage(from: dict), up == kHIDPage_GenericDesktop {
+                    if let u = usage(from: dict),
+                        u == kHIDUsage_GD_Keyboard || u == kHIDUsage_GD_Keypad
+                    {
+                        idx += 1
+                        let product =
+                            strValue(dict, kIOHIDProductKey as String) ?? strValue(dict, "Product")
+                            ?? "(Unknown Product)"
+                        let manufacturer =
+                            strValue(dict, kIOHIDManufacturerKey as String)
+                            ?? "(Unknown Manufacturer)"
+                        let transport = strValue(dict, kIOHIDTransportKey as String) ?? "Unknown"
+                        let vendorID = intValue(dict, kIOHIDVendorIDKey as String)
+                        let productID = intValue(dict, kIOHIDProductIDKey as String)
+                        let location = intValue(dict, kIOHIDLocationIDKey as String)
+                        let countryID = intValue(dict, kIOHIDCountryCodeKey as String)
+
+                        lines.append("  - \(product)")
+                        lines.append("    - Manufacturer: \(manufacturer)")
+                        lines.append("    - Transport: \(transport)")
+                        if let vendorID {
+                            lines.append("    - VendorID: \(vendorID)")
+                        }
+                        if let productID {
+                            lines.append("    - ProductID: \(productID)")
+                        }
+                        if let countryID {
+                            lines.append("    - Country Code: \(countryID)")
+                        }
+                        if let location {
+                            lines.append("    - Location: \(numberToHex(location))")
+                        }
+                    }
+                }
+            }
+            IOObjectRelease(entry)
+            entry = IOIteratorNext(iter)
+        }
+
+        if idx == 0 {
+            print("No keyboards found in IORegistry.")
+        }
+        if lines.isEmpty {
+            callback(.success(""))
+        } else {
+            callback(.success("- Keyboards:\n" + lines.joined(separator: "\n")))
+        }
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/KeyboardTypeCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import Carbon
 import Foundation
 import IOKit

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/MacVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/MacVersionCollectorPlugin.swift
@@ -1,0 +1,11 @@
+import AppKit
+
+struct MacVersionCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "macOS version collector" }
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        let versionString =
+            "- OS Version: macOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+        callback(.success(versionString))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/MacVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/MacVersionCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import AppKit
 
 struct MacVersionCollectorPlugin: InfoCollectorPlugin {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/MachineModelCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/MachineModelCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import Darwin
 import Foundation
 import IOKit
@@ -61,25 +84,32 @@ struct MachineModelCollectorPlugin: InfoCollectorPlugin {
             return String(format: "%.2f GHz", ghz)
         }
 
-        let mainEntry = IORegistryEntryFromPath(kIOMainPortDefault, "IOService:/AppleARMPE/product")
-        let property = IORegistryEntryCreateCFProperty(
-            mainEntry, "product-description" as CFString, kCFAllocatorDefault, 0)
-
         var terminatedModelString = "unknown"
-
-        if let bytes = property?.takeRetainedValue() as? Data {
-            var array = [UInt8](bytes)
-            // Truncate any trailing NUL terminator before decoding, per deprecation guidance
-            if let last = array.last, last == 0 {
-                array.removeLast()
+        if #available(macOS 12.0, *) {
+            let mainEntry = IORegistryEntryFromPath(
+                kIOMainPortDefault,
+                "IOService:/AppleARMPE/product"
+            )
+            let property = IORegistryEntryCreateCFProperty(
+                mainEntry, "product-description" as CFString, kCFAllocatorDefault, 0)
+            if let bytes = property?.takeRetainedValue() as? Data {
+                var array = [UInt8](bytes)
+                // Truncate any trailing NUL terminator before decoding, per deprecation guidance
+                if let last = array.last, last == 0 {
+                    array.removeLast()
+                }
+                terminatedModelString = String(decoding: array, as: UTF8.self)
             }
-            terminatedModelString = String(decoding: array, as: UTF8.self)
+            IOObjectRelease(mainEntry)
+        } else {
+            // Fallback on earlier versions
         }
-        IOObjectRelease(mainEntry)
 
         var lines: [String] = []
         lines.append("- Model: \(model ?? "unknown")")
-        lines.append("- Readable Model: \(terminatedModelString)")
+        if #available(macOS 12.0, *) {
+            lines.append("- Readable Model: \(terminatedModelString)")
+        }
         lines.append("- Machine: \(machine ?? "unknown")")
         if let brand = cpuBrand, !brand.isEmpty {
             lines.append("- CPU: \(brand)")

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/MachineModelCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/MachineModelCollectorPlugin.swift
@@ -1,0 +1,95 @@
+import Darwin
+import Foundation
+import IOKit
+
+struct MachineModelCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "Machine model collector" }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        // Helpers to read sysctl values
+        func sysctlString(_ name: String) -> String? {
+            var size: size_t = 0
+            if sysctlbyname(name, nil, &size, nil, 0) != 0 || size == 0 { return nil }
+            var buffer = [CChar](repeating: 0, count: size)
+            let result = buffer.withUnsafeMutableBufferPointer { ptr -> Int32 in
+                return sysctlbyname(name, ptr.baseAddress, &size, nil, 0)
+            }
+            if result != 0 { return nil }
+            // Trim trailing NUL if present and decode as UTF-8 to avoid deprecated String(cString:)
+            let trimmed: [CChar]
+            if let last = buffer.last, last == 0 {
+                trimmed = Array(buffer.dropLast())
+            } else {
+                trimmed = buffer
+            }
+            return String(decoding: trimmed.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+        }
+        func sysctlUInt64(_ name: String) -> UInt64? {
+            var value: UInt64 = 0
+            var size = MemoryLayout<UInt64>.size
+            let result = withUnsafeMutablePointer(to: &value) { ptr -> Int32 in
+                return sysctlbyname(name, ptr, &size, nil, 0)
+            }
+            return (result == 0) ? value : nil
+        }
+        func sysctlInt32(_ name: String) -> Int32? {
+            var value: Int32 = 0
+            var size = MemoryLayout<Int32>.size
+            let result = withUnsafeMutablePointer(to: &value) { ptr -> Int32 in
+                return sysctlbyname(name, ptr, &size, nil, 0)
+            }
+            return (result == 0) ? value : nil
+        }
+
+        let model = sysctlString("hw.model")
+        let machine = sysctlString("hw.machine")
+        let cpuBrand = sysctlString("machdep.cpu.brand_string")  // may be nil on Apple Silicon
+        let cpuType = sysctlInt32("hw.cputype")
+        let cpuSubtype = sysctlInt32("hw.cpusubtype")
+        let ncpu = sysctlInt32("hw.ncpu")
+        let memBytes = sysctlUInt64("hw.memsize")
+        let freqHz = sysctlUInt64("hw.cpufrequency")
+
+        func bytesToGB(_ bytes: UInt64?) -> String {
+            guard let bytes else { return "n/a" }
+            let gb = Double(bytes) / (1024.0 * 1024.0 * 1024.0)
+            return String(format: "%.1f GB", gb)
+        }
+        func hzToGHz(_ hz: UInt64?) -> String {
+            guard let hz else { return "n/a" }
+            let ghz = Double(hz) / 1_000_000_000.0
+            return String(format: "%.2f GHz", ghz)
+        }
+
+        let mainEntry = IORegistryEntryFromPath(kIOMainPortDefault, "IOService:/AppleARMPE/product")
+        let property = IORegistryEntryCreateCFProperty(
+            mainEntry, "product-description" as CFString, kCFAllocatorDefault, 0)
+
+        var terminatedModelString = "unknown"
+
+        if let bytes = property?.takeRetainedValue() as? Data {
+            var array = [UInt8](bytes)
+            // Truncate any trailing NUL terminator before decoding, per deprecation guidance
+            if let last = array.last, last == 0 {
+                array.removeLast()
+            }
+            terminatedModelString = String(decoding: array, as: UTF8.self)
+        }
+        IOObjectRelease(mainEntry)
+
+        var lines: [String] = []
+        lines.append("- Model: \(model ?? "unknown")")
+        lines.append("- Readable Model: \(terminatedModelString)")
+        lines.append("- Machine: \(machine ?? "unknown")")
+        if let brand = cpuBrand, !brand.isEmpty {
+            lines.append("- CPU: \(brand)")
+        } else {
+            lines.append("- CPU: type=\(cpuType ?? -1) subtype=\(cpuSubtype ?? -1)")
+        }
+        lines.append("- Cores: \(ncpu ?? 0)")
+        lines.append("- Memory: \(bytesToGB(memBytes))")
+        lines.append("- CPU Frequency: \(hzToGHz(freqHz))")
+
+        callback(.success(lines.joined(separator: "\n")))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafariVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafariVersionCollectorPlugin.swift
@@ -23,7 +23,7 @@
 
 import AppKit
 
-struct SafaruVersionCollectorPlugin: InfoCollectorPlugin {
+struct SafariVersionCollectorPlugin: InfoCollectorPlugin {
     var name: String { "Safari version collector" }
 
     func collect(callback: @escaping (Result<String, Error>) -> Void) {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafaruVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafaruVersionCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import AppKit
 
 struct SafaruVersionCollectorPlugin: InfoCollectorPlugin {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafaruVersionCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/SafaruVersionCollectorPlugin.swift
@@ -1,0 +1,59 @@
+import AppKit
+
+struct SafaruVersionCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "Safari version collector" }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        // Try standard install location first
+        let safariPath = "/Applications/Safari.app"
+        if let bundle = Bundle(path: safariPath) ?? Bundle(url: URL(fileURLWithPath: safariPath)) {
+            let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String
+            let build = bundle.infoDictionary?["CFBundleVersion"] as? String
+            if let short, let build {
+                callback(.success("- Safari \(short) (\(build))"))
+                return
+            } else if let short {
+                callback(.success("- Safari \(short)"))
+                return
+            } else if let build {
+                callback(.success("- Safari build \(build)"))
+                return
+            }
+        }
+
+        // Fallback: search common locations in case Safari is relocated
+        let candidateDirs = [
+            "/Applications",
+            NSHomeDirectory() + "/Applications",
+        ]
+        for dir in candidateDirs {
+            if let contents = try? FileManager.default.contentsOfDirectory(atPath: dir) {
+                if let safariApp = contents.first(where: {
+                    $0.caseInsensitiveCompare("Safari.app") == .orderedSame
+                }) {
+                    let full = (dir as NSString).appendingPathComponent(safariApp)
+                    if let bundle = Bundle(path: full) ?? Bundle(url: URL(fileURLWithPath: full)) {
+                        let short = bundle.infoDictionary?["CFBundleShortVersionString"] as? String
+                        let build = bundle.infoDictionary?["CFBundleVersion"] as? String
+                        if let short, let build {
+                            callback(.success("- Safari \(short) (\(build))"))
+                            return
+                        } else if let short {
+                            callback(.success("- Safari \(short)"))
+                            return
+                        } else if let build {
+                            callback(.success("- Safari build \(build)"))
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
+        // If we reach here, we couldn't determine the version
+        struct SafariNotFoundError: LocalizedError {
+            var errorDescription: String? { "Safari.app not found or no version info available" }
+        }
+        callback(.failure(SafariNotFoundError()))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/SystemLanguageSettingsCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/SystemLanguageSettingsCollectorPlugin.swift
@@ -1,3 +1,26 @@
+// Copyright (c) 2022 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
 import AppKit
 
 struct SystemLanguageSettingsCollectorPlugin: InfoCollectorPlugin {

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/SystemLanguageSettingsCollectorPlugin.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/SystemLanguageSettingsCollectorPlugin.swift
@@ -1,0 +1,58 @@
+import AppKit
+
+struct SystemLanguageSettingsCollectorPlugin: InfoCollectorPlugin {
+    var name: String { "System language settings collector" }
+
+    func collect(callback: @escaping (Result<String, Error>) -> Void) {
+        // Gather preferred languages and current locale information
+        let preferred = Locale.preferredLanguages
+        let current = Locale.current
+
+        var lines: [String] = []
+        if preferred.isEmpty == false {
+            // Show top 5 preferred languages to keep output concise
+            let list = preferred.prefix(5).joined(separator: ", ")
+            lines.append("- Preferred Languages: \(list)")
+        } else {
+            lines.append("- Preferred Languages: (none)")
+        }
+
+        // Locale identifier and some common components
+        lines.append("- Current Locale: \(current.identifier)")
+
+        // Language code
+        if #available(iOS 16, macOS 13, *) {
+            if let languageCode = current.language.languageCode?.identifier {
+                lines.append("- Language Code: \(languageCode)")
+            }
+        } else {
+            if let languageCode = current.languageCode {
+                lines.append("- Language Code: \(languageCode)")
+            }
+        }
+
+        // Region code
+        if #available(iOS 16, macOS 13, *) {
+            if let regionCode = current.region?.identifier {
+                lines.append("- Region Code: \(regionCode)")
+            }
+        } else {
+            if let regionCode = current.regionCode {
+                lines.append("- Region Code: \(regionCode)")
+            }
+        }
+
+        // Currency
+        if #available(iOS 16, macOS 13, *) {
+            if let currency = current.currency?.identifier {
+                lines.append("- Currency: \(currency)")
+            }
+        } else {
+            if let currency = current.currencyCode {
+                lines.append("- Currency: \(currency)")
+            }
+        }
+
+        callback(.success(lines.joined(separator: "\n")))
+    }
+}

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/Utils.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/Utils.swift
@@ -37,5 +37,5 @@ func osStatusToString(_ status: OSStatus) -> String {
 func numberToHex<T: FixedWidthInteger>(_ number: T, withPrefix prefix: Bool = true) -> String {
     let width = MemoryLayout<T>.size * 2
     let formatString = prefix ? "%#0\(width + 2)X" : "%0\(width)X"
-    return String(format: formatString, number.littleEndian as! CVarArg)
+    return String(format: formatString, number as! CVarArg)
 }

--- a/Packages/InfoCollector/Sources/InfoCollector/Plugins/Utils.swift
+++ b/Packages/InfoCollector/Sources/InfoCollector/Plugins/Utils.swift
@@ -1,0 +1,18 @@
+import Carbon
+
+func osStatusToString(_ status: OSStatus) -> String {
+    let bigEndianValue = status.bigEndian
+    let data = withUnsafeBytes(of: bigEndianValue) { Data($0) }
+
+    if let fourCharString = String(data: data, encoding: .ascii) {
+        return fourCharString
+    } else {
+        return "(\(String(format: "%08X", status)))"
+    }
+}
+
+func numberToHex<T: FixedWidthInteger>(_ number: T, withPrefix prefix: Bool = true) -> String {
+    let width = MemoryLayout<T>.size * 2
+    let formatString = prefix ? "%#0\(width + 2)X" : "%0\(width)X"
+    return String(format: formatString, number.littleEndian as! CVarArg)
+}

--- a/Packages/InfoCollector/Tests/InfoCollectorTests/InfoCollectorTests.swift
+++ b/Packages/InfoCollector/Tests/InfoCollectorTests/InfoCollectorTests.swift
@@ -10,6 +10,5 @@ import Testing
             }
         }
     }
-    print(result)
-    #expect(!result.isEmpty, "G enerated string should not be empty")
+    #expect(!result.isEmpty, "Generated string should not be empty")
 }

--- a/Packages/InfoCollector/Tests/InfoCollectorTests/InfoCollectorTests.swift
+++ b/Packages/InfoCollector/Tests/InfoCollectorTests/InfoCollectorTests.swift
@@ -1,0 +1,15 @@
+import Testing
+
+@testable import InfoCollector
+
+@Test func example() async throws {
+    let result: String = await withCheckedContinuation { continuation in
+        Task { @MainActor in
+            InfoCollector.generate { string in
+                continuation.resume(returning: string)
+            }
+        }
+    }
+    print(result)
+    #expect(!result.isEmpty, "G enerated string should not be empty")
+}

--- a/Packages/InputSourceHelper/README.md
+++ b/Packages/InputSourceHelper/README.md
@@ -1,0 +1,60 @@
+# InputSourceHelper
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+InputSourceHelper wraps the Carbon Text Input Source (TIS) APIs in a small Swift
+utility so you can enumerate, enable, and disable keyboard input sources without
+dropping into Core Foundation manually. It is used by McBopomofo to ensure its
+input method bundle is registered and all input modes are enabled.
+
+## Requirements
+
+- macOS 10.15 or later (relies on Carbon TIS)
+- Swift 5.9 or later
+- App must link against `Carbon.framework`
+
+## Key Capabilities
+
+- `allInstalledInputSources()` returns every `TISInputSource` currently visible
+  to the system.
+- `inputSource(for: stringValue:)` locates an input source by any TIS property
+  key (such as `kTISPropertyBundleID`).
+- `enable(inputSource:)` and `disable(inputSource:)` toggle a specific source.
+- `enableAllInputMode(for:)` and `enable(inputMode:for:)` activate every mode,
+  or a single mode, bundled with the specified input method.
+- `registerInputSource(at:)` wraps `TISRegisterInputSource` for installing
+  bundles at runtime (requires user approval on modern macOS).
+
+## Usage
+
+```swift
+import InputSourceHelper
+
+let bundleID = "com.openvanilla.McBopomofo.McBopomofoIMK"
+
+if InputSourceHelper.enableAllInputMode(for: bundleID) {
+    print("All input modes are now enabled.")
+} else {
+    print("At least one mode could not be enabled.")
+}
+
+if let source = InputSourceHelper.inputSource(for: kTISPropertyInputSourceID, stringValue: bundleID) {
+    _ = InputSourceHelper.enable(inputSource: source)
+}
+```
+
+## Integration Tips
+
+- The helper returns raw `TISInputSource` references. Cast properties using
+  `Unmanaged` APIs if you need additional metadata.
+- Wrap enable/disable calls in error handling; macOS may decline changes without
+  proper permissions or user approval.
+- Always run these APIs on the main thread when interacting with AppKit text
+  input subsystems.
+- Avoid shipping debug `print` output in production code; replace it with your
+  project's logging facility if needed.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/NSStringUtils/README.md
+++ b/Packages/NSStringUtils/README.md
@@ -1,0 +1,49 @@
+# NSStringUtils
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+NSStringUtils extends `NSString` with helpers that make it easier to work with
+Swift strings while still interoperating with legacy Cocoa APIs. The extensions
+normalize UTF-16 indices so you can move between `NSString` offsets and Swift
+grapheme clusters without accidentally splitting composed characters.
+
+## Requirements
+
+- macOS 10.15 or later
+- Swift 5.9 or later
+- Link against AppKit/Foundation (no additional dependencies)
+
+## Key Extensions
+
+- `characterIndex(from:)` converts a UTF-16 offset (as used by `NSString`) into
+  the equivalent Swift `String` character index and returns the bridged string.
+- `nextUtf16Position(for:)` and `previousUtf16Position(for:)` advance or retreat
+  by one user-perceived character while staying aligned with UTF-16 code units.
+- `count` exposes the Swift character count on `NSString` instances.
+- `split()` returns an array of single-character `NSString` values, respecting
+  composed scalars.
+
+## Usage Example
+
+```swift
+import NSStringUtils
+
+let nsString: NSString = "漢字"
+let next = nsString.nextUtf16Position(for: 0) // 2: skips the entire first character
+let previous = nsString.previousUtf16Position(for: next) // 0
+let pieces = nsString.split() // ["漢", "字"] as NSString instances
+```
+
+## Integration Tips
+
+- Use these helpers when bridging between Objective-C APIs (which index strings
+  by UTF-16) and Swift code that expects character-based indices.
+- Always work on the main thread if you are coordinating text input or UI
+  updates alongside these helpers.
+- The methods allocate intermediate Swift strings internally; reuse results if
+  you need to inspect multiple indices within the same string.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/NotifierUI/README.md
+++ b/Packages/NotifierUI/README.md
@@ -1,0 +1,49 @@
+# NotifierUI
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+NotifierUI provides a lightweight popover-style notification window for macOS
+apps. It is used by McBopomofo to display short status messages (such as
+input-source changes) without relying on Notification Center.
+
+## Requirements
+
+- macOS 10.15 or later
+- Swift 5.9 or later
+- Link against AppKit (uses `NSWindowController`, `NSTextField`, and timers)
+
+## Features
+
+- Presents a borderless, shadowed window that animates into view near the
+  top-right corner.
+- Automatically stacks multiple notifications by tracking the last onscreen position.
+- Supports configurable dwell time; pass `stay: true` to keep the message
+  visible longer before fading.
+- Fades out smoothly and dismisses early when the user clicks the window.
+- Exposes a single `NotifierController.notify(message:stay:)` entry point so
+  callers stay on the main thread.
+
+## Usage
+
+```swift
+import NotifierUI
+
+NotifierController.notify(message: "Input source refreshed")
+NotifierController.notify(message: "Dictionary updated", stay: true)
+```
+
+The controller creates its own window and timers, so you do not need to manage
+lifetimes manually. Each call runs on the main thread; dispatch from background
+queues if needed.
+
+## Integration Tips
+
+- Ensure calls occur on the main thread because AppKit window operations are not
+  thread-safe.
+- Provide succinct messages; the window width is fixed at 160pt and text wraps vertically.
+- Avoid reusing the controller instance; `NotifierController.notify` constructs
+  a fresh controller per call and handles stacking automatically.
+
+## License
+
+NotifierUI ships under the MIT license. Refer to the repository root `LICENSE` file for full terms.

--- a/Packages/NotifierUI/README.md
+++ b/Packages/NotifierUI/README.md
@@ -46,4 +46,5 @@ queues if needed.
 
 ## License
 
-NotifierUI ships under the MIT license. Refer to the repository root `LICENSE` file for full terms.
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/OpenCCBridge/README.md
+++ b/Packages/OpenCCBridge/README.md
@@ -1,0 +1,58 @@
+# OpenCCBridge
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+OpenCCBridge exposes SwiftyOpenCC conversion utilities to Objective-C and
+Objective-C++ code by wrapping them in an `NSObject` subclass. The package
+provides a tiny bridging layer so the main McBopomofo app can convert between
+Traditional and Simplified Chinese without reimplementing OpenCC bindings.
+
+## Requirements
+
+- macOS 10.15 or later
+- Swift 5.9 or later
+- SwiftyOpenCC 2.0.0-beta (resolves automatically via Swift Package Manager)
+- Foundation and OpenCC frameworks linked in the host target
+
+## API Overview
+
+- `OpenCCBridge.shared` lazily configures paired converters and shares them
+  across the process.
+- `convertToSimplified(_:)` converts Traditional Chinese text to Simplified
+  Chinese.
+- `convertToTraditional(_:)` converts Simplified Chinese text to Traditional
+  Chinese.
+
+## Usage Examples
+
+### Swift
+
+```swift
+import OpenCCBridge
+
+let simplified = OpenCCBridge.shared.convertToSimplified("\u{9EA5}")
+let traditional = OpenCCBridge.shared.convertToTraditional("\u{9EA6}")
+```
+
+### Objective-C++
+
+```objective-c++
+#import <OpenCCBridge/OpenCCBridge-Swift.h>
+
+NSString *simplified = [[OpenCCBridge sharedInstance] convertToSimplified:@"\u9EA5"];
+NSString *traditional = [[OpenCCBridge sharedInstance] convertToTraditional:@"\u9EA6"];
+```
+
+## Integration Notes
+
+- Always access the shared singleton; the underlying `ChineseConverter` objects
+  are expensive to create and maintain custom conversion caches.
+- The conversion methods return optionals; when bridging from Objective-C, check
+  for `nil` to catch failures caused by resource loading issues.
+- Callers are responsible for running on the correct thread; conversions are
+  thread-safe but the bridge does not provide additional locking.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/RomanNumbers/README.md
+++ b/Packages/RomanNumbers/README.md
@@ -1,81 +1,63 @@
 # RomanNumbers
 
-RomanNumbers is a Swift package that converts decimal numbers into Roman
-numerals. It powers parts of the McBopomofo input method project where formatted
-Roman numerals are needed in Swift and Objective-C contexts.
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+RomanNumbers converts decimal integers into Roman numerals and exposes the API
+to both Swift and Objective-C callers. It powers McBopomofo features that
+present formatted numerals inside the candidate window and user preferences.
+
+## Requirements
+
+- macOS 10.15 or later
+- Swift 5.9 or later
+- No external dependencies (Foundation only)
 
 ## Features
 
-- Supports integer values from 0 through 3999
-- Offers three output styles via `RomanNumbersStyle`: `alphabets`,
-  `fullWidthUpper` (Unicode U+2160–U+216F), and `fullWidthLower` (Unicode
-  U+2170–U+217F)
-- Accepts either `Int` input or decimal text strings
-- Throws descriptive errors (`RomanNumbersErrors`) when the source value is out of range or invalid
-- Marked with `@objc` so the conversion APIs are reachable from Objective-C code
-
-## Installation
-
-Add RomanNumbers to the `dependencies` section of your `Package.swift`:
-
-```swift
-.dependencies([
-    .package(path: "Packages/RomanNumbers")
-])
-```
-
-Then link the library from a target:
-
-```swift
-.target(
-    name: "YourTarget",
-    dependencies: [
-        .product(name: "RomanNumbers", package: "RomanNumbers")
-    ]
-)
-```
-
-If you vend the package from another repository, replace the `.package` path
-with the appropriate `.package(url: "...", from: "...")` declaration.
+- Accepts `Int` and decimal `String` inputs via convenience overloads.
+- Supports three presentation styles through `RomanNumbersStyle`: `alphabets`,
+  `fullWidthUpper` (U+2160 block), and `fullWidthLower` (U+2170 block).
+- Handles canonical ligatures for 11 and 12 in the full-width styles (`Ⅺ`, `Ⅻ`, `ⅺ`, `ⅻ`).
+- Throws typed `RomanNumbersErrors` (`tooLarge`, `tooSmall`, `invalidInput`) with localized descriptions suitable for UI.
+- Annotated with `@objc` so the converter is callable from Objective-C or Swift/Objective-C mixed targets.
 
 ## Usage
 
 ```swift
 import RomanNumbers
 
-let number = 2025
-let standard = try RomanNumbers.convert(input: number)
-let upperFullWidth = try RomanNumbers.convert(input: number, style: .fullWidthUpper)
-let lowerFromText = try RomanNumbers.convert(string: "3999", style: .fullWidthLower)
+let value = 2025
+let classic = try RomanNumbers.convert(input: value)            // "MMXXV"
+let fullUpper = try RomanNumbers.convert(input: value, style: .fullWidthUpper)
+let fromText = try RomanNumbers.convert(string: "3999", style: .fullWidthLower)
+```
 
-print(standard)        // "MMXXV"
-print(upperFullWidth)  // Unicode Roman numeral letters in the U+2160 block
-print(lowerFromText)   // Unicode Roman numeral letters in the U+2170 block
+Objective-C callers can interact with the same API:
+
+```objectivec
+@import RomanNumbers;
+
+NSError *error = nil;
+NSString *roman = [RomanNumbers convertWithInt:2025 style:RomanNumbersStyleAlphabets error:&error];
 ```
 
 ## Error Handling
 
-`RomanNumbers.convert` throws values of `RomanNumbersErrors`:
-
-- `tooLarge`: the input exceeds 3999
-- `tooSmall`: the input is negative
-- `invalidInput`: the string argument cannot be parsed as an integer
-
-These errors conform to `LocalizedError`, providing human-readable descriptions
-suitable for UI presentation.
+Wrap conversions in `do { try ... } catch` (Swift) or check the `NSError`
+pointer (Objective-C). The helper enforces the inclusive range 0…3999 and
+validates that string input is numeric.
 
 ## Testing
 
-Run the package tests with:
+Run the package tests locally with:
 
 ```bash
-swift test
+swift test --package-path Packages/RomanNumbers
 ```
 
-The suite exercises every conversion style and covers edge cases for the
-supported numeric range.
+The suite covers every style, the special-case ligatures, and boundary values.
 
 ## License
 
-RomanNumbers ships as part of McBopomofo. Refer to the repository's root
-`LICENSE` file for licensing terms.
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/SystemCharacterInfo/README.md
+++ b/Packages/SystemCharacterInfo/README.md
@@ -1,0 +1,83 @@
+# SystemCharacterInfo
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+SystemCharacterInfo reads character decomposition data from the macOS private
+CoreChineseEngine database. McBopomofo uses it to expose radical and exemplar
+information for Traditional Chinese characters inside the user interface.
+
+## Requirements
+
+- macOS 10.15 or later (must include
+  `/System/Library/PrivateFrameworks/CoreChineseEngine.framework`)
+- Swift 5.9 or later
+- Links against `SQLite.swift` (declared in `Package.swift`)
+- The host process must have read access to `CharacterAccessibilityData.sqlite`
+
+## Data Source
+
+The package opens the system database located at:
+
+```
+/System/Library/PrivateFrameworks/CoreChineseEngine.framework/Versions/A/Resources/CharacterAccessibilityData.sqlite
+```
+
+This file is owned by macOS and ships read-only. The helper does not bundle its
+own copy, so it will throw an error if the database is missing (for example on
+non-macOS platforms).
+
+## API Overview
+
+- `SystemCharacterInfo()` creates a connection to the database (throws if the
+  file cannot be opened).
+- `read(string:)` looks up a single character and returns a `CharacterInfo`
+  struct with:
+  - `character`: The canonical character stored in the database
+  - `components`: Decomposition data (e.g. radicals or phonetic components)
+  - `simplifiedExample` / `traditionalExample`: Example characters when provided
+    by Apple
+- Throws `SystemCharacterInfoError.notFound` when there is no matching entry.
+
+## Usage
+
+```swift
+import SystemCharacterInfo
+
+let service = try SystemCharacterInfo()
+let info = try service.read(string: "燈")
+print(info.components ?? "") // "火登"
+```
+
+Wrap calls in `do`/`catch` to handle missing rows or database access errors:
+
+```swift
+ do {
+     let info = try service.read(string: "𠮷")
+     // use info
+ } catch SystemCharacterInfoError.notFound {
+     // character is not in the database
+ } catch {
+     // database could not be opened or another SQLite error occurred
+ }
+```
+
+## Testing
+
+Unit tests expect the system database to exist, so run them on a macOS host with
+CoreChineseEngine available:
+
+```bash
+swift test --package-path Packages/SystemCharacterInfo
+```
+
+## Privacy & Distribution Notes
+
+- The package reads data from a macOS private framework; review App Store
+  guidelines before shipping this functionality to the Mac App Store.
+- Do not modify the system database. The helper opens it read-only and caches no
+  data.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Packages/TooltipUI/README.md
+++ b/Packages/TooltipUI/README.md
@@ -1,0 +1,61 @@
+# TooltipUI
+
+Copyright (c) 2022 and onwards The McBopomofo Authors.
+
+TooltipUI presents a non-activating tooltip window on macOS. McBopomofo uses it
+to explain candidate window actions and display quick hints while keeping the
+input method focused.
+
+## Requirements
+
+- macOS 10.15 or later
+- Swift 5.9 or later
+- Link against AppKit (uses `NSPanel`, `NSTextField`, and screen positioning
+  helpers)
+
+## Features
+
+- Shows a borderless, non-activating panel that floats above normal windows.
+- Automatically resizes to fit the provided text while keeping padding around
+  the content.
+- Positions the tooltip near a requested top-left point and clamps it to the
+  visible screen region.
+- Offers `@objc` selectors so Objective-C callers can show or hide the tooltip.
+
+## Usage
+
+```swift
+import TooltipUI
+
+let tooltip = TooltipController()
+tooltip.show(tooltip: "按下 ⌘ 空白 可以切換輸入法", at: NSEvent.mouseLocation)
+
+DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+    tooltip.hide()
+}
+```
+
+Objective-C integration looks similar:
+
+```objectivec
+@import TooltipUI;
+
+TooltipController *tooltip = [[TooltipController alloc] init];
+[tooltip showTooltip:@"Press ⌘ Space" atPoint:[NSEvent mouseLocation]];
+```
+
+## Integration Tips
+
+- Create and interact with the controller on the main thread; AppKit windows are
+  not thread-safe.
+- Keep a strong reference to the controller for as long as the tooltip should
+  stay visible.
+- Provide succinct messages; the controller expands the window to fit the text
+  but keeps a modest maximum width.
+- The tooltip panel is non-activating, so it will not steal focus from the
+  current application.
+
+## License
+
+This package is released under the MIT license. See the header comments in the
+source files for the full text.

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -33,14 +33,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="475" height="567"/>
                 <autoresizingMask key="autoresizingMask"/>
             </view>
-            <point key="canvasLocation" x="138" y="349"/>
+            <point key="canvasLocation" x="132" y="460"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="32"/>
         <view autoresizesSubviews="NO" id="YEO-Nr-Xri">
             <rect key="frame" x="0.0" y="0.0" width="478" height="576"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1UT-Vk-jJp">
                     <rect key="frame" x="45" y="534" width="176" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bopomofo Keyboard Layout:" id="VTD-h6-q9r">
                         <font key="font" metaFont="system"/>
@@ -62,7 +62,7 @@
                         <action selector="updateBasisKeyboardLayoutAction:" target="-2" id="mjl-uI-U8T"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFW-qA-UTv">
                     <rect key="frame" x="24" y="496" width="197" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Alphanumeric Keyboard Layout:" id="cTl-dv-9gx">
                         <font key="font" metaFont="system"/>
@@ -80,7 +80,7 @@
                         <binding destination="32" name="value" keyPath="values.ChooseCandidateUsingSpaceKey" id="Z1u-Xj-5q7"/>
                     </connections>
                 </button>
-                <comboBox verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
+                <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Kb-9o-Czh">
                     <rect key="frame" x="232" y="435" width="217" height="24"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="217" id="MSj-4R-AdD"/>
@@ -99,7 +99,7 @@
                         <action selector="changeSelectionKeyAction:" target="-2" id="dwv-UP-fcW"/>
                     </connections>
                 </comboBox>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="buv-Na-btc">
                     <rect key="frame" x="124" y="443" width="97" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Selection Keys:" id="5RC-uF-JMe">
                         <font key="font" metaFont="system"/>
@@ -137,7 +137,7 @@
                         <binding destination="32" name="value" keyPath="values.EscToCleanInputBuffer" id="uBc-h3-Lqq"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Hh-po-xMG">
                     <rect key="frame" x="69" y="385" width="152" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Show Candidate Phrase:" id="Old-PI-MEs">
                         <font key="font" metaFont="system"/>
@@ -145,7 +145,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBz-xC-fkE">
                     <rect key="frame" x="93" y="272" width="129" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate List Style:" id="Xj4-f5-50V">
                         <font key="font" metaFont="system"/>
@@ -153,7 +153,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
                     <rect key="frame" x="93" y="224" width="128" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
@@ -224,7 +224,7 @@
                         <binding destination="32" name="value" keyPath="values.MoveCursorAfterSelectingCandidate" id="Jra-P0-jp5"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
                     <rect key="frame" x="101" y="178" width="120" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
@@ -257,7 +257,7 @@
                         <binding destination="32" name="selectedTag" keyPath="values.LetterBehavior" id="YP4-Tc-T1I"/>
                     </connections>
                 </matrix>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
                     <rect key="frame" x="162" y="96" width="59" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
@@ -310,7 +310,7 @@
                         <binding destination="32" name="value" keyPath="values.ShiftEnterEnabled" id="RyW-HU-SUL"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
                     <rect key="frame" x="112" y="130" width="109" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter Key:" id="H9E-f1-tBt">
                         <font key="font" metaFont="system"/>
@@ -318,7 +318,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MdX-1s-2eC">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MdX-1s-2eC">
                     <rect key="frame" x="45" y="311" width="175" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="When Selecting Candidates:" id="wkY-8D-tZm">
                         <font key="font" metaFont="system"/>
@@ -433,11 +433,11 @@
             <point key="canvasLocation" x="-410.5" y="-333"/>
         </view>
         <view id="S2Y-nP-nn8">
-            <rect key="frame" x="0.0" y="0.0" width="478" height="214"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="336"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
-                    <rect key="frame" x="74" y="178" width="163" height="16"/>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wds-Zh-QHP">
+                    <rect key="frame" x="74" y="300" width="163" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Chinese Conversion Style:" id="cMO-Ss-Jar">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -445,7 +445,7 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xwt-fe-fQG">
-                    <rect key="frame" x="243" y="156" width="218" height="38"/>
+                    <rect key="frame" x="243" y="278" width="218" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="218" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -470,7 +470,7 @@
                     </connections>
                 </matrix>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NGh-Dn-Qpf">
-                    <rect key="frame" x="246" y="100" width="124" height="16"/>
+                    <rect key="frame" x="246" y="222" width="124" height="16"/>
                     <buttonCell key="cell" type="check" title="Input Big 5 Code" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9wE-js-xtM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -479,24 +479,24 @@
                         <binding destination="32" name="value" keyPath="values.Big5InputEnabled" id="0sV-29-JVt"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
-                    <rect key="frame" x="134" y="130" width="103" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tT1-Uf-Efn">
+                    <rect key="frame" x="134" y="252" width="103" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + Enter Key:" id="lrz-7F-6e5">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
-                    <rect key="frame" x="156" y="100" width="81" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OxC-Bs-SbF">
+                    <rect key="frame" x="156" y="222" width="81" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + `  Key:" id="F6Q-1k-YTn">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
-                    <rect key="frame" x="102" y="72" width="136" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eG4-yu-RXo">
+                    <rect key="frame" x="102" y="194" width="136" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="132" id="TLl-fl-TAQ"/>
                     </constraints>
@@ -507,7 +507,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I7Q-TH-9oP">
-                    <rect key="frame" x="246" y="72" width="213" height="16"/>
+                    <rect key="frame" x="246" y="194" width="213" height="16"/>
                     <buttonCell key="cell" type="check" title="Repeated key to next candidate" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="sze-kb-iDT">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -516,19 +516,16 @@
                         <binding destination="32" name="value" keyPath="values.RepeatedPunctuationToSelectCandidateEnabled" id="lgT-7e-2ai"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
-                    <rect key="frame" x="241" y="22" width="219" height="42"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="215" id="748-J5-BGk"/>
-                    </constraints>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="3vw-yW-KPa">
+                    <rect key="frame" x="241" y="144" width="219" height="42"/>
                     <textFieldCell key="cell" selectable="YES" title="When enabled, if you type &quot;Shift+,&quot; repeatedly with the standard layout, it will produce symbols like 〈 and 《." id="UyS-Xx-V8S">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sHq-Tf-8nD">
-                    <rect key="frame" x="247" y="122" width="212" height="24"/>
+                <popUpButton verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sHq-Tf-8nD">
+                    <rect key="frame" x="247" y="244" width="212" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Off" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="bAf-tJ-tnK" id="dl4-pi-p7L">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -546,40 +543,62 @@
                         <binding destination="32" name="selectedTag" keyPath="values.ControlEnterOutput" id="X6k-Nm-Z0a"/>
                     </connections>
                 </popUpButton>
+                <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ioI-j3-NSC">
+                    <rect key="frame" x="20" y="126" width="438" height="5"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                </box>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iAT-ur-QK5">
+                    <rect key="frame" x="241" y="20" width="219" height="50"/>
+                    <textFieldCell key="cell" selectable="YES" title="You can create a system report and attach it when filing an issue, so the developers can help you better." id="2A9-YK-Kz8">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r96-y2-KqX">
+                    <rect key="frame" x="243" y="84" width="160" height="24"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="push" title="Create System Report" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="biU-gg-5JJ">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" size="13" name=".PingFangUITextTC-Regular"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="openSystemInfoReport:" target="-2" id="dji-i8-0ce"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="NGh-Dn-Qpf" secondAttribute="trailing" constant="108" id="0bO-dF-405"/>
+                <constraint firstItem="3vw-yW-KPa" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="150" id="07M-ki-q9v"/>
                 <constraint firstItem="wds-Zh-QHP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="20" symbolic="YES" id="2n0-mf-Dgi"/>
+                <constraint firstAttribute="trailing" secondItem="wds-Zh-QHP" secondAttribute="trailing" constant="243" id="3KF-KU-Hzw"/>
                 <constraint firstAttribute="trailing" secondItem="eG4-yu-RXo" secondAttribute="trailing" constant="242" id="5yX-ki-6EK"/>
-                <constraint firstItem="wds-Zh-QHP" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="20" symbolic="YES" id="6Bt-aJ-kfb"/>
-                <constraint firstItem="I7Q-TH-9oP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="20" symbolic="YES" id="7m9-fz-sJa"/>
-                <constraint firstItem="Xwt-fe-fQG" firstAttribute="leading" secondItem="wds-Zh-QHP" secondAttribute="trailing" constant="8" symbolic="YES" id="B7g-vL-ZUl"/>
-                <constraint firstItem="wds-Zh-QHP" firstAttribute="top" secondItem="Xwt-fe-fQG" secondAttribute="top" id="CQf-GR-EhY"/>
-                <constraint firstItem="3vw-yW-KPa" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="243" id="Ct1-7i-adk"/>
-                <constraint firstItem="OxC-Bs-SbF" firstAttribute="trailing" secondItem="wds-Zh-QHP" secondAttribute="trailing" id="H0p-LE-u7d"/>
-                <constraint firstItem="sHq-Tf-8nD" firstAttribute="centerX" secondItem="Xwt-fe-fQG" secondAttribute="centerX" constant="1" id="T0q-m6-K4g"/>
-                <constraint firstItem="OxC-Bs-SbF" firstAttribute="top" secondItem="tT1-Uf-Efn" secondAttribute="bottom" constant="14" id="T9I-Ao-XJc"/>
-                <constraint firstItem="sHq-Tf-8nD" firstAttribute="top" secondItem="tT1-Uf-Efn" secondAttribute="top" id="UZc-gi-Mzk"/>
-                <constraint firstItem="OxC-Bs-SbF" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="158" id="VKa-Dw-QPJ"/>
-                <constraint firstItem="OxC-Bs-SbF" firstAttribute="trailing" secondItem="tT1-Uf-Efn" secondAttribute="trailing" id="a0r-gb-nGL"/>
-                <constraint firstAttribute="trailing" secondItem="I7Q-TH-9oP" secondAttribute="trailing" constant="19" id="bmU-Gs-h0N"/>
+                <constraint firstItem="NGh-Dn-Qpf" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="246" id="6N5-ha-XRR"/>
+                <constraint firstItem="iAT-ur-QK5" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="266" id="6fC-ZY-FqT"/>
+                <constraint firstItem="sHq-Tf-8nD" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="247" id="Ads-P0-EhY"/>
+                <constraint firstAttribute="trailing" secondItem="tT1-Uf-Efn" secondAttribute="trailing" constant="243" id="Aff-Fm-kae"/>
+                <constraint firstItem="Xwt-fe-fQG" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="20" symbolic="YES" id="Bz8-sK-QjE"/>
+                <constraint firstItem="I7Q-TH-9oP" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="246" id="C1h-QP-3yJ"/>
+                <constraint firstAttribute="trailing" secondItem="iAT-ur-QK5" secondAttribute="trailing" constant="20" symbolic="YES" id="DHc-VS-Wv7"/>
+                <constraint firstItem="Xwt-fe-fQG" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="243" id="GmK-At-7hx"/>
+                <constraint firstItem="OxC-Bs-SbF" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="98" id="IPM-yC-IYw"/>
+                <constraint firstAttribute="trailing" secondItem="OxC-Bs-SbF" secondAttribute="trailing" constant="243" id="KgI-QY-Ztv"/>
+                <constraint firstItem="wds-Zh-QHP" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="20" symbolic="YES" id="NYC-rS-CHP"/>
+                <constraint firstItem="sHq-Tf-8nD" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="68" id="Q2m-Sx-DrN"/>
+                <constraint firstItem="tT1-Uf-Efn" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="68" id="RLT-bm-mCu"/>
+                <constraint firstAttribute="trailing" secondItem="3vw-yW-KPa" secondAttribute="trailing" constant="20" symbolic="YES" id="X1b-m9-WWR"/>
+                <constraint firstItem="NGh-Dn-Qpf" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="98" id="bIe-Dq-SfT"/>
+                <constraint firstItem="3vw-yW-KPa" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="243" id="bQS-o8-uBU"/>
                 <constraint firstItem="eG4-yu-RXo" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="126" id="foq-Xo-gnP"/>
-                <constraint firstItem="NGh-Dn-Qpf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OxC-Bs-SbF" secondAttribute="trailing" constant="8" symbolic="YES" id="j9j-GL-5FK"/>
+                <constraint firstItem="iAT-ur-QK5" firstAttribute="leading" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="243" id="heF-41-wt2"/>
                 <constraint firstItem="I7Q-TH-9oP" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="126" id="jw0-ea-TwX"/>
-                <constraint firstItem="3vw-yW-KPa" firstAttribute="top" secondItem="S2Y-nP-nn8" secondAttribute="top" constant="150" id="lmI-rt-oQ3"/>
-                <constraint firstItem="sHq-Tf-8nD" firstAttribute="leading" secondItem="NGh-Dn-Qpf" secondAttribute="leading" constant="1" id="sqB-9s-KL0"/>
-                <constraint firstItem="tT1-Uf-Efn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="S2Y-nP-nn8" secondAttribute="leading" constant="20" symbolic="YES" id="tUQ-lk-I7D"/>
-                <constraint firstAttribute="trailing" secondItem="sHq-Tf-8nD" secondAttribute="trailing" constant="19" id="xd4-JD-UTu"/>
-                <constraint firstItem="OxC-Bs-SbF" firstAttribute="baseline" secondItem="NGh-Dn-Qpf" secondAttribute="baseline" id="y5w-3S-Tzr"/>
-                <constraint firstAttribute="bottom" secondItem="OxC-Bs-SbF" secondAttribute="bottom" constant="100" id="yVu-vP-IwN"/>
             </constraints>
-            <point key="canvasLocation" x="129.5" y="-130"/>
+            <point key="canvasLocation" x="131" y="-94"/>
         </view>
         <customView id="7EY-3X-sVm">
             <rect key="frame" x="0.0" y="0.0" width="477" height="329"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
                     <rect key="frame" x="18" y="293" width="137" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="User Phrase Location:" id="Sc6-Rd-pOy">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -607,7 +626,7 @@
                         <action selector="changeCustomUserPhraseLocationEnabledAction:" target="-2" id="fUI-Z1-8Cg"/>
                     </connections>
                 </popUpButton>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
                     <rect key="frame" x="124" y="252" width="293" height="25"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="6kS-fE-Kz7">
                         <font key="font" metaFont="system"/>
@@ -619,7 +638,7 @@
                         <binding destination="32" name="enabled" keyPath="values.UseCustomUserPhraseLocation" id="liS-L1-RTD"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
                     <rect key="frame" x="20" y="170" width="439" height="28"/>
                     <textFieldCell key="cell" id="Vz3-KS-1rk">
                         <font key="font" metaFont="smallSystem"/>
@@ -652,7 +671,7 @@
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5ce-rm-tsn">
                     <rect key="frame" x="20" y="147" width="433" height="5"/>
                 </box>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
                     <rect key="frame" x="18" y="113" width="437" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="After Adding a New Phrase:" id="wGR-0A-cqv">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -670,7 +689,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookEnabled" id="DFg-tK-bEf"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
                     <rect key="frame" x="62" y="57" width="391" height="24"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Sbq-JE-A4U">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -681,7 +700,7 @@
                         <binding destination="32" name="value" keyPath="values.AddPhraseHookPath" id="IJd-KL-Ytn"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jl3-q4-Fg4">
                     <rect key="frame" x="20" y="59" width="36" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Path:" id="ZY3-98-BrK">
                         <font key="font" usesAppearanceFont="YES"/>
@@ -689,7 +708,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
                     <rect key="frame" x="20" y="20" width="439" height="28"/>
                     <textFieldCell key="cell" title="You can run a script to use git to backup your phrases. The script will run in the folder of your user phrases folder." id="byk-Br-x2Z">
                         <font key="font" metaFont="smallSystem"/>

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -579,13 +579,13 @@ extension Preferences {
         lines.append("  - Function Keyboard Layout: \(Preferences.functionKeyboardLayout)")
         lines.append("  - Candidate Keys: \(Preferences.candidateKeys)")
         lines.append(
-            "  - Selection Mode: \(Preferences.selectPhraseAfterCursorAsCandidate ? "After Cursor" : "Before Cusor")"
+            "  - Selection Mode: \(Preferences.selectPhraseAfterCursorAsCandidate ? "After Cursor" : "Before Cursor")"
         )
         lines.append(
             "  - Move Cursor After Selecting Candidate: \(Preferences.moveCursorAfterSelectingCandidate ? "Enabled" : "Disabled")"
         )
         lines.append(
-            "  - Canddidate Window: \(Preferences.useHorizontalCandidateList ? "Horizontal" : "Vertical")"
+            "  - Candidate Window: \(Preferences.useHorizontalCandidateList ? "Horizontal" : "Vertical")"
         )
         lines.append(
             "  - Chinese Conversion: \(Preferences.chineseConversionEnabled ? "Enabled" : "Disabled")"
@@ -598,13 +598,13 @@ extension Preferences {
             "  - Punctuations: \(Preferences.halfWidthPunctuationEnabled ? "Half-width" : "Full-width")"
         )
         lines.append(
-            "  - Select Canidate With Numbric Keyboard: \(Preferences.selectCandidateWithNumericKeypad ? "Enabled" : "Disabled")"
+            "  - Select Candidate With Numeric Keyboard: \(Preferences.selectCandidateWithNumericKeypad ? "Enabled" : "Disabled")"
         )
         lines.append(
             "  - Allow Ctrl + ` For Big5 Input: \(Preferences.big5InputEnabled ? "Enabled" : "Disabled")"
         )
         lines.append(
-            "  - Phrase Repalcement: \(Preferences.phraseReplacementEnabled ? "Enabled" : "Disabled")"
+            "  - Phrase Replacement: \(Preferences.phraseReplacementEnabled ? "Enabled" : "Disabled")"
         )
         lines.append(
             "  - Associated Phrases (McBopomofo): \(Preferences.associatedPhrasesEnabled ? "Enabled" : "Disabled")"

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -52,7 +52,8 @@ private let kAssociatedPhrasesEnabledKey = "AssociatedPhrasesEnabled"
 private let kLetterBehaviorKey = "LetterBehavior"
 private let kControlEnterOutputKey = "ControlEnterOutput"
 private let kShiftEnterEnabledKey = "ShiftEnterEnabled"
-private let kRepeatedPunctuationToSelectCandidateEnabledKey = "RepeatedPunctuationToSelectCandidateEnabled"
+private let kRepeatedPunctuationToSelectCandidateEnabledKey =
+    "RepeatedPunctuationToSelectCandidateEnabled"
 private let kUseCustomUserPhraseLocation = "UseCustomUserPhraseLocation"
 private let kCustomUserPhraseLocation = "CustomUserPhraseLocation"
 
@@ -235,8 +236,10 @@ class Preferences: NSObject {
         Preferences.basisKeyboardLayout = Preferences.basisKeyboardLayout
         Preferences.functionKeyboardLayout = Preferences.functionKeyboardLayout
         Preferences.candidateKeys = Preferences.candidateKeys
-        Preferences.selectPhraseAfterCursorAsCandidate = Preferences.selectPhraseAfterCursorAsCandidate
-        Preferences.moveCursorAfterSelectingCandidate = Preferences.moveCursorAfterSelectingCandidate
+        Preferences.selectPhraseAfterCursorAsCandidate =
+            Preferences.selectPhraseAfterCursorAsCandidate
+        Preferences.moveCursorAfterSelectingCandidate =
+            Preferences.moveCursorAfterSelectingCandidate
         Preferences.useHorizontalCandidateList = Preferences.useHorizontalCandidateList
         Preferences.chineseConversionEnabled = Preferences.chineseConversionEnabled
         Preferences.halfWidthPunctuationEnabled = Preferences.halfWidthPunctuationEnabled
@@ -248,12 +251,14 @@ class Preferences: NSObject {
         Preferences.letterBehavior = Preferences.letterBehavior
         Preferences.controlEnterOutput = Preferences.controlEnterOutput
         Preferences.shiftEnterEnabled = Preferences.shiftEnterEnabled
-        Preferences.repeatedPunctuationToSelectCandidateEnabled = Preferences.repeatedPunctuationToSelectCandidateEnabled
+        Preferences.repeatedPunctuationToSelectCandidateEnabled =
+            Preferences.repeatedPunctuationToSelectCandidateEnabled
         Preferences.addPhraseHookEnabled = Preferences.addPhraseHookEnabled
         Preferences.addPhraseHookPath = Preferences.addPhraseHookPath
         Preferences.beepUponInputError = Preferences.beepUponInputError
         Preferences.enableUserPhrasesInPlainBopomofo = Preferences.enableUserPhrasesInPlainBopomofo
-        Preferences.allowMovingCursorWhenChoosingCandidates = Preferences.allowMovingCursorWhenChoosingCandidates
+        Preferences.allowMovingCursorWhenChoosingCandidates =
+            Preferences.allowMovingCursorWhenChoosingCandidates
     }
 
     @EnumUserDefault(key: kKeyboardLayoutPreferenceKey, defaultValue: KeyboardLayout.standard)
@@ -389,6 +394,16 @@ class Preferences: NSObject {
     case useHL = 2
 }
 
+extension MovingCursorKey {
+    var name: String {
+        switch self {
+        case .disabled: "Disabled"
+        case .useJK: "J/K"
+        case .useHL: "H/L"
+        }
+    }
+}
+
 extension Preferences {
     /// Whether allows moving the cursor by J/K or H/L keys, when the candidate
     /// window is presented.
@@ -440,6 +455,18 @@ extension Preferences {
     case htmlRuby = 2
     case braille = 3
     case hanyuPinyin = 4
+}
+
+extension ControlEnterOutput {
+    var name: String {
+        switch self {
+        case .off: "Off"
+        case .bpmfReading: "Bopomofo Reading"
+        case .htmlRuby: "HTML Ruby Text"
+        case .braille: "Taiwan Braille"
+        case .hanyuPinyin: "Hanyu Pinyin"
+        }
+    }
 }
 
 extension Preferences {
@@ -541,4 +568,67 @@ extension Preferences {
 extension Preferences {
     @UserDefault(key: kEnableUserPhrasesInPlainBopomofo, defaultValue: false)
     @objc static var enableUserPhrasesInPlainBopomofo: Bool
+}
+
+extension Preferences {
+    static func createReport() -> String {
+        var lines: [String] = []
+        lines.append("- McBopomofo Settings")
+        lines.append("  - Keyboard Layout: \(Preferences.keyboardLayout.name)")
+        lines.append("  - Basis Keyboard Layout: \(Preferences.basisKeyboardLayout)")
+        lines.append("  - Function Keyboard Layout: \(Preferences.functionKeyboardLayout)")
+        lines.append("  - Candidate Keys: \(Preferences.candidateKeys)")
+        lines.append(
+            "  - Selection Mode: \(Preferences.selectPhraseAfterCursorAsCandidate ? "After Cursor" : "Before Cusor")"
+        )
+        lines.append(
+            "  - Move Cursor After Selecting Candidate: \(Preferences.moveCursorAfterSelectingCandidate ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Canddidate Window: \(Preferences.useHorizontalCandidateList ? "Horizontal" : "Vertical")"
+        )
+        lines.append(
+            "  - Chinese Conversion: \(Preferences.chineseConversionEnabled ? "Enabled" : "Disabled")"
+        )
+        lines
+            .append(
+                "  - Chinese Conversion Style: \(Preferences.chineseConversionStyle.name)"
+            )
+        lines.append(
+            "  - Punctuations: \(Preferences.halfWidthPunctuationEnabled ? "Half-width" : "Full-width")"
+        )
+        lines.append(
+            "  - Select Canidate With Numbric Keyboard: \(Preferences.selectCandidateWithNumericKeypad ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Allow Ctrl + ` For Big5 Input: \(Preferences.big5InputEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Phrase Repalcement: \(Preferences.phraseReplacementEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Associated Phrases (McBopomofo): \(Preferences.associatedPhrasesEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Associated Phrases (Plain Bopomofo): \(Preferences.enableUserPhrasesInPlainBopomofo ? "Enabled" : "Disabled")"
+        )
+
+        lines.append("  - Letter Keys: \(Preferences.letterBehavior)")
+        lines.append("  - Ctrl + Enter Key: \(Preferences.controlEnterOutput.name)")
+        lines.append(
+            "  - Shift + Enter Key For Associated Phrases: \(Preferences.shiftEnterEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Repeated Keys For Next Candidate: \(Preferences.repeatedPunctuationToSelectCandidateEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Add Phrase Hook: \(Preferences.addPhraseHookEnabled ? "Enabled" : "Disabled")")
+        lines.append("  - Add Phrase Hook Path: \(Preferences.addPhraseHookPath)")
+        lines.append(
+            "  - Beep Upon Errors: \(Preferences.beepUponInputError ? "Enabled" : "Disabled")")
+        lines.append(
+            "  - Moving Cursor When Choosing Candidates: \(Preferences.allowMovingCursorWhenChoosingCandidates)"
+        )
+        return lines.joined(separator: "\n")
+    }
 }

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24128" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24128"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="489" y="334" width="433" height="575"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1049"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="433" height="575"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -41,7 +41,7 @@
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSi-pH-F8f">
-                    <rect key="frame" x="183" y="482" width="219" height="25"/>
+                    <rect key="frame" x="186" y="482" width="212" height="24"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="iXH-DJ-dBb">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -71,7 +71,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="6eT-rC-gVz">
-                    <rect key="frame" x="183" y="452" width="219" height="25"/>
+                    <rect key="frame" x="186" y="452" width="212" height="24"/>
                     <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="M0n-R9-S5B">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -153,7 +153,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="2Nx-PK-HCb">
-                    <rect key="frame" x="184" y="386" width="117" height="18"/>
+                    <rect key="frame" x="186" y="387" width="113" height="16"/>
                     <buttonCell key="cell" type="check" title="使用空白鍵選字" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="viN-E3-CpO">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -163,7 +163,7 @@
                     </connections>
                 </button>
                 <comboBox focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gtY-jT-2F6">
-                    <rect key="frame" x="185" y="409" width="216" height="23"/>
+                    <rect key="frame" x="186" y="407" width="212" height="24"/>
                     <comboBoxCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" completes="NO" numberOfVisibleItems="5" id="SQ9-Pr-yQD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -187,7 +187,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KOq-SU-0dw">
-                    <rect key="frame" x="182" y="92" width="214" height="18"/>
+                    <rect key="frame" x="184" y="93" width="210" height="16"/>
                     <buttonCell key="cell" type="check" title="按下 ESC 會清除整個輸入緩衝區" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lGd-Af-8ly">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -211,7 +211,7 @@
                     <rect key="frame" x="20" y="445" width="256" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qLt-o2-oPl">
-                    <rect key="frame" x="187" y="316" width="181" height="18"/>
+                    <rect key="frame" x="191" y="317" width="177" height="16"/>
                     <buttonCell key="cell" type="check" title="選字之後自動移動游標位置" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jlf-jk-hJY">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -262,7 +262,7 @@
                     </connections>
                 </matrix>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="oya-hD-nIE">
-                    <rect key="frame" x="182" y="55" width="155" height="18"/>
+                    <rect key="frame" x="184" y="56" width="151" height="16"/>
                     <buttonCell key="cell" type="check" title="輸入錯誤時發出警示聲" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="N4o-lx-RYS">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -272,7 +272,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hvF-32-Zw1">
-                    <rect key="frame" x="182" y="33" width="143" height="18"/>
+                    <rect key="frame" x="184" y="34" width="139" height="16"/>
                     <buttonCell key="cell" type="check" title="定期檢查是否有新版" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="k9r-ii-fdD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -307,7 +307,7 @@
                     </connections>
                 </matrix>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tDv-b3-Mrm">
-                    <rect key="frame" x="182" y="120" width="117" height="18"/>
+                    <rect key="frame" x="186" y="121" width="113" height="16"/>
                     <buttonCell key="cell" type="check" title="使用聯想詞功能" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jXH-Sv-SCM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -339,7 +339,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IHs-uV-EyH">
-                    <rect key="frame" x="181" y="283" width="167" height="25"/>
+                    <rect key="frame" x="184" y="283" width="173" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="不使用" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="eGy-zp-bhw" id="8kw-Sg-bV9">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -443,11 +443,11 @@
             <point key="canvasLocation" x="168" y="-350"/>
         </view>
         <view id="L2Q-IX-SXc">
-            <rect key="frame" x="0.0" y="0.0" width="436" height="208"/>
+            <rect key="frame" x="0.0" y="0.0" width="436" height="297"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cks-CZ-m7g">
-                    <rect key="frame" x="60" y="172" width="118" height="16"/>
+                    <rect key="frame" x="60" y="261" width="118" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="中文簡繁轉換模式：" id="bX9-g7-U8G">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -455,7 +455,7 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PuO-lM-5fF">
-                    <rect key="frame" x="184" y="150" width="206" height="38"/>
+                    <rect key="frame" x="184" y="239" width="206" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="206" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -480,7 +480,7 @@
                     </connections>
                 </matrix>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YR5-r0-KVo">
-                    <rect key="frame" x="65" y="125" width="113" height="16"/>
+                    <rect key="frame" x="65" y="214" width="113" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + Enter 按鍵：" id="euS-8m-1LM">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -488,7 +488,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QYl-R0-PIq">
-                    <rect key="frame" x="91" y="98" width="87" height="16"/>
+                    <rect key="frame" x="91" y="187" width="87" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Ctrl + ` 按鍵：" id="ezl-df-SwH">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -496,7 +496,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Toh-FQ-MTf">
-                    <rect key="frame" x="181" y="118" width="219" height="25"/>
+                    <rect key="frame" x="181" y="207" width="219" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="關閉" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="4VD-Kh-SxN" id="Gcx-5r-kDK">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -515,7 +515,7 @@
                     </connections>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bAc-Eh-8y4">
-                    <rect key="frame" x="182" y="97" width="189" height="18"/>
+                    <rect key="frame" x="184" y="187" width="185" height="16"/>
                     <buttonCell key="cell" type="check" title="使用 Ctrl + ` 輸入 Big5 內碼" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="29h-4W-Qux">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -525,7 +525,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="92X-g9-wsi">
-                    <rect key="frame" x="182" y="70" width="168" height="18"/>
+                    <rect key="frame" x="184" y="160" width="166" height="16"/>
                     <buttonCell key="cell" type="check" title="連續輸入標點切換候選字" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="uza-2x-Yem">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -538,7 +538,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="i1G-1y-ihS">
-                    <rect key="frame" x="182" y="17" width="236" height="48"/>
+                    <rect key="frame" x="182" y="106" width="236" height="48"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="232" id="W9j-gd-BG6"/>
                     </constraints>
@@ -549,7 +549,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mgj-mT-xZ6">
-                    <rect key="frame" x="113" y="70" width="69" height="16"/>
+                    <rect key="frame" x="113" y="159" width="69" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="65" id="fFl-lX-SN3"/>
                     </constraints>
@@ -559,11 +559,33 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="BKA-Sp-uuc">
+                    <rect key="frame" x="20" y="96" width="396" height="5"/>
+                </box>
+                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k5j-ZT-zUm">
+                    <rect key="frame" x="181" y="64" width="128" height="24"/>
+                    <buttonCell key="cell" type="push" title="產生系統資訊報告" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Z6Q-r5-E9H">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" size="13" name=".PingFangUITextTC-Regular"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="openSystemInfoReport:" target="-2" id="AZK-NZ-01I"/>
+                    </connections>
+                </button>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2rb-rs-r3j">
+                    <rect key="frame" x="182" y="28" width="236" height="28"/>
+                    <textFieldCell key="cell" selectable="YES" title="當您在回報問題的時候，可以用這個按鈕，產生一份系統資訊，方便開發團隊了解您的問題。" id="vN2-uZ-LGN">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cks-CZ-m7g" secondAttribute="trailing" constant="20" symbolic="YES" id="2vN-7H-kMX"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="i1G-1y-ihS" secondAttribute="trailing" constant="20" symbolic="YES" id="55u-1x-Gza"/>
                 <constraint firstItem="QYl-R0-PIq" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="93" id="654-qr-PVz"/>
+                <constraint firstItem="BKA-Sp-uuc" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="198" id="8Kb-ij-Hfa"/>
                 <constraint firstItem="PuO-lM-5fF" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="20" symbolic="YES" id="8RB-nU-gsQ"/>
                 <constraint firstAttribute="trailing" secondItem="mgj-mT-xZ6" secondAttribute="trailing" constant="256" id="Ag7-HU-Mrb"/>
                 <constraint firstItem="mgj-mT-xZ6" firstAttribute="top" secondItem="QYl-R0-PIq" secondAttribute="bottom" constant="12" id="Aip-Mp-4m8"/>
@@ -577,24 +599,31 @@
                 <constraint firstItem="bAc-Eh-8y4" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="184" id="MaU-YK-uu3"/>
                 <constraint firstItem="YR5-r0-KVo" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="67" id="OIV-aX-QE9"/>
                 <constraint firstItem="QYl-R0-PIq" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="94" id="Uxa-bX-L63"/>
+                <constraint firstItem="BKA-Sp-uuc" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="20" symbolic="YES" id="WKn-db-N8d"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Toh-FQ-MTf" secondAttribute="trailing" constant="20" symbolic="YES" id="bHq-Ek-dwH"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bAc-Eh-8y4" secondAttribute="trailing" constant="20" symbolic="YES" id="blE-3q-IHj"/>
                 <constraint firstItem="92X-g9-wsi" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="121" id="cWS-6m-SvY"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QYl-R0-PIq" secondAttribute="trailing" constant="20" symbolic="YES" id="clc-vZ-J9H"/>
                 <constraint firstItem="PuO-lM-5fF" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="184" id="d9p-FP-caF"/>
+                <constraint firstItem="k5j-ZT-zUm" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="219" id="dQb-5B-fcp"/>
                 <constraint firstItem="cks-CZ-m7g" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="20" symbolic="YES" id="ePS-tF-QAw"/>
+                <constraint firstItem="2rb-rs-r3j" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="184" id="fJJ-XY-bJG"/>
                 <constraint firstItem="i1G-1y-ihS" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="184" id="g9S-38-Fym"/>
+                <constraint firstAttribute="trailing" secondItem="BKA-Sp-uuc" secondAttribute="trailing" constant="20" symbolic="YES" id="gCy-AV-8xL"/>
+                <constraint firstItem="2rb-rs-r3j" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="241" id="gsh-jH-yeF"/>
                 <constraint firstItem="i1G-1y-ihS" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="143" id="jMJ-rU-Z9P"/>
                 <constraint firstItem="YR5-r0-KVo" firstAttribute="top" secondItem="L2Q-IX-SXc" secondAttribute="top" constant="67" id="lPb-qK-5c7"/>
+                <constraint firstItem="k5j-ZT-zUm" firstAttribute="leading" secondItem="L2Q-IX-SXc" secondAttribute="leading" constant="184" id="llW-dV-YCu"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2rb-rs-r3j" secondAttribute="trailing" constant="20" symbolic="YES" id="mrL-Q3-sES"/>
             </constraints>
-            <point key="canvasLocation" x="651" y="-121.5"/>
+            <point key="canvasLocation" x="651" y="-103.5"/>
         </view>
         <customView id="M7i-Af-lNp">
             <rect key="frame" x="0.0" y="0.0" width="436" height="334"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
-                    <rect key="frame" x="22" y="298" width="105" height="16"/>
+                    <rect key="frame" x="9" y="298" width="105" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="使用者詞彙位置：" id="ulY-l0-tqg">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -602,7 +631,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b15-I3-wDL">
-                    <rect key="frame" x="21" y="257" width="65" height="25"/>
+                    <rect key="frame" x="11" y="258" width="71" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="標準" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="WPo-X9-YuK" id="zEZ-0A-2Df">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -620,7 +649,7 @@
                     </popUpButtonCell>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aAf-VY-6CO">
-                    <rect key="frame" x="90" y="261" width="291" height="21"/>
+                    <rect key="frame" x="90" y="258" width="291" height="24"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Ooe-Ve-njT">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -632,7 +661,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="749" preferredMaxLayoutWidth="405" translatesAutoresizingMaskIntoConstraints="NO" id="pb0-gR-J2p">
-                    <rect key="frame" x="18" y="177" width="403" height="28"/>
+                    <rect key="frame" x="18" y="174" width="403" height="28"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="28" id="8wn-XD-VFx"/>
                     </constraints>
@@ -643,7 +672,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ibr-mk-lwr">
-                    <rect key="frame" x="90" y="232" width="39" height="21"/>
+                    <rect key="frame" x="90" y="229" width="39" height="21"/>
                     <buttonCell key="cell" type="bevel" title="Button" bezelStyle="rounded" imagePosition="overlaps" alignment="left" controlSize="small" imageScaling="proportionallyDown" inset="2" id="QMk-FM-cgo">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -653,7 +682,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="bHQ-bR-nHc">
-                    <rect key="frame" x="18" y="120" width="396" height="16"/>
+                    <rect key="frame" x="18" y="117" width="396" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="在手動加入使用者詞彙之後:" id="Yhg-pv-SyV">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -661,7 +690,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="u6i-rg-gq3">
-                    <rect key="frame" x="18" y="86" width="398" height="18"/>
+                    <rect key="frame" x="20" y="84" width="396" height="16"/>
                     <buttonCell key="cell" type="check" title="執行特定的 Shell Script" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="bkX-1g-jGL">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -671,7 +700,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VKE-yo-TdG">
-                    <rect key="frame" x="71" y="58" width="346" height="21"/>
+                    <rect key="frame" x="71" y="52" width="346" height="24"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="346" id="62p-rx-Sp1"/>
                     </constraints>
@@ -685,7 +714,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="8ku-Pt-FIH">
-                    <rect key="frame" x="21" y="60" width="44" height="16"/>
+                    <rect key="frame" x="21" y="56" width="44" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="路徑：" id="2Ox-BG-OqC">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -693,10 +722,10 @@
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="LVR-3l-T11">
-                    <rect key="frame" x="20" y="154" width="396" height="5"/>
+                    <rect key="frame" x="20" y="151" width="396" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nf4-gN-42Y">
-                    <rect key="frame" x="384" y="262" width="32" height="20"/>
+                    <rect key="frame" x="384" y="259" width="32" height="24"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSFolder" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="nfb-rv-kdU">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>


### PR DESCRIPTION
The PR adds a button in the preferences to create a report that users can attach it when filing issues. A report is like

```
- Model: Mac16,1
- Readable Model: MacBook Pro (14-inch, Nov 2024)
- Machine: arm64
- CPU: Apple M4
- Cores: 10
- Memory: 16.0 GB
- CPU Frequency: n/a
- OS Version: macOS 26.0.1
- Preferred Languages: en-US, zh-Hant-US
- Current Locale: en_US
- Language Code: en
- Region Code: US
- Currency: USD
- Keyboards:
  - Apple Internal Keyboard / Trackpad
    - Manufacturer: Apple
    - Transport: FIFO
    - Location: 0X00000000000000D5
  - USB Keyboard
    - Manufacturer: (Unknown Manufacturer)
    - Transport: USB
    - VendorID: 1241
    - ProductID: 8209
    - Country Code: 0
    - Location: 0X0000000001131200
- Enabled Input Sources:
  - U.S. (com.apple.keylayout.US) [TISCategoryKeyboardInputSource]
  - Bopomofo (org.openvanilla.inputmethod.McBopomofo.McBopomofo.Bopomofo) [TISCategoryKeyboardInputSource]
  - Yahoo! KeyKey (com.yahoo.inputmethod.KeyKey) [TISCategoryKeyboardInputSource]
  - Ainu (com.apple.inputmethod.AinuIM.Ainu) [TISCategoryKeyboardInputSource]
  - Hiragana (com.apple.inputmethod.Kotoeri.KanaTyping.Japanese) [TISCategoryKeyboardInputSource]
  - Hiragana (com.apple.inputmethod.Kotoeri.RomajiTyping.Japanese) [TISCategoryKeyboardInputSource]
  - Zhuyin – Traditional (com.apple.inputmethod.TCIM.Zhuyin) [TISCategoryKeyboardInputSource]
- Default Browser: Microsoft Edge (com.microsoft.edgemac)
- Safari 26.0.1 (21622.1.22.11.15)
- App Version: 2.9.3
- App Build: 1964
- McBopomofo Settings
  - Keyboard Layout: Standard
  - Basis Keyboard Layout: com.apple.keylayout.US
  - Function Keyboard Layout: com.apple.keylayout.US
  - Candidate Keys: 123456789
  - Selection Mode: After Cursor
  - Move Cursor After Selecting Candidate: Enabled
  - Canddidate Window: Horizontal
  - Chinese Conversion: Disabled
  - Chinese Conversion Style: model
  - Punctuations: Full-width
  - Select Canidate With Numbric Keyboard: Disabled
  - Allow Ctrl + ` For Big5 Input: Enabled
  - Phrase Repalcement: Disabled
  - Associated Phrases (McBopomofo): Disabled
  - Associated Phrases (Plain Bopomofo): Disabled
  - Letter Keys: 1
  - Ctrl + Enter Key: Taiwan Braille
  - Shift + Enter Key For Associated Phrases: Enabled
  - Repeated Keys For Next Candidate: Enabled
  - Add Phrase Hook: Enabled
  - Add Phrase Hook Path: /Users/zonble/Library/Input Methods/McBopomofo.app/Contents/Resources/add-phrase-hook.sh
  - Beep Upon Errors: Enabled
  - Moving Cursor When Choosing Candidates: MovingCursorKey(rawValue: 1)

```

The PR also updates the README files for the local packages.