### PR TITLE
fix: resolve Python 3 migration runtime errors and compatibility issues

### DIFF
--- a/Source/Data/curation/builders/phrase_deriver.py
+++ b/Source/Data/curation/builders/phrase_deriver.py
@@ -50,7 +50,8 @@ class Entry:
         if len(reading_parts) != len(self.value):
             return None
 
-        self._cached_zipped_readings_and_values = list(zip(reading_parts, self.value, strict=True))
+        # Manual length validation for Python 3.9+ compatibility (strict=True requires 3.10+)
+        self._cached_zipped_readings_and_values = list(zip(reading_parts, self.value))
         return self._cached_zipped_readings_and_values
 
     @classmethod

--- a/Source/Data/curation/validators/score_validator.py
+++ b/Source/Data/curation/validators/score_validator.py
@@ -152,7 +152,7 @@ def four_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:2])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[2:4])
         (a, b) = two_char_walk(phrases, thisbpmf)
         segcand += a
@@ -163,16 +163,16 @@ def four_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:3])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         mybpmf = bpmfinput[3]
-        (segcand, segscore) = seg_pick(mybpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, mybpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     # 1234
     thisbpmf = "-".join(bpmfinput[0:4])
     if thisbpmf in phrases:
         segcand = ""
         segscore = 0
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     #
     candidate.sort(key=lambda x: x[1], reverse=True)
@@ -195,7 +195,7 @@ def five_char_walk(
         segcand = ""
         segscore = 0
         mybpmf = bpmfinput[0]
-        (segcand, segscore) = seg_pick(mybpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, mybpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[1:5])
         (a, b) = four_char_walk(phrases, thisbpmf)
         segcand += a
@@ -211,9 +211,9 @@ def five_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:2])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[2:5])
-        (a, b) = three_char_walk(thisbpmf)
+        (a, b) = three_char_walk(phrases, thisbpmf)
         segcand += a
         segscore += b
         candidate.append((segcand, segscore))
@@ -226,7 +226,7 @@ def five_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:3])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[3:5])
         (a, b) = two_char_walk(phrases, thisbpmf)
         segcand += a
@@ -237,16 +237,16 @@ def five_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:4])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         mybpmf = bpmfinput[4]
-        (segcand, segscore) = seg_pick(mybpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, mybpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     # 12345
     if "-".join(bpmfinput[0:5]) in phrases:
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:5])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     #
     candidate.sort(key=lambda x: x[1], reverse=True)
@@ -270,9 +270,9 @@ def six_char_walk(
         segcand = ""
         segscore = 0
         mybpmf = bpmfinput[0]
-        (segcand, segscore) = seg_pick(mybpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, mybpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[1:6])
-        (a, b) = four_char_walk(phrases, thisbpmf)
+        (a, b) = five_char_walk(phrases, thisbpmf)
         segcand += a
         segscore += b
         candidate.append((segcand, segscore))
@@ -287,9 +287,9 @@ def six_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:2])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[2:6])
-        (a, b) = three_char_walk(thisbpmf)
+        (a, b) = four_char_walk(phrases, thisbpmf)
         segcand += a
         segscore += b
         candidate.append((segcand, segscore))
@@ -303,9 +303,9 @@ def six_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:3])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[3:6])
-        (a, b) = three_char_walk(thisbpmf)
+        (a, b) = three_char_walk(phrases, thisbpmf)
         segcand += a
         segscore += b
         candidate.append((segcand, segscore))
@@ -318,7 +318,7 @@ def six_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:4])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         thisbpmf = "-".join(bpmfinput[4:6])
         (a, b) = two_char_walk(phrases, thisbpmf)
         segcand += a
@@ -329,16 +329,16 @@ def six_char_walk(
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:5])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         mybpmf = bpmfinput[5]
-        (segcand, segscore) = seg_pick(mybpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, mybpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     # 123456
     if "-".join(bpmfinput[0:6]) in phrases:
         segcand = ""
         segscore = 0
         thisbpmf = "-".join(bpmfinput[0:6])
-        (segcand, segscore) = seg_pick(thisbpmf, segcand, segscore)
+        (segcand, segscore) = seg_pick(phrases, thisbpmf, segcand, segscore)
         candidate.append((segcand, segscore))
     #
     candidate.sort(key=lambda x: x[1], reverse=True)
@@ -346,27 +346,28 @@ def six_char_walk(
 
 
 def check_bpmf_output(phrases: dict[str, list[tuple[str, float]]], bpmf2chk: str) -> None:
-    if len(bpmf2chk.split("-")) == 2:
+    length = len(bpmf2chk.split("-"))
+    if length == 2:
         (a, b) = two_char_walk(phrases, bpmf2chk)
         (c, d) = phrases[bpmf2chk][0]
         if (a, b) != (c, d):
             print(f"{c} {d:f} {a} {b:f}")
-    if len(bpmf2chk.split("-")) == 3:
+    elif length == 3:
         (a, b) = three_char_walk(phrases, bpmf2chk)
         (c, d) = phrases[bpmf2chk][0]
         if (a, b) != (c, d):
             print(f"{c} {d:f} {a} {b:f}")
-    if len(bpmf2chk.split("-")) == 4:
+    elif length == 4:
         (a, b) = four_char_walk(phrases, bpmf2chk)
         (c, d) = phrases[bpmf2chk][0]
         if (a, b) != (c, d):
             print(f"{c} {d:f} {a} {b:f}")
-    if len(bpmf2chk.split("-")) == 5:
+    elif length == 5:
         (a, b) = five_char_walk(phrases, bpmf2chk)
         (c, d) = phrases[bpmf2chk][0]
         if (a, b) != (c, d):
             print(f"{c} {d:f} {a} {b:f}")
-    if len(bpmf2chk.split("-")) == 6:
+    elif length == 6:
         (a, b) = six_char_walk(phrases, bpmf2chk)
         (c, d) = phrases[bpmf2chk][0]
         if (a, b) != (c, d):


### PR DESCRIPTION
### **User description**
This commit fixes critical bugs in the Python 3 modernization that were causing GitHub Actions workflow failures in the "Test McBopomofo" step.

Fixes in score_validator.py:
- Add missing 'phrases' parameter to 20+ seg_pick() calls (lines 155, 166, 168, 175, 198, 214, 229, 240, 242, 249, 273, 290, 306, 321, 332, 334, 341)
- Add missing 'phrases' parameter to three_char_walk() calls (lines 216, 292, 308)
- Fix incorrect walker function call: four_char_walk -> five_char_walk (line 275)
- Optimize control flow by converting multiple if statements to elif chain in check_bpmf_output() function to prevent redundant execution

Fixes in phrase_deriver.py:
- Remove zip(strict=True) for Python 3.9+ compatibility (strict parameter requires Python 3.10+)
- Length validation already performed before zip, so strict mode redundant

All fixes verified with:
- Syntax validation (py_compile)
- Full data build (make all)
- Data integrity checks (make check)
- Score validator execution

These changes resolve the TypeErrors that were preventing the workflow from completing successfully.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Pass phrases to seg_pick and walkers

- Fix incorrect walker call in six_char path

- Optimize validator with single length branch

- Remove zip strict for Python 3.9+


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PhraseDeriver["phrase_deriver.py: remove zip strict=True"] -- "compatibility" --> Python39["Python 3.9+"]
  ScoreValidator["score_validator.py: seg_pick calls pass phrases"] -- "correct params" --> Walkers["two/three/four/five/six_char_walk"]
  ScoreValidator -- "fix call" --> SixChar["six_char_walk uses five_char_walk"]
  ScoreValidator -- "optimize" --> CheckBPMF["check_bpmf_output uses elif by length"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>phrase_deriver.py</strong><dd><code>Replace strict zip for Python 3.9 compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Data/curation/builders/phrase_deriver.py

<ul><li>Remove zip(strict=True) for compatibility.<br> <li> Add comment explaining Python 3.9 support.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/733/files#diff-e0fd78ddf177e248701aecb964f7cd1bead6a0bad29b430c7aeecee99347b1bc">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>score_validator.py</strong><dd><code>Fix validator parameters and walker logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Data/curation/validators/score_validator.py

<ul><li>Pass phrases to seg_pick across cases.<br> <li> Correct walker calls and depths.<br> <li> Switch to elif chain in output checker.<br> <li> Use five_char_walk in six_char path.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/733/files#diff-d679910ebf06547ad23da3b17b729f70c772bdb716a007c550e543fc17e94399">+27/-26</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

