### PR TITLE
Introduce a new CI job for building the phrase db

### DIFF
--- a/.github/workflows/continuous-build-data.yml
+++ b/.github/workflows/continuous-build-data.yml
@@ -1,0 +1,21 @@
+name: Build
+on:
+  push:
+    paths:
+      - 'Source/Data/**'
+  pull_request:
+    paths:
+      - 'Source/Data/**'
+
+jobs:
+  build:
+    name: Build phrase database
+    runs-on: macOS-15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Build phrase database
+        run: make
+        working-directory: Source/Data

--- a/.github/workflows/continuous-build-data.yml
+++ b/.github/workflows/continuous-build-data.yml
@@ -1,16 +1,18 @@
-name: Build
+name: Build phrase database
 on:
   push:
     paths:
       - 'Source/Data/**'
+      - '.github/workflows/continuous-build-data.yml'
   pull_request:
     paths:
       - 'Source/Data/**'
+      - '.github/workflows/continuous-build-data.yml'
 
 jobs:
   build:
     name: Build phrase database
-    runs-on: macOS-15
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6


### PR DESCRIPTION
### **User description**
This makes sure that we build the entire phrase db upon any changes in `Source/Data/**`.


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Add CI workflow to build phrase DB

- Trigger on Source/Data path changes

- Set up Python 3.12 on macOS-15

- Run make in Source/Data directory


___

### Diagram Walkthrough


```mermaid
flowchart LR
  trigger["Push/PR to 'Source/Data/**'"] 
  setup["Checkout + Setup Python 3.12 (macOS-15)"]
  build["Run 'make' in 'Source/Data' to build phrase DB"]
  trigger -- "starts job" --> setup
  setup -- "executes" --> build
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>continuous-build-data.yml</strong><dd><code>New GitHub Actions workflow for phrase DB build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/continuous-build-data.yml

<ul><li>Add GitHub Actions workflow named Build<br> <li> Trigger on push/PR affecting Source/Data/**<br> <li> Setup Python 3.12 on macOS-15 runner<br> <li> Run make in Source/Data to build phrase DB</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/737/files#diff-a68695cec8530709caf7ae97c6ed952d9c26d9d76a9337e765bfe5426eb018ec">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

