### PR TITLE
UX improvement: surface user file issues

### DIFF
--- a/Source/Base.lproj/Localizable.strings
+++ b/Source/Base.lproj/Localizable.strings
@@ -138,3 +138,21 @@
 "Roman Numbers (Full-Width Upper Case)" = "Roman Numbers (Full-Width Upper Case)";
 
 "Roman Numbers (Full-Width Lower Case)" = "Roman Numbers (Full-Width Lower Case)";
+
+"Show Issues in User Files ⚠️" = "Show Issues in User Files ⚠️";
+
+"Issues were found in the following user phrase files:" = "Issues were found in the following user phrase files:";
+
+"Check McBopomofo menu for user file issues" = "Check McBopomofo menu for user file issues";
+
+"User phrase file" = "User phrase file";
+
+"Excluded phrase file" = "Excluded phrase file";
+
+"Phrase replacement file" = "Phrase replacement file";
+
+"line %lu: " = "line %lu: ";
+
+"Only one column was found." = "Only one column was found.";
+
+"Illegal NULL character was found." = "Illegal NULL character was found.";

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -92,6 +92,8 @@ extern InputMode InputModePlainBopomofo;
 
 - (size_t)computeActualCursorIndex:(size_t)cursor;
 
+- (NSArray<NSString *> *)collectUserFileIssues;
+
 @property (strong, nonatomic) InputMode inputMode;
 @property (weak, nonatomic) id<KeyHandlerDelegate> delegate;
 @property (assign, nonatomic, readonly) NSInteger actualCandidateCursorIndex;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -2502,4 +2502,51 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     return [self buildAssociatedPhraseStateWithPreviousState:state prefixCursorAt:[self computeActualCursorIndex:candidtaeStateOriginalCursorIndex] reading:prefixReading value:prefixValue selectedCandidateIndex:candidateIndex useVerticalMode:useVerticalMode useShiftKey:useShiftKey];
 }
 
+- (NSArray<NSString *> *)collectUserFileIssues
+{
+    NSMutableArray<NSString *> *array = [NSMutableArray array];
+
+    std::vector<McBopomofo::McBopomofoLM::UserFileIssue> issues = _languageModel->getUserFileIssues();
+    for (const auto& issue : issues) {
+        NSMutableString *msg = [NSMutableString string];
+
+        switch (issue.fileType) {
+        case McBopomofo::McBopomofoLM::UserFileType::USER_PHRASES:
+            [msg appendString:NSLocalizedString(@"User phrase file", "")];
+            break;
+        case McBopomofo::McBopomofoLM::UserFileType::EXCLUDED_PHRASES:
+            [msg appendString:NSLocalizedString(@"Excluded phrase file", "")];
+            break;
+        case McBopomofo::McBopomofoLM::UserFileType::PHRASE_REPLACEMENT_MAP:
+            [msg appendString:NSLocalizedString(@"Phrase replacement file", "")];
+            break;
+        default:
+            // Shouldn't happen, and so the string is not localized.
+            [msg appendString:@"Unknown user file"];
+            break;
+        }
+
+        [msg appendFormat:@" (%@) ", [NSString stringWithUTF8String:issue.path.filename().c_str()]];
+        [msg appendFormat:NSLocalizedString(@"line %lu: ", ""), issue.lineNumber];
+
+        switch (issue.issueType) {
+        case McBopomofo::McBopomofoLM::IssueType::MISSING_SECOND_COLUMN:
+            [msg appendString:NSLocalizedString(@"Only one column was found.", "")];
+            break;
+        case McBopomofo::McBopomofoLM::IssueType::NULL_CHARACTER_IN_TEXT:
+            [msg appendString:NSLocalizedString(@"Illegal NULL character was found.", "")];
+            break;
+        case McBopomofo::McBopomofoLM::IssueType::NO_ISSUE:
+        default:
+            // Shouldn't happen, and so the string is not localized.
+            [msg appendString:@"Unknown issue."];
+            break;
+        }
+
+        [array addObject:msg];
+    }
+
+    return array;
+}
+
 @end

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -140,3 +140,21 @@
 "Roman Numbers (Full-Width Upper Case)" = "Roman Numbers (Full-Width Upper Case)";
 
 "Roman Numbers (Full-Width Lower Case)" = "Roman Numbers (Full-Width Lower Case)";
+
+"Show Issues in User Files ⚠️" = "Show Issues in User Files ⚠️";
+
+"Issues were found in the following user phrase files:" = "Issues were found in the following user phrase files:";
+
+"Check McBopomofo menu for user file issues" = "Check McBopomofo menu for user file issues";
+
+"User phrase file" = "User phrase file";
+
+"Excluded phrase file" = "Excluded phrase file";
+
+"Phrase replacement file" = "Phrase replacement file";
+
+"line %lu: " = "line %lu: ";
+
+"Only one column was found." = "Only one column was found.";
+
+"Illegal NULL character was found." = "Illegal NULL character was found.";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -138,3 +138,21 @@
 "Roman Numbers (Full-Width Upper Case)" = "羅馬數字 (大寫全形)";
 
 "Roman Numbers (Full-Width Lower Case)" = "羅馬數字 (小寫全形)";
+
+"Show Issues in User Files ⚠️" = "列出自訂詞庫中的問題 ⚠️";
+
+"Issues were found in the following user phrase files:" = "以下是用戶自訂詞庫檔案中發現的問題：";
+
+"Check McBopomofo menu for user file issues" = "自訂詞庫有誤，請從小麥注音選單點選「列出自訂詞庫中的問題」";
+
+"User phrase file" = "使用者自訂詞彙檔";
+
+"Excluded phrase file" = "排除詞彙檔";
+
+"Phrase replacement file" = "詞彙替換表格檔";
+
+"line %lu: " = "第 %lu 行：";
+
+"Only one column was found." = "一行應該有兩欄文字，這行只有一欄。";
+
+"Illegal NULL character was found." = "這一行包含了不合規則的 NULL 字元 (0x00)。";


### PR DESCRIPTION
A long-staying (5 seconds) notification is shown upon any user file issues found when `activateServer` is called or when the user reloads the files manually from the menu.

A menu item is added to allow the user to inspect those issues—when there are such issues. I tried to set an SF Symbol to the `NSMenuItem` but it doesn't work, and so the alert emoji is used in the menu (it is not supposed to be shown often, and so I'm fine with making this glaring).

<img width="286" height="334" alt="screenshot" src="https://github.com/user-attachments/assets/0a6dc660-f2fe-4ebe-9ee6-82054a05e5c8" />
