### PR TITLE
Fix vertical candidate window flickering

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/CandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/CandidateController.swift
@@ -55,20 +55,23 @@ public class CandidateController: NSWindowController {
     @objc public var selectedCandidateIndex: UInt = .max
     @objc public var visible: Bool = false {
         didSet {
-            NSObject.cancelPreviousPerformRequests(withTarget: self)
             guard let window else {
                 return
             }
             let alreadyVisible = window.isVisible
             if visible {
-                window.perform(#selector(NSWindow.orderFront(_:)), with: self, afterDelay: 0.0)
+                DispatchQueue.main.async {
+                    window.orderFront(self)
+                }
                 if !alreadyVisible {
                     NSAccessibility.post(element: window, notification: .created)
                     NSAccessibility
                         .post(element: window, notification: .focusedWindowChanged)
                 }
             } else {
-                window.perform(#selector(NSWindow.orderOut(_:)), with: self, afterDelay: 0.0)
+                DispatchQueue.main.async {
+                    window.orderOut(self)
+                }
             }
         }
     }

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -799,8 +799,6 @@ extension McBopomofoInputMethodController {
         gCurrentCandidateController?.reloadData()
         currentClient = client
 
-        gCurrentCandidateController?.visible = true
-
         var lineHeightRect = NSMakeRect(0.0, 0.0, 16.0, 16.0)
         var cursor: Int = 0
 
@@ -829,6 +827,8 @@ extension McBopomofoInputMethodController {
                     lineHeightRect.origin.x, lineHeightRect.origin.y - 4.0),
                 bottomOutOfScreenAdjustmentHeight: lineHeightRect.size.height + 4.0)
         }
+
+        gCurrentCandidateController?.visible = true
     }
 
     private func show(tooltip: String, composingBuffer: String, cursorIndex: UInt, client: Any!) {


### PR DESCRIPTION
The flickering issue is more often found with the vertical candidate window, likely due to the layout passes it needs to go through. This PR makes sure that candidate window position is first set before the window becomes visible.

This PR also switches to use dispatch queue for all delayed method invocation. This makes sure that all such deferred actions are put in the same queue, and so they will be performed in the expected order.