### PR TITLE
Put additional width constraints to a few buttons

### DIFF
--- a/Source/Installer/Base.lproj/MainMenu.xib
+++ b/Source/Installer/Base.lproj/MainMenu.xib
@@ -93,17 +93,20 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button imageHugsTitle="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="575">
-                        <rect key="frame" x="495" y="16" width="125" height="24"/>
+                        <rect key="frame" x="488" y="16" width="132" height="24"/>
                         <buttonCell key="cell" type="push" title="Agree and Install" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="576">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="132" id="6in-bW-FvA"/>
+                        </constraints>
                         <connections>
                             <action selector="agreeAndInstallAction:" target="494" id="708"/>
                         </connections>
                     </button>
                     <button imageHugsTitle="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="592">
-                        <rect key="frame" x="417" y="16" width="66" height="24"/>
+                        <rect key="frame" x="380" y="16" width="96" height="24"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="593">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -111,11 +114,14 @@
 Gw
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="Zs7-a3-cix"/>
+                        </constraints>
                         <connections>
                             <action selector="cancelAction:" target="494" id="707"/>
                         </connections>
                     </button>
-                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="623">
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="623">
                         <rect key="frame" x="18" y="324" width="506" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Welcome to the McBopomofo Installer! Please read the following Software Licence:" id="624">
                             <font key="font" metaFont="system"/>
@@ -123,7 +129,7 @@ Gw
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="688">
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="688">
                         <rect key="frame" x="18" y="20" width="281" height="14"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="By installing the software I agree to the terms above." id="689">
                             <font key="font" metaFont="smallSystem"/>
@@ -201,13 +207,14 @@ Gw
                 <rect key="frame" x="0.0" y="0.0" width="480" height="180"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <progressIndicator wantsLayer="YES" fixedFrame="YES" maxValue="1" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="deb-uT-yNv">
+                    <progressIndicator wantsLayer="YES" maxValue="1" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="deb-uT-yNv">
                         <rect key="frame" x="20" y="67" width="440" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                     </progressIndicator>
-                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VDL-Yq-heb">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VDL-Yq-heb">
                         <rect key="frame" x="18" y="94" width="444" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="17" id="kHi-qQ-SL5"/>
+                        </constraints>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Stopping the old version. This may take up to one minute…" id="nTo-dx-qfZ">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -215,6 +222,14 @@ Gw
                         </textFieldCell>
                     </textField>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="VDL-Yq-heb" secondAttribute="trailing" constant="20" symbolic="YES" id="5vd-Nm-6J4"/>
+                    <constraint firstItem="VDL-Yq-heb" firstAttribute="leading" secondItem="deb-uT-yNv" secondAttribute="leading" id="LS0-Oi-jId"/>
+                    <constraint firstItem="VDL-Yq-heb" firstAttribute="top" secondItem="wAe-c8-Vh9" secondAttribute="top" constant="69" id="ZFU-wR-o5h"/>
+                    <constraint firstItem="VDL-Yq-heb" firstAttribute="trailing" secondItem="deb-uT-yNv" secondAttribute="trailing" id="gbh-71-gQH"/>
+                    <constraint firstItem="deb-uT-yNv" firstAttribute="top" secondItem="VDL-Yq-heb" secondAttribute="bottom" constant="7" id="p4M-1d-lKa"/>
+                    <constraint firstItem="VDL-Yq-heb" firstAttribute="leading" secondItem="wAe-c8-Vh9" secondAttribute="leading" constant="20" symbolic="YES" id="q2R-Q8-ajF"/>
+                </constraints>
             </view>
             <point key="canvasLocation" x="4" y="123.5"/>
         </window>

--- a/Source/Installer/zh-Hant.lproj/MainMenu.xib
+++ b/Source/Installer/zh-Hant.lproj/MainMenu.xib
@@ -119,17 +119,20 @@
                         </scroller>
                     </scrollView>
                     <button imageHugsTitle="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="575">
-                        <rect key="frame" x="544" y="16" width="76" height="24"/>
+                        <rect key="frame" x="524" y="16" width="96" height="24"/>
                         <buttonCell key="cell" type="push" title="同意安裝" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="576">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="iM3-Dn-zWz"/>
+                        </constraints>
                         <connections>
                             <action selector="agreeAndInstallAction:" target="494" id="708"/>
                         </connections>
                     </button>
                     <button imageHugsTitle="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="592">
-                        <rect key="frame" x="482" y="19" width="50" height="16"/>
+                        <rect key="frame" x="416" y="19" width="96" height="16"/>
                         <buttonCell key="cell" type="push" title="取消" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="593">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -138,13 +141,14 @@ Gw
 </string>
                         </buttonCell>
                         <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="96" id="PnU-pl-qqr"/>
                             <constraint firstAttribute="height" constant="16" id="wz6-NH-04O"/>
                         </constraints>
                         <connections>
                             <action selector="cancelAction:" target="494" id="707"/>
                         </connections>
                     </button>
-                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="688">
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="688">
                         <rect key="frame" x="18" y="20" width="246" height="14"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="點選「同意安裝」，表示您同意本軟體的使用授權。" id="689">
                             <font key="font" metaFont="smallSystem"/>
@@ -152,7 +156,7 @@ Gw
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="623">
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="623">
                         <rect key="frame" x="18" y="332" width="604" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="歡迎您安裝「小麥注音輸入法」！在安裝之前，請您閱讀本軟體的使用授權：" id="624">
                             <font key="font" metaFont="system"/>
@@ -204,13 +208,14 @@ Gw
                 <rect key="frame" x="0.0" y="0.0" width="480" height="180"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <progressIndicator wantsLayer="YES" fixedFrame="YES" maxValue="1" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="4v9-yU-zek">
+                    <progressIndicator wantsLayer="YES" maxValue="1" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="4v9-yU-zek">
                         <rect key="frame" x="20" y="67" width="440" height="20"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
                     </progressIndicator>
-                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6mo-HZ-Dbl">
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6mo-HZ-Dbl">
                         <rect key="frame" x="18" y="94" width="444" height="17"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="17" id="0IY-4c-hWH"/>
+                        </constraints>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="等待舊版完全停用，大約需要一分鐘…" id="T73-Ph-Unt">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -218,6 +223,14 @@ Gw
                         </textFieldCell>
                     </textField>
                 </subviews>
+                <constraints>
+                    <constraint firstItem="4v9-yU-zek" firstAttribute="top" secondItem="6mo-HZ-Dbl" secondAttribute="bottom" constant="7" id="3zZ-2v-iZN"/>
+                    <constraint firstItem="6mo-HZ-Dbl" firstAttribute="leading" secondItem="4v9-yU-zek" secondAttribute="leading" id="5cy-3j-8V6"/>
+                    <constraint firstAttribute="trailing" secondItem="6mo-HZ-Dbl" secondAttribute="trailing" constant="20" symbolic="YES" id="8z8-Ba-MRe"/>
+                    <constraint firstItem="6mo-HZ-Dbl" firstAttribute="trailing" secondItem="4v9-yU-zek" secondAttribute="trailing" id="Lsk-i2-G4Z"/>
+                    <constraint firstItem="6mo-HZ-Dbl" firstAttribute="top" secondItem="Qab-7x-ryB" secondAttribute="top" constant="69" id="iOq-4K-suY"/>
+                    <constraint firstItem="6mo-HZ-Dbl" firstAttribute="leading" secondItem="Qab-7x-ryB" secondAttribute="leading" constant="20" symbolic="YES" id="sE8-Jz-xEB"/>
+                </constraints>
             </view>
             <point key="canvasLocation" x="4" y="123.5"/>
         </window>

--- a/Source/NonModalAlertWindowController.xib
+++ b/Source/NonModalAlertWindowController.xib
@@ -27,11 +27,14 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5">
-                        <rect key="frame" x="335" y="20" width="65" height="24"/>
+                        <rect key="frame" x="310" y="20" width="90" height="24"/>
                         <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="90" id="LAB-gI-c3V"/>
+                        </constraints>
                         <connections>
                             <action selector="confirmButtonAction:" target="-2" id="85"/>
                         </connections>
@@ -40,7 +43,7 @@
                         <rect key="frame" x="24" y="50" width="64" height="64"/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="AlertIcon" id="13"/>
                     </imageView>
-                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="39">
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="39">
                         <rect key="frame" x="102" y="98" width="88" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Lorem ipsum" id="40">
                             <font key="font" metaFont="systemBold"/>
@@ -48,7 +51,7 @@
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="296" translatesAutoresizingMaskIntoConstraints="NO" id="59">
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" preferredMaxLayoutWidth="296" translatesAutoresizingMaskIntoConstraints="NO" id="59">
                         <rect key="frame" x="102" y="75" width="304" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Lorem ipsum" id="60">
                             <font key="font" metaFont="smallSystem"/>
@@ -57,11 +60,14 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="71">
-                        <rect key="frame" x="258" y="20" width="65" height="24"/>
+                        <rect key="frame" x="208" y="20" width="90" height="24"/>
                         <buttonCell key="cell" type="push" title="Button" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="73">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="90" id="o24-Ke-PnF"/>
+                        </constraints>
                         <connections>
                             <action selector="cancelButtonAction:" target="-2" id="86"/>
                         </connections>


### PR DESCRIPTION
They can sometimes look too narrow when the title is short. This restores the pre-auto-layout look.