### PR TITLE
Fix SyntaxWarning in regex using raw string

### DIFF
--- a/Source/Data/curation/compilers/plain_bpmf_compiler.py
+++ b/Source/Data/curation/compilers/plain_bpmf_compiler.py
@@ -8,7 +8,7 @@ __author__ = "Lukhnos Liu and The McBopomofo Authors"
 __copyright__ = "Copyright 2012 and onwards The McBopomofo Authors"
 __license__ = "MIT"
 
-skip = re.compile("．\s+_punctuation.*_>")
+skip = re.compile(r"．\s+_punctuation.*_>")
 
 insert = ["．", "_punctuation_\"", "0.0"]
 


### PR DESCRIPTION
When running with `python -m`, Python only shows a given warning once, so the message disappears after the first run unless `__pycache__` is removed.

That’s probably why we missed it before. Still, it makes sense to clean this up : )

<img width="600" src="https://github.com/user-attachments/assets/841afdce-937c-4a88-ab7c-3fbbaf88320a" />

<img width="600" src="https://github.com/user-attachments/assets/2bb3534f-2cef-4ee0-b334-c37dd1e897ab" />