### PR TITLE
Allow tone key to revise prior reading (#753)

### DIFF
--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -2709,7 +2709,7 @@ extension KeyHandlerBopomofoTests {
 
 extension KeyHandlerBopomofoTests {
 
-    func testChnagingReadingUsingToneKey1() {
+    func checkChangingReadingUsingToneKey(input: String, expected: String) {
         let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
         Preferences.associatedPhrasesEnabled = false
 
@@ -2718,7 +2718,7 @@ extension KeyHandlerBopomofoTests {
         }
 
         var state: InputState = InputState.Empty()
-        let keys = Array("vul3a943").map {
+        let keys = Array(input).map {
             String($0)
         }
         for key in keys {
@@ -2732,61 +2732,22 @@ extension KeyHandlerBopomofoTests {
         }
         XCTAssertTrue(state is InputState.Inputting, "\(state)")
         if let state = state as? InputState.Inputting {
-            XCTAssertEqual(state.composingBuffer, "小買")
+            XCTAssertEqual(state.composingBuffer, expected)
         }
     }
 
-    func testChnagingReadingUsingToneKey2() {
-        let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
-        Preferences.associatedPhrasesEnabled = false
-
-        defer {
-            Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
-        }
-
-        var state: InputState = InputState.Empty()
-        let keys = Array("vul3a946").map {
-            String($0)
-        }
-        for key in keys {
-            let input = KeyHandlerInput(
-                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
-                isVerticalMode: false)
-            handler.handle(input: input, state: state) { newState in
-                state = newState
-            } errorCallback: {
-            }
-        }
-        XCTAssertTrue(state is InputState.Inputting, "\(state)")
-        if let state = state as? InputState.Inputting {
-            XCTAssertEqual(state.composingBuffer, "小埋")
-        }
+    // Input 小麥 then change to tone 3
+    func testChangingReadingUsingToneKey1() {
+        checkChangingReadingUsingToneKey(input: "vul3a943", expected: "小買")
     }
 
-    func testChnagingReadingUsingToneKey3() {
-        let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
-        Preferences.associatedPhrasesEnabled = false
+    // Input 小麥 then change to tone 4
+    func testChangingReadingUsingToneKey2() {
+        checkChangingReadingUsingToneKey(input: "vul3a946", expected: "小埋")
+    }
 
-        defer {
-            Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
-        }
-
-        var state: InputState = InputState.Empty()
-        let keys = Array("vul3a947").map {
-            String($0)
-        }
-        for key in keys {
-            let input = KeyHandlerInput(
-                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
-                isVerticalMode: false)
-            handler.handle(input: input, state: state) { newState in
-                state = newState
-            } errorCallback: {
-            }
-        }
-        XCTAssertTrue(state is InputState.Inputting, "\(state)")
-        if let state = state as? InputState.Inputting {
-            XCTAssertEqual(state.composingBuffer, "小麥˙")
-        }
+    // Input 小麥 then change to tone 5
+    func testChangingReadingUsingToneKey3() {
+        checkChangingReadingUsingToneKey(input: "vul3a947", expected: "小麥˙")
     }
 }

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -2711,10 +2711,13 @@ extension KeyHandlerBopomofoTests {
 
     func checkChangingReadingUsingToneKey(input: String, expected: String) {
         let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
+        let allowChangingPriorTone = Preferences.allowChangingPriorTone
         Preferences.associatedPhrasesEnabled = false
+        Preferences.allowChangingPriorTone = true
 
         defer {
             Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
+            Preferences.allowChangingPriorTone = allowChangingPriorTone
         }
 
         var state: InputState = InputState.Empty()

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -2706,3 +2706,87 @@ extension KeyHandlerBopomofoTests {
         }
     }
 }
+
+extension KeyHandlerBopomofoTests {
+
+    func testChnagingReadingUsingToneKey1() {
+        let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+
+        defer {
+            Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
+        }
+
+        var state: InputState = InputState.Empty()
+        let keys = Array("vul3a943").map {
+            String($0)
+        }
+        for key in keys {
+            let input = KeyHandlerInput(
+                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
+                isVerticalMode: false)
+            handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+        }
+        XCTAssertTrue(state is InputState.Inputting, "\(state)")
+        if let state = state as? InputState.Inputting {
+            XCTAssertEqual(state.composingBuffer, "小買")
+        }
+    }
+
+    func testChnagingReadingUsingToneKey2() {
+        let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+
+        defer {
+            Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
+        }
+
+        var state: InputState = InputState.Empty()
+        let keys = Array("vul3a946").map {
+            String($0)
+        }
+        for key in keys {
+            let input = KeyHandlerInput(
+                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
+                isVerticalMode: false)
+            handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+        }
+        XCTAssertTrue(state is InputState.Inputting, "\(state)")
+        if let state = state as? InputState.Inputting {
+            XCTAssertEqual(state.composingBuffer, "小埋")
+        }
+    }
+
+    func testChnagingReadingUsingToneKey3() {
+        let associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+
+        defer {
+            Preferences.associatedPhrasesEnabled = associatedPhrasesEnabled
+        }
+
+        var state: InputState = InputState.Empty()
+        let keys = Array("vul3a947").map {
+            String($0)
+        }
+        for key in keys {
+            let input = KeyHandlerInput(
+                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
+                isVerticalMode: false)
+            handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+        }
+        XCTAssertTrue(state is InputState.Inputting, "\(state)")
+        if let state = state as? InputState.Inputting {
+            XCTAssertEqual(state.composingBuffer, "小麥˙")
+        }
+    }
+}

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -458,7 +458,15 @@ class BopomofoReadingBuffer {
 
   const BPMF syllable() const { return syllable_; }
 
-  void setSyllable(BPMF syllable) { syllable_ = syllable; }
+  void setSyllableRemovingTone(BPMF syllable) {
+    BPMF::Component masked = (syllable.consonantComponent() |
+                               syllable.middleVowelComponent() |
+                               syllable.vowelComponent());
+    syllable_ = BPMF(masked);
+    if (pinyin_mode_) {
+      pinyin_sequence_ = syllable_.HanyuPinyinString(false, false);
+    }
+  }
 
   const std::string standardLayoutQueryString() const {
     return BopomofoKeyboardLayout::StandardLayout()->keySequenceFromSyllable(
@@ -484,3 +492,4 @@ class BopomofoReadingBuffer {
 }  // namespace Formosa
 
 #endif  // SRC_ENGINE_MANDARIN_MANDARIN_H_
+

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -458,6 +458,8 @@ class BopomofoReadingBuffer {
 
   const BPMF syllable() const { return syllable_; }
 
+  void setsSyllable(BPMF syllable) { syllable_ = syllable; }
+
   const std::string standardLayoutQueryString() const {
     return BopomofoKeyboardLayout::StandardLayout()->keySequenceFromSyllable(
         syllable_);

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -458,16 +458,6 @@ class BopomofoReadingBuffer {
 
   const BPMF syllable() const { return syllable_; }
 
-  void setSyllableRemovingTone(BPMF syllable) {
-    BPMF::Component masked = (syllable.consonantComponent() |
-                               syllable.middleVowelComponent() |
-                               syllable.vowelComponent());
-    syllable_ = BPMF(masked);
-    if (pinyin_mode_) {
-      pinyin_sequence_ = syllable_.HanyuPinyinString(false, false);
-    }
-  }
-
   const std::string standardLayoutQueryString() const {
     return BopomofoKeyboardLayout::StandardLayout()->keySequenceFromSyllable(
         syllable_);

--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -458,7 +458,7 @@ class BopomofoReadingBuffer {
 
   const BPMF syllable() const { return syllable_; }
 
-  void setsSyllable(BPMF syllable) { syllable_ = syllable; }
+  void setSyllable(BPMF syllable) { syllable_ = syllable; }
 
   const std::string standardLayoutQueryString() const {
     return BopomofoKeyboardLayout::StandardLayout()->keySequenceFromSyllable(

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -470,10 +470,10 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     // the current cursor.
     if (_bpmfReadingBuffer->hasToneMarkerOnly() && _grid->readings().size() > 0 && _grid->cursor() > 0) {
         size_t cursor = _grid->cursor() - 1;
-        std::string reading = _grid->readings()[cursor];
+        const std::string reading = _grid->readings()[cursor];
         if (!reading.empty() && reading[0] != '_') {
             Formosa::Mandarin::BopomofoReadingBuffer tmpBuffer(_bpmfReadingBuffer->keyboardLayout());
-            Formosa::Mandarin::BopomofoSyllable syllable = Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
+            Formosa::Mandarin::BopomofoSyllable syllable =      Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
             tmpBuffer.setSyllableRemovingTone(syllable);
             tmpBuffer.combineKey((char)charCode);
             std::string newReading = tmpBuffer.syllable().composedString();

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -468,12 +468,11 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     //
     // This allows users to use tone key to change an existing reading before
     // the current cursor.
-    if (Preferences.allowChangingPriorTone &&
-        _bpmfReadingBuffer->hasToneMarkerOnly() &&
+    if (_bpmfReadingBuffer->hasToneMarkerOnly() &&
         _grid->readings().size() > 0 &&
-        _grid->cursor() > 0) {
+        _grid->cursor() > 0 &&
+        Preferences.allowChangingPriorTone) {
         size_t cursor = _grid->cursor() - 1;
-//        const std::string reading = _grid->readings()[cursor];
         const std::string& reading = _grid->readings()[cursor];
         if (!reading.empty() && reading[0] != '_') {
             Formosa::Mandarin::BopomofoReadingBuffer tmpBuffer(_bpmfReadingBuffer->keyboardLayout());

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -472,12 +472,11 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         size_t cursor = _grid->cursor() - 1;
         std::string reading = _grid->readings()[cursor];
         if (reading.rfind(std::string("_"), 0) != 0) {
-            Formosa::Mandarin::BopomofoReadingBuffer *tmpBuffer = new Formosa::Mandarin::BopomofoReadingBuffer(_bpmfReadingBuffer->keyboardLayout());
+            Formosa::Mandarin::BopomofoReadingBuffer tmpBuffer(_bpmfReadingBuffer->keyboardLayout());
             Formosa::Mandarin::BopomofoSyllable syllable = Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
-            tmpBuffer->setsSyllable(syllable);
-            tmpBuffer->combineKey((char)charCode);
-            std::string newReading = tmpBuffer->syllable().composedString();
-            delete tmpBuffer;
+            tmpBuffer.setSyllable(syllable);
+            tmpBuffer.combineKey((char)charCode);
+            std::string newReading = tmpBuffer.syllable().composedString();
             if (_languageModel->hasUnigrams(newReading)) {
                 _bpmfReadingBuffer->clear();
                 _grid->deleteReadingBeforeCursor();

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -468,13 +468,20 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     //
     // This allows users to use tone key to change an existing reading before
     // the current cursor.
-    if (_bpmfReadingBuffer->hasToneMarkerOnly() && _grid->readings().size() > 0 && _grid->cursor() > 0) {
+    if (Preferences.allowChangingPriorTone &&
+        _bpmfReadingBuffer->hasToneMarkerOnly() &&
+        _grid->readings().size() > 0 &&
+        _grid->cursor() > 0) {
         size_t cursor = _grid->cursor() - 1;
-        const std::string reading = _grid->readings()[cursor];
+//        const std::string reading = _grid->readings()[cursor];
+        const std::string& reading = _grid->readings()[cursor];
         if (!reading.empty() && reading[0] != '_') {
             Formosa::Mandarin::BopomofoReadingBuffer tmpBuffer(_bpmfReadingBuffer->keyboardLayout());
-            Formosa::Mandarin::BopomofoSyllable syllable =      Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
-            tmpBuffer.setSyllableRemovingTone(syllable);
+            Formosa::Mandarin::BopomofoSyllable syllable = Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
+            std::string keys = _bpmfReadingBuffer->keyboardLayout()->keySequenceFromSyllable(syllable);
+            for (char k:keys) {
+                tmpBuffer.combineKey(k);
+            }
             tmpBuffer.combineKey((char)charCode);
             std::string newReading = tmpBuffer.syllable().composedString();
             if (_languageModel->hasUnigrams(newReading)) {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -471,10 +471,10 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     if (_bpmfReadingBuffer->hasToneMarkerOnly() && _grid->readings().size() > 0 && _grid->cursor() > 0) {
         size_t cursor = _grid->cursor() - 1;
         std::string reading = _grid->readings()[cursor];
-        if (reading.rfind(std::string("_"), 0) != 0) {
+        if (!reading.empty() && reading[0] != '_') {
             Formosa::Mandarin::BopomofoReadingBuffer tmpBuffer(_bpmfReadingBuffer->keyboardLayout());
             Formosa::Mandarin::BopomofoSyllable syllable = Formosa::Mandarin::BopomofoSyllable::FromComposedString(reading);
-            tmpBuffer.setSyllable(syllable);
+            tmpBuffer.setSyllableRemovingTone(syllable);
             tmpBuffer.combineKey((char)charCode);
             std::string newReading = tmpBuffer.syllable().composedString();
             if (_languageModel->hasUnigrams(newReading)) {
@@ -488,7 +488,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             }
         }
     }
-
 
     BOOL composeReading = isValidKey && _bpmfReadingBuffer->hasToneMarker() && !_bpmfReadingBuffer->hasToneMarkerOnly();
 

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -74,6 +74,7 @@ private let kBig5InputEnabledKey = "Big5InputEnabled"
 let kBeepUponInputErrorKey = "BeepUponInputError"
 
 private let kEnableUserPhrasesInPlainBopomofo = "EnableUserPhrasesInPlainBopomofo"
+private let kAllowChangingPriorTone = "AllowChangingPriorTone"
 
 // MARK: Property wrappers
 
@@ -568,6 +569,11 @@ extension Preferences {
 extension Preferences {
     @UserDefault(key: kEnableUserPhrasesInPlainBopomofo, defaultValue: false)
     @objc static var enableUserPhrasesInPlainBopomofo: Bool
+}
+
+extension Preferences {
+    @UserDefault(key: kAllowChangingPriorTone, defaultValue: false)
+    @objc static var allowChangingPriorTone: Bool
 }
 
 extension Preferences {


### PR DESCRIPTION
The PR implements the feature request in #753. It allows users to change the tone of a prior BPMF reading.

When a user presses a tone key without any other syllabels, the key handler tries to convert the reading before the cursor to syllabel and then append the new tone key. Finally, it delete the original reading and insert a new one.

The PR add a new API to allow chaning the syllabel of `BopomofoReadingBuffer `. 