### PR TITLE
Potential fix for code scanning alert no. 10: String length conflation

### DIFF
--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -721,7 +721,7 @@ extension McBopomofoInputMethodController {
             commit(text: previous.composingBuffer, client: client)
         }
         client.setMarkedText(
-            composingBuffer, selectionRange: NSMakeRange(composingBuffer.count, 0),
+            composingBuffer, selectionRange: NSMakeRange(NSString(string: composingBuffer).length, 0),
             replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -721,7 +721,7 @@ extension McBopomofoInputMethodController {
             commit(text: previous.composingBuffer, client: client)
         }
         client.setMarkedText(
-            composingBuffer, selectionRange: NSMakeRange(NSString(string: composingBuffer).length, 0),
+            composingBuffer, selectionRange: NSMakeRange(composingBuffer.utf16.count, 0),
             replacementRange: NSMakeRange(NSNotFound, NSNotFound))
     }
 


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/openvanilla/McBopomofo/security/code-scanning/10](https://github.com/openvanilla/McBopomofo/security/code-scanning/10)

To fix the problem, ensure that all offsets and lengths passed to NSRange (such as in `NSMakeRange`) are expressed in UTF-16 code units as expected by NSString and Cocoa APIs. Specifically, instead of using `composingBuffer.count`, use the length of the corresponding NSString, i.e. `NSString(string: composingBuffer).length`.  
**File/region to change:**  
- File: Source/InputMethodController.swift  
- Line(s): 724  
Update the `selectionRange: NSMakeRange(composingBuffer.count, 0)` to use the NSString length instead.  
No new methods or complex imports are required; NSString is available via Foundation/Cocoa.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Bug fix


___

### **Description**
- Fix UTF-16 length for NSRange

- Prevent string length conflation issue

- Align selectionRange with Cocoa expectations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  str["Swift String length (characters)"]
  utf16["NSString length (UTF-16 units)"]
  nsrange["NSRange for setMarkedText"]
  apis["Cocoa Text APIs"]

  str -- "was used (incorrect)" --> nsrange
  utf16 -- "now used (correct)" --> nsrange
  nsrange -- "compatible with" --> apis
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InputMethodController.swift</strong><dd><code>Use NSString length for NSRange in setMarkedText</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/InputMethodController.swift

<ul><li>Replace character count with NSString length.<br> <li> Build NSRange using UTF-16 code units.<br> <li> Update setMarkedText selectionRange argument.</ul>


</details>


  </td>
  <td><a href="https://github.com/openvanilla/McBopomofo/pull/756/files#diff-992568b383e757cf13b3e05a3ce16b35c29ec07e8431cf7348d2ae56379d1670">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

