### PR TITLE
Fix scroll-to-0 regression in vertical panel

### DIFF
--- a/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
+++ b/Packages/CandidateUI/Sources/CandidateUI/VerticalCandidateController.swift
@@ -405,8 +405,8 @@ public class VerticalCandidateController: CandidateController {
                 let selectedRow = tableView.selectedRow
                 let pageIndex = newRowIndex / labelCount
 
-                if selectedRow == -1 || abs(newRowIndex - selectedRow) == 1 {
-                    // Simply scroll to the row if never selected or if it's moving by one.
+                if selectedRow == -1 || newRowIndex == 0 || abs(newRowIndex - selectedRow) == 1 {
+                    // Simply scroll to the row if never selected, if to row 0, or if it's moving by one.
                     tableView.scrollRowToVisible(newRowIndex)
                 } else {
                     if newRowIndex > selectedRow {


### PR DESCRIPTION
In https://github.com/openvanilla/McBopomofo/pull/755 we generalized the math in vertical panel scrolling and synced the code with OpenVanilla, but due to how McBopomofo sets the panel candidate differently, the PR caused a regression in that the vertical panel failed to scroll back to page 0 if a previous candidate selection session moved to a non-zero page.

## Postmortem

The generalized math has a code path that does nothing. However, we didn't account for the fact that McBopomofo repeatedly resets the candidate panel's delegate. _Resetting delegate reloads the data_, but when the delegate is set to `nil`, there are no actual rows, and the table view's selected row is reset to 0 while the scroll view is still set to where the non-zero page started (this is consistent with Cocoa's behavior). But because the selected row is now reset, when the new candidate data is loaded, the candidate panel thinks that no further action is needed (because it's already set to 0), and so no scrolling is needed. In the previous code, `-scrollRowToVisible` was always called in this case. We therefore need to make sure that `-scrollRowToVisible` is always called when the selected candidate index is set to 0.

OpenVanilla is not affected due to how it interacts with the panel's delegate logic, but syncing this change is still desirable.