### PR TITLE
feat(engine): add ContextualUserModel with interpolated Kneser-Ney scoring

### DIFF
--- a/McBopomofo.xcodeproj/project.pbxproj
+++ b/McBopomofo.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		D47F7DCE278BFB57002F9DD7 /* PreferencesWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47F7DCD278BFB57002F9DD7 /* PreferencesWindowController.swift */; };
 		D47F7DD0278C0897002F9DD7 /* NonModalAlertWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D47F7DCF278C0897002F9DD7 /* NonModalAlertWindowController.swift */; };
 		D47F7DD3278C1263002F9DD7 /* UserOverrideModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D47F7DD2278C1263002F9DD7 /* UserOverrideModel.cpp */; };
+		D47F7DD4278C1263002F9DE1 /* ContextualUserModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D47F7DD6278C1263002F9DE1 /* ContextualUserModel.cpp */; };
 		D485D3B92796A8A000657FF3 /* PreferencesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D485D3B82796A8A000657FF3 /* PreferencesTests.swift */; };
 		D485D3C02796CE3200657FF3 /* VersionUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D485D3BF2796CE3200657FF3 /* VersionUpdateTests.swift */; };
 		D48F853E2EACDB6C00C2FDAB /* RomanNumbers in Frameworks */ = {isa = PBXBuildFile; productRef = D48F853D2EACDB6C00C2FDAB /* RomanNumbers */; };
@@ -229,6 +230,8 @@
 		D47F7DCF278C0897002F9DD7 /* NonModalAlertWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonModalAlertWindowController.swift; sourceTree = "<group>"; };
 		D47F7DD1278C1263002F9DD7 /* UserOverrideModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserOverrideModel.h; sourceTree = "<group>"; };
 		D47F7DD2278C1263002F9DD7 /* UserOverrideModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserOverrideModel.cpp; sourceTree = "<group>"; };
+		D47F7DD5278C1263002F9DE1 /* ContextualUserModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContextualUserModel.h; sourceTree = "<group>"; };
+		D47F7DD6278C1263002F9DE1 /* ContextualUserModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ContextualUserModel.cpp; sourceTree = "<group>"; };
 		D485D3B62796A8A000657FF3 /* McBopomofoTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = McBopomofoTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D485D3B82796A8A000657FF3 /* PreferencesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesTests.swift; sourceTree = "<group>"; };
 		D485D3BF2796CE3200657FF3 /* VersionUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionUpdateTests.swift; sourceTree = "<group>"; };
@@ -385,6 +388,8 @@
 				6ACC3D412793701600F1B140 /* ParselessPhraseDB.h */,
 				D44FB74B2792189A003C80A6 /* PhraseReplacementMap.cpp */,
 				D44FB74C2792189A003C80A6 /* PhraseReplacementMap.h */,
+				D47F7DD6278C1263002F9DE1 /* ContextualUserModel.cpp */,
+				D47F7DD5278C1263002F9DE1 /* ContextualUserModel.h */,
 				D47F7DD2278C1263002F9DD7 /* UserOverrideModel.cpp */,
 				D47F7DD1278C1263002F9DD7 /* UserOverrideModel.h */,
 				D41355DC278EA3ED005E5CBD /* UserPhrasesLM.cpp */,
@@ -768,6 +773,7 @@
 				D47F7DCE278BFB57002F9DD7 /* PreferencesWindowController.swift in Sources */,
 				D41355DB278E6D17005E5CBD /* McBopomofoLM.cpp in Sources */,
 				D47F7DD3278C1263002F9DD7 /* UserOverrideModel.cpp in Sources */,
+				D47F7DD4278C1263002F9DE1 /* ContextualUserModel.cpp in Sources */,
 				6A0D4F4515FC0EB100ABF4B3 /* Mandarin.cpp in Sources */,
 				6ACC3D452793701600F1B140 /* ParselessLM.cpp in Sources */,
 				D4CB1A5B2B389B78006EA984 /* DictionaryService.swift in Sources */,

--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(McBopomofoLMLib
         AssociatedPhrasesV2.cpp
         ByteBlockBackedDictionary.h
         ByteBlockBackedDictionary.cpp
+        ContextualUserModel.h
+        ContextualUserModel.cpp
         McBopomofoLM.cpp
         McBopomofoLM.h
         MemoryMappedFile.h
@@ -86,6 +88,7 @@ if (ENABLE_TEST)
         add_executable(McBopomofoLMLibTest
                 AssociatedPhrasesV2Test.cpp
                 ByteBlockBackedDictionaryTest.cpp
+                ContextualUserModelTest.cpp
                 McBopomofoLMTest.cpp
                 MemoryMappedFileTest.cpp
                 ParselessLMTest.cpp

--- a/Source/Engine/ContextualUserModel.cpp
+++ b/Source/Engine/ContextualUserModel.cpp
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include "ContextualUserModel.h"
+
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace McBopomofo {
+
+namespace {
+
+constexpr char kFileHeader[] = "# mcbopomofo-contextual-user-model v1";
+
+// A candidate generalizes to an unseen context only after it has been
+// confirmed in at least this many distinct contexts.
+constexpr size_t kMinContextsForGeneralization = 2;
+
+// Decayed evidence below this is treated as absent so that stale entries
+// stop producing suggestions.
+constexpr double kMinSuggestionProbability = 0.25;
+
+std::string CombineReadingValue(const std::string& reading,
+                                const std::string& value) {
+  return std::string("(") + reading + "," + value + ")";
+}
+
+bool IsPunctuation(const Formosa::Gramambular2::ReadingGrid::NodePtr& node) {
+  const std::string& reading = node->reading();
+  return !reading.empty() && reading[0] == '_';
+}
+
+bool ContainsSeparator(const std::string& s) {
+  return s.find('\t') != std::string::npos ||
+         s.find('\n') != std::string::npos || s.find('\r') != std::string::npos;
+}
+
+// The context marker for the node preceding `it` in a walk, or kStartContext
+// if there is none or it is punctuation.
+std::string ContextBefore(
+    const std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>& nodes,
+    std::vector<Formosa::Gramambular2::ReadingGrid::NodePtr>::const_iterator
+        it) {
+  if (it == nodes.cbegin()) {
+    return ContextualUserModel::kStartContext;
+  }
+  --it;
+  if (IsPunctuation(*it)) {
+    return ContextualUserModel::kStartContext;
+  }
+  return CombineReadingValue((*it)->reading(), (*it)->currentUnigram().value());
+}
+
+std::vector<std::string> SplitByTab(const std::string& line) {
+  std::vector<std::string> fields;
+  size_t start = 0;
+  while (true) {
+    size_t pos = line.find('\t', start);
+    if (pos == std::string::npos) {
+      fields.push_back(line.substr(start));
+      break;
+    }
+    fields.push_back(line.substr(start, pos - start));
+    start = pos + 1;
+  }
+  return fields;
+}
+
+bool ParseFiniteDouble(const std::string& s, double* out) {
+  if (s.empty()) {
+    return false;
+  }
+  try {
+    size_t consumed = 0;
+    double value = std::stod(s, &consumed);
+    if (consumed != s.size() || !std::isfinite(value)) {
+      return false;
+    }
+    *out = value;
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+}  // namespace
+
+ContextualUserModel::ContextualUserModel(size_t capacity,
+                                         double decayHalfLifeSeconds)
+    : capacity_(capacity > 0 ? capacity : kDefaultCapacity),
+      decayHalfLifeSeconds_(decayHalfLifeSeconds > 0
+                                ? decayHalfLifeSeconds
+                                : kDefaultDecayHalfLifeSeconds) {}
+
+double ContextualUserModel::decayedCount(const CandidateStats& stats,
+                                         double timestamp) const {
+  double elapsed = timestamp - stats.timestamp;
+  if (elapsed <= 0) {
+    return stats.count;
+  }
+  return stats.count * std::exp2(-elapsed / decayHalfLifeSeconds_);
+}
+
+void ContextualUserModel::observe(
+    const Formosa::Gramambular2::ReadingGrid::WalkResult&
+        walkBeforeUserOverride,
+    const Formosa::Gramambular2::ReadingGrid::WalkResult& walkAfterUserOverride,
+    size_t cursor, double timestamp) {
+  if (walkBeforeUserOverride.totalReadings !=
+      walkAfterUserOverride.totalReadings) {
+    return;
+  }
+
+  size_t actualCursor = 0;
+  auto currentNodeIt = walkAfterUserOverride.findNodeAt(cursor, &actualCursor);
+  if (currentNodeIt == walkAfterUserOverride.nodes.cend()) {
+    return;
+  }
+
+  // Same cutoff as UserOverrideModel: learning phrases longer than 3
+  // characters was found to be meaningless.
+  if ((*currentNodeIt)->spanningLength() > 3) {
+    return;
+  }
+
+  if (actualCursor == 0) {
+    return;
+  }
+  --actualCursor;
+  auto prevHeadNodeIt = walkBeforeUserOverride.findNodeAt(actualCursor);
+  if (prevHeadNodeIt == walkBeforeUserOverride.nodes.cend()) {
+    return;
+  }
+
+  // The same three cases UserOverrideModel distinguishes. When the user
+  // breaks a longer phrase into a 1-character candidate, the observation is
+  // based on the walk after the override and must not be force-boosted;
+  // when the user builds a longer phrase out of shorter nodes, the
+  // suggestion must be force-boosted to beat the individually higher-scored
+  // characters.
+  const auto& currentNode = *currentNodeIt;
+  const auto& prevHeadNode = *prevHeadNodeIt;
+  bool forceHighScoreOverride =
+      currentNode->spanningLength() > prevHeadNode->spanningLength();
+  bool breakingUp =
+      currentNode->spanningLength() == 1 && prevHeadNode->spanningLength() > 1;
+
+  const auto& contextWalk =
+      breakingUp ? walkAfterUserOverride : walkBeforeUserOverride;
+  auto headIt = breakingUp ? currentNodeIt : prevHeadNodeIt;
+
+  std::string context = ContextBefore(contextWalk.nodes, headIt);
+  observe(context, (*headIt)->reading(), currentNode->currentUnigram().value(),
+          timestamp, forceHighScoreOverride);
+}
+
+ContextualUserModel::Suggestion ContextualUserModel::suggest(
+    const Formosa::Gramambular2::ReadingGrid::WalkResult& currentWalk,
+    size_t cursor, double timestamp) const {
+  auto nodeIter = currentWalk.findNodeAt(cursor);
+  if (nodeIter == currentWalk.nodes.cend()) {
+    return {};
+  }
+  std::string context = ContextBefore(currentWalk.nodes, nodeIter);
+  return suggest(context, (*nodeIter)->reading(), timestamp);
+}
+
+void ContextualUserModel::observe(const std::string& context,
+                                  const std::string& reading,
+                                  const std::string& candidate,
+                                  double timestamp,
+                                  bool forceHighScoreOverride) {
+  if (reading.empty() || candidate.empty() || context.empty()) {
+    return;
+  }
+  if (ContainsSeparator(context) || ContainsSeparator(reading) ||
+      ContainsSeparator(candidate)) {
+    return;
+  }
+
+  std::string key = context + "\t" + reading;
+  CandidateMap entry;
+  auto mapIter = lruMap_.find(key);
+  if (mapIter != lruMap_.end()) {
+    entry = mapIter->second->second;
+  }
+
+  CandidateStats& stats = entry[candidate];
+  stats.count = decayedCount(stats, timestamp) + 1.0;
+  stats.timestamp = timestamp;
+  stats.forceHighScoreOverride = forceHighScoreOverride;
+
+  touch(key, std::move(entry));
+}
+
+ContextualUserModel::Suggestion ContextualUserModel::suggest(
+    const std::string& context, const std::string& reading,
+    double timestamp) const {
+  std::string key = context + "\t" + reading;
+
+  Continuation continuation = continuationFor(reading);
+  auto continuationProbability = [&](const std::string& candidate) {
+    if (continuation.totalContexts == 0) {
+      return 0.0;
+    }
+    auto it = continuation.contextsPerCandidate.find(candidate);
+    if (it == continuation.contextsPerCandidate.end()) {
+      return 0.0;
+    }
+    return static_cast<double>(it->second) /
+           static_cast<double>(continuation.totalContexts);
+  };
+
+  std::string bestCandidate;
+  double bestProbability = 0;
+  bool bestForce = false;
+
+  auto mapIter = lruMap_.find(key);
+  if (mapIter != lruMap_.end()) {
+    const CandidateMap& entry = mapIter->second->second;
+    double total = 0;
+    size_t types = 0;
+    for (const auto& [candidate, stats] : entry) {
+      double count = decayedCount(stats, timestamp);
+      if (count > 0) {
+        total += count;
+        ++types;
+      }
+    }
+
+    // Absolute discounting only makes sense while there is at least one
+    // discount's worth of evidence; below that, decayed-out entries fall
+    // through to the continuation level.
+    if (total >= kDiscount && types > 0) {
+      double lambda = kDiscount * static_cast<double>(types) / total;
+      for (const auto& [candidate, stats] : entry) {
+        double count = decayedCount(stats, timestamp);
+        if (count <= 0) {
+          continue;
+        }
+        double probability = std::max(count - kDiscount, 0.0) / total +
+                             lambda * continuationProbability(candidate);
+        if (probability > bestProbability) {
+          bestProbability = probability;
+          bestCandidate = candidate;
+          bestForce = stats.forceHighScoreOverride;
+        }
+      }
+    }
+  }
+
+  if (bestCandidate.empty()) {
+    // No usable evidence in this exact context: generalize through the
+    // continuation level, but only for candidates confirmed in enough
+    // distinct contexts. Suggestions from this level are never
+    // force-boosted.
+    for (const auto& [candidate, contexts] :
+         continuation.contextsPerCandidate) {
+      if (contexts < kMinContextsForGeneralization) {
+        continue;
+      }
+      double probability = continuationProbability(candidate);
+      if (probability > bestProbability) {
+        bestProbability = probability;
+        bestCandidate = candidate;
+        bestForce = false;
+      }
+    }
+  }
+
+  if (bestCandidate.empty() || bestProbability < kMinSuggestionProbability) {
+    return {};
+  }
+  return {bestCandidate, bestForce};
+}
+
+ContextualUserModel::Continuation ContextualUserModel::continuationFor(
+    const std::string& reading) const {
+  Continuation result;
+  std::string suffix = "\t" + reading;
+  for (const auto& [key, entry] : lruList_) {
+    if (key.size() < suffix.size() ||
+        key.compare(key.size() - suffix.size(), suffix.size(), suffix) != 0) {
+      continue;
+    }
+    for (const auto& [candidate, stats] : entry) {
+      if (stats.count > 0) {
+        ++result.contextsPerCandidate[candidate];
+        ++result.totalContexts;
+      }
+    }
+  }
+  return result;
+}
+
+void ContextualUserModel::touch(const std::string& key, CandidateMap entry) {
+  auto mapIter = lruMap_.find(key);
+  if (mapIter != lruMap_.end()) {
+    lruList_.erase(mapIter->second);
+    lruMap_.erase(mapIter);
+  }
+
+  lruList_.emplace_front(key, std::move(entry));
+  lruMap_[key] = lruList_.begin();
+
+  while (lruList_.size() > capacity_) {
+    lruMap_.erase(lruList_.back().first);
+    lruList_.pop_back();
+  }
+}
+
+std::optional<ContextualUserModel::LoadStats> ContextualUserModel::loadFromFile(
+    const std::string& path) {
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return std::nullopt;
+  }
+
+  LoadStats stats;
+  std::list<KeyEntryPair> newList;
+  std::map<std::string, std::list<KeyEntryPair>::iterator> newMap;
+
+  std::string line;
+  while (std::getline(file, line)) {
+    if (line.empty() || line[0] == '#') {
+      continue;
+    }
+    std::vector<std::string> fields = SplitByTab(line);
+    if (fields.size() != 6) {
+      ++stats.skipped;
+      continue;
+    }
+    const std::string& context = fields[0];
+    const std::string& reading = fields[1];
+    const std::string& candidate = fields[2];
+    double count = 0;
+    double timestamp = 0;
+    if (context.empty() || reading.empty() || candidate.empty() ||
+        !ParseFiniteDouble(fields[3], &count) || count <= 0 ||
+        !ParseFiniteDouble(fields[4], &timestamp) || timestamp < 0 ||
+        (fields[5] != "0" && fields[5] != "1")) {
+      ++stats.skipped;
+      continue;
+    }
+
+    std::string key = context + "\t" + reading;
+    auto mapIter = newMap.find(key);
+    if (mapIter == newMap.end()) {
+      newList.emplace_front(key, CandidateMap());
+      mapIter = newMap.emplace(key, newList.begin()).first;
+    } else {
+      // Move to the front so that later lines (saved most-recent-last) end
+      // up as the most recently used.
+      newList.splice(newList.begin(), newList, mapIter->second);
+    }
+    CandidateStats& candidateStats = mapIter->second->second[candidate];
+    candidateStats.count = count;
+    candidateStats.timestamp = timestamp;
+    candidateStats.forceHighScoreOverride = fields[5] == "1";
+    ++stats.loaded;
+  }
+
+  while (newList.size() > capacity_) {
+    newMap.erase(newList.back().first);
+    newList.pop_back();
+  }
+
+  lruList_ = std::move(newList);
+  lruMap_ = std::move(newMap);
+  return stats;
+}
+
+std::string ContextualUserModel::serialize() const {
+  std::ostringstream out;
+  out << kFileHeader << "\n";
+  // Least recently used first, so that loading restores the same order.
+  for (auto it = lruList_.crbegin(); it != lruList_.crend(); ++it) {
+    std::vector<std::string> parts = SplitByTab(it->first);
+    const std::string& context = parts[0];
+    const std::string& reading = parts[1];
+    for (const auto& [candidate, stats] : it->second) {
+      out << context << "\t" << reading << "\t" << candidate << "\t"
+          << stats.count << "\t" << stats.timestamp << "\t"
+          << (stats.forceHighScoreOverride ? "1" : "0") << "\n";
+    }
+  }
+  return out.str();
+}
+
+bool ContextualUserModel::saveToFile(const std::string& path) const {
+  std::string tmpPath = path + ".tmp";
+  {
+    std::ofstream file(tmpPath, std::ios::trunc);
+    if (!file.is_open()) {
+      return false;
+    }
+    file << serialize();
+    file.flush();
+    if (!file.good()) {
+      file.close();
+      std::remove(tmpPath.c_str());
+      return false;
+    }
+  }
+  if (std::rename(tmpPath.c_str(), path.c_str()) != 0) {
+    std::remove(tmpPath.c_str());
+    return false;
+  }
+  return true;
+}
+
+}  // namespace McBopomofo

--- a/Source/Engine/ContextualUserModel.h
+++ b/Source/Engine/ContextualUserModel.h
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef SRC_ENGINE_CONTEXTUALUSERMODEL_H_
+#define SRC_ENGINE_CONTEXTUALUSERMODEL_H_
+
+#include <list>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "gramambular2/reading_grid.h"
+
+namespace McBopomofo {
+
+// A persistent, context-sensitive user adaptation model.
+//
+// The model observes the user's candidate selections together with the node
+// immediately preceding the selection (the bigram context), and suggests the
+// learned candidate when the same reading is later typed in the same or a
+// similar context. Scoring uses absolute-discounting interpolated Kneser-Ney:
+// a candidate seen in this exact context is scored by its discounted count,
+// and the discounted probability mass is given to the continuation
+// probability, i.e. how many *distinct* contexts the candidate has been
+// selected in. This lets a frequently-confirmed candidate generalize to
+// contexts it has never been seen in, which the exact-match UserOverrideModel
+// cannot do.
+//
+// The model deliberately has no reference to the base language model. When it
+// has no or too little evidence, suggest() returns an empty Suggestion and the
+// caller simply leaves the grid alone, so the walk falls back to the base
+// model scores naturally. This makes the base-language-model levels of the
+// Kneser-Ney backoff implicit and keeps the model self-contained.
+//
+// Observations decay exponentially by wall-clock time (half-life in seconds),
+// and the number of remembered contexts is bounded by an LRU cap, mirroring
+// UserOverrideModel. Unlike UserOverrideModel, the model can be saved to and
+// loaded from a file, so adaptation survives restarts.
+//
+// This class is not thread-safe; the input method accesses it from a single
+// thread.
+class ContextualUserModel {
+ public:
+  static constexpr size_t kDefaultCapacity = 500;
+  static constexpr double kDefaultDecayHalfLifeSeconds = 5400;  // 90 minutes.
+  static constexpr double kDiscount = 0.5;
+  // The marker used when there is no usable preceding node (start of the
+  // sentence, or the preceding node is punctuation). Matches the empty-node
+  // marker UserOverrideModel uses in its observation keys.
+  static constexpr char kStartContext[] = "()";
+
+  explicit ContextualUserModel(
+      size_t capacity = kDefaultCapacity,
+      double decayHalfLifeSeconds = kDefaultDecayHalfLifeSeconds);
+
+  // The LRU map holds iterators into the LRU list, so the default copy and
+  // move semantics would leave the copy pointing into the original.
+  ContextualUserModel(const ContextualUserModel&) = delete;
+  ContextualUserModel& operator=(const ContextualUserModel&) = delete;
+
+  // Same shape as UserOverrideModel::Suggestion, so the call sites in
+  // KeyHandler can switch models without changes.
+  struct Suggestion {
+    Suggestion() = default;
+    Suggestion(std::string c, bool f)
+        : candidate(std::move(c)), forceHighScoreOverride(f) {}
+    std::string candidate;
+    bool forceHighScoreOverride = false;
+
+    [[nodiscard]] bool empty() const { return candidate.empty(); }
+  };
+
+  // Walk-based API, drop-in compatible with UserOverrideModel. observe()
+  // derives the context from the walk *before* the user override, so the
+  // recorded context is what the user actually saw when selecting.
+  void observe(const Formosa::Gramambular2::ReadingGrid::WalkResult&
+                   walkBeforeUserOverride,
+               const Formosa::Gramambular2::ReadingGrid::WalkResult&
+                   walkAfterUserOverride,
+               size_t cursor, double timestamp);
+
+  Suggestion suggest(
+      const Formosa::Gramambular2::ReadingGrid::WalkResult& currentWalk,
+      size_t cursor, double timestamp) const;
+
+  // Granular API. The context is "(reading,value)" of the preceding node, or
+  // kStartContext. Arguments containing tab or newline characters are
+  // rejected (they would corrupt the persistence format).
+  void observe(const std::string& context, const std::string& reading,
+               const std::string& candidate, double timestamp,
+               bool forceHighScoreOverride = false);
+
+  Suggestion suggest(const std::string& context, const std::string& reading,
+                     double timestamp) const;
+
+  // Persistence. loadFromFile() replaces the current state on success and
+  // reports how many entries were loaded and how many malformed lines were
+  // skipped; it returns std::nullopt without touching the state if the file
+  // cannot be opened. saveToFile() writes to a temporary file first and
+  // renames it into place, returning false on any I/O failure.
+  struct LoadStats {
+    size_t loaded = 0;
+    size_t skipped = 0;
+  };
+  std::optional<LoadStats> loadFromFile(const std::string& path);
+  bool saveToFile(const std::string& path) const;
+
+  // The persistence-format snapshot saveToFile() writes. Callers that must
+  // not block (e.g. the input thread) can take this cheap in-memory snapshot
+  // and write it out on another thread, since the model itself is not
+  // thread-safe.
+  [[nodiscard]] std::string serialize() const;
+
+  [[nodiscard]] size_t entryCount() const { return lruList_.size(); }
+
+ private:
+  struct CandidateStats {
+    double count = 0;
+    double timestamp = 0;
+    bool forceHighScoreOverride = false;
+  };
+
+  // One entry per (context, reading) pair; the map holds the candidates the
+  // user has selected for that reading in that context.
+  using CandidateMap = std::map<std::string, CandidateStats>;
+  using KeyEntryPair = std::pair<std::string, CandidateMap>;
+
+  [[nodiscard]] double decayedCount(const CandidateStats& stats,
+                                    double timestamp) const;
+
+  // Continuation statistics for a reading: for each candidate, the number of
+  // distinct contexts it has been observed in, plus the total across all
+  // candidates of the reading. Derived from the LRU store on demand so there
+  // is a single source of truth and eviction stays consistent.
+  struct Continuation {
+    std::map<std::string, size_t> contextsPerCandidate;
+    size_t totalContexts = 0;
+  };
+  [[nodiscard]] Continuation continuationFor(const std::string& reading) const;
+
+  void touch(const std::string& key, CandidateMap entry);
+
+  size_t capacity_;
+  double decayHalfLifeSeconds_;
+  std::list<KeyEntryPair> lruList_;
+  std::map<std::string, std::list<KeyEntryPair>::iterator> lruMap_;
+};
+
+}  // namespace McBopomofo
+
+#endif  // SRC_ENGINE_CONTEXTUALUSERMODEL_H_

--- a/Source/Engine/ContextualUserModelTest.cpp
+++ b/Source/Engine/ContextualUserModelTest.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2026 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ContextualUserModel.h"
+#include "gramambular2/reading_grid.h"
+#include "gtest/gtest.h"
+
+namespace McBopomofo {
+
+namespace {
+constexpr double kFakeNow = 1657772432;
+constexpr size_t kCapacity = 5;
+constexpr double kHalfLife = 5400.0;  // 1.5 hr.
+
+std::string TempFilePath(const std::string& name) {
+  return testing::TempDir() + name;
+}
+}  // namespace
+
+TEST(ContextualUserModelTest, BasicObserveAndSuggest) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄒㄧㄣ,心)", "ㄒㄧˋ", "係", kFakeNow);
+
+  auto v = model.suggest("(ㄒㄧㄣ,心)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "係");
+  ASSERT_FALSE(v.forceHighScoreOverride);
+
+  // A single observation must not generalize to a different context.
+  v = model.suggest("(ㄉㄚˋ,大)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_TRUE(v.empty());
+
+  // Nor to a different reading.
+  v = model.suggest("(ㄒㄧㄣ,心)", "ㄒㄧ", kFakeNow);
+  ASSERT_TRUE(v.empty());
+}
+
+TEST(ContextualUserModelTest, GeneralizesAfterMultipleContexts) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄉㄚˋ,大)", "ㄒㄧˋ", "係", kFakeNow);
+  model.observe("(ㄒㄧㄠˇ,小)", "ㄒㄧˋ", "係", kFakeNow);
+
+  // Confirmed in two distinct contexts, the candidate now generalizes to a
+  // context it has never been seen in.
+  auto v = model.suggest("(ㄓㄨㄥ,中)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "係");
+  // Continuation-level suggestions are never force-boosted.
+  ASSERT_FALSE(v.forceHighScoreOverride);
+}
+
+TEST(ContextualUserModelTest, ExactContextBeatsContinuation) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  // "戲" generalizes from two contexts...
+  model.observe("(ㄉㄚˋ,大)", "ㄒㄧˋ", "戲", kFakeNow);
+  model.observe("(ㄒㄧㄠˇ,小)", "ㄒㄧˋ", "戲", kFakeNow);
+  // ...but in this specific context the user picked "係".
+  model.observe("(ㄍㄨㄢ,關)", "ㄒㄧˋ", "係", kFakeNow);
+
+  auto v = model.suggest("(ㄍㄨㄢ,關)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "係");
+
+  v = model.suggest("(ㄉㄚˋ,大)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "戲");
+}
+
+TEST(ContextualUserModelTest, TemporalDecay) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄒㄧㄣ,心)", "ㄒㄧˋ", "係", kFakeNow);
+
+  auto v = model.suggest("(ㄒㄧㄣ,心)", "ㄒㄧˋ", kFakeNow + kHalfLife);
+  ASSERT_EQ(v.candidate, "係");
+
+  // A single observation fully decays out after a few half-lives.
+  v = model.suggest("(ㄒㄧㄣ,心)", "ㄒㄧˋ", kFakeNow + kHalfLife * 4);
+  ASSERT_TRUE(v.empty());
+
+  // Repeated confirmation accumulates evidence and survives much longer.
+  for (int i = 0; i < 8; i++) {
+    model.observe("(ㄒㄧㄣ,心)", "ㄒㄧˋ", "係", kFakeNow);
+  }
+  v = model.suggest("(ㄒㄧㄣ,心)", "ㄒㄧˋ", kFakeNow + kHalfLife * 4);
+  ASSERT_EQ(v.candidate, "係");
+}
+
+TEST(ContextualUserModelTest, ForceHighScoreOverrideIsRemembered) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄗㄥ,增)", "ㄗˋ-ㄏㄨㄟˋ", "字彙", kFakeNow,
+                /*forceHighScoreOverride=*/true);
+
+  auto v = model.suggest("(ㄗㄥ,增)", "ㄗˋ-ㄏㄨㄟˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "字彙");
+  ASSERT_TRUE(v.forceHighScoreOverride);
+}
+
+TEST(ContextualUserModelTest, RejectsSeparatorCharacters) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(a,b)\t", "r", "c", kFakeNow);
+  model.observe("(a,b)", "r\n", "c", kFakeNow);
+  model.observe("(a,b)", "r", "c\td", kFakeNow);
+  ASSERT_EQ(model.entryCount(), 0);
+}
+
+TEST(ContextualUserModelTest, CapacityEviction) {
+  ContextualUserModel model(2, kHalfLife);
+  model.observe("(a,A)", "r1", "c1", kFakeNow);
+  model.observe("(b,B)", "r2", "c2", kFakeNow + 1);
+  model.observe("(c,C)", "r3", "c3", kFakeNow + 2);
+  ASSERT_EQ(model.entryCount(), 2);
+
+  // The least recently used entry is gone.
+  ASSERT_TRUE(model.suggest("(a,A)", "r1", kFakeNow + 3).empty());
+  ASSERT_EQ(model.suggest("(c,C)", "r3", kFakeNow + 3).candidate, "c3");
+}
+
+TEST(ContextualUserModelTest, PersistenceRoundTrip) {
+  std::string path = TempFilePath("contextual_user_model_roundtrip.txt");
+
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄒㄧㄣ,心)", "ㄒㄧˋ", "係", kFakeNow);
+  model.observe("(ㄗㄥ,增)", "ㄗˋ-ㄏㄨㄟˋ", "字彙", kFakeNow,
+                /*forceHighScoreOverride=*/true);
+  ASSERT_TRUE(model.saveToFile(path));
+
+  ContextualUserModel restored(kCapacity, kHalfLife);
+  auto stats = restored.loadFromFile(path);
+  ASSERT_TRUE(stats.has_value());
+  ASSERT_EQ(stats->loaded, 2);
+  ASSERT_EQ(stats->skipped, 0);
+
+  auto v = restored.suggest("(ㄒㄧㄣ,心)", "ㄒㄧˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "係");
+  v = restored.suggest("(ㄗㄥ,增)", "ㄗˋ-ㄏㄨㄟˋ", kFakeNow);
+  ASSERT_EQ(v.candidate, "字彙");
+  ASSERT_TRUE(v.forceHighScoreOverride);
+
+  std::remove(path.c_str());
+}
+
+TEST(ContextualUserModelTest, LoadSkipsMalformedLines) {
+  std::string path = TempFilePath("contextual_user_model_malformed.txt");
+  {
+    std::ofstream file(path, std::ios::trunc);
+    file << "# mcbopomofo-contextual-user-model v1\n";
+    file << "(a,A)\tr1\tc1\t1.0\t" << kFakeNow << "\t0\n";   // good
+    file << "(b,B)\tr2\tc2\t1.0\n";                          // missing fields
+    file << "(c,C)\tr3\tc3\tnan\t" << kFakeNow << "\t0\n";   // NaN count
+    file << "(d,D)\tr4\tc4\tinf\t" << kFakeNow << "\t0\n";   // Inf count
+    file << "(e,E)\tr5\tc5\t-1.0\t" << kFakeNow << "\t0\n";  // negative count
+    file << "(f,F)\tr6\tc6\t1.0\t" << kFakeNow << "\t2\n";   // bad force flag
+    file << "(g,G)\tr7\tc7\t1.0\tabc\t0\n";                  // bad timestamp
+  }
+
+  ContextualUserModel model(kCapacity, kHalfLife);
+  auto stats = model.loadFromFile(path);
+  ASSERT_TRUE(stats.has_value());
+  ASSERT_EQ(stats->loaded, 1);
+  ASSERT_EQ(stats->skipped, 6);
+  ASSERT_EQ(model.suggest("(a,A)", "r1", kFakeNow).candidate, "c1");
+
+  std::remove(path.c_str());
+}
+
+TEST(ContextualUserModelTest, SerializeMatchesSavedFile) {
+  std::string path = TempFilePath("contextual_user_model_serialize.txt");
+
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(ㄒㄧㄣ,心)", "ㄒㄧˋ", "係", kFakeNow);
+  ASSERT_TRUE(model.saveToFile(path));
+
+  std::ifstream file(path);
+  std::string fileContents((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+  ASSERT_EQ(model.serialize(), fileContents);
+
+  std::remove(path.c_str());
+}
+
+TEST(ContextualUserModelTest, LoadReturnsNulloptForMissingFile) {
+  ContextualUserModel model(kCapacity, kHalfLife);
+  model.observe("(a,A)", "r1", "c1", kFakeNow);
+  auto stats =
+      model.loadFromFile(TempFilePath("contextual_user_model_no_such_file"));
+  ASSERT_FALSE(stats.has_value());
+  // A failed load leaves the current state untouched.
+  ASSERT_EQ(model.entryCount(), 1);
+}
+
+namespace {
+
+// A small language model for walk-based tests. The data deliberately scores
+// 戲 above 係 so that only a user-model override can produce 係.
+class TinyLM : public Formosa::Gramambular2::LanguageModel {
+ public:
+  TinyLM() {
+    db_["ㄍㄨㄢ"] = {{"關", -5.0}};
+    db_["ㄒㄧˋ"] = {{"戲", -5.0}, {"係", -6.0}};
+  }
+
+  std::vector<Unigram> getUnigrams(const std::string& reading) override {
+    auto it = db_.find(reading);
+    if (it == db_.end()) {
+      return {};
+    }
+    std::vector<Unigram> result;
+    for (const auto& [value, score] : it->second) {
+      result.emplace_back(value, score);
+    }
+    return result;
+  }
+
+  bool hasUnigrams(const std::string& reading) override {
+    return db_.find(reading) != db_.end();
+  }
+
+ private:
+  std::map<std::string, std::vector<std::pair<std::string, double>>> db_;
+};
+
+}  // namespace
+
+TEST(ContextualUserModelTest, WalkBasedObserveAndSuggest) {
+  using Formosa::Gramambular2::ReadingGrid;
+
+  ContextualUserModel model(kCapacity, kHalfLife);
+
+  // The user types 關係 and overrides the default 戲 with 係.
+  ReadingGrid grid(std::make_shared<TinyLM>());
+  grid.insertReading("ㄍㄨㄢ");
+  grid.insertReading("ㄒㄧˋ");
+  ReadingGrid::WalkResult walkBefore = grid.walk();
+  ASSERT_EQ(walkBefore.nodes.size(), 2);
+  ASSERT_EQ(walkBefore.nodes[1]->value(), "戲");
+
+  ASSERT_TRUE(grid.overrideCandidate(
+      1, "係", ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore));
+  ReadingGrid::WalkResult walkAfter = grid.walk();
+  ASSERT_EQ(walkAfter.nodes[1]->value(), "係");
+
+  model.observe(walkBefore, walkAfter, 1, kFakeNow);
+
+  // Later, the user types the same input again. The model suggests the
+  // learned candidate for the node at the cursor.
+  ReadingGrid grid2(std::make_shared<TinyLM>());
+  grid2.insertReading("ㄍㄨㄢ");
+  grid2.insertReading("ㄒㄧˋ");
+  ReadingGrid::WalkResult freshWalk = grid2.walk();
+  ASSERT_EQ(freshWalk.nodes[1]->value(), "戲");
+
+  auto v = model.suggest(freshWalk, 1, kFakeNow + 60);
+  ASSERT_EQ(v.candidate, "係");
+}
+
+}  // namespace McBopomofo


### PR DESCRIPTION
## Summary

**Reworked from the original proposal**, following the review direction on #779 ("work with what's in HEAD"): the model no longer hooks into the walk. It is a self-contained, persistent, context-sensitive successor to `UserOverrideModel`, applied through the **existing** `overrideCandidate`/`selectOverrideUnigram` machinery. `ReadingGrid` is untouched by this PR.

- `observe()`/`suggest()` are walk-based and signature-compatible with `UserOverrideModel`, including the three override cases (same-length, phrase-building with force-high-score, phrase-breaking based on the post-override walk) and punctuation/sentence-start context handling
- Scoring: absolute-discounting interpolated Kneser-Ney over bigram contexts; continuation probability is normalized per reading (Σ N₁₊ over that reading's candidates). A candidate confirmed in ≥2 distinct contexts generalizes to unseen contexts — the capability exact-key UOM lacks
- **Persistence**: atomic save (write-to-temp + rename); load validates every field, skips malformed lines with a reported count, rejects NaN/Inf/negative values
- **No base-LM reference**: with insufficient evidence `suggest()` returns empty and the walk falls back to base scores naturally (the lower KN backoff levels are implicit) — no aliasing-shared_ptr lifetime concerns by construction
- Wall-clock exponential decay (half-life seconds) + LRU capacity bound, mirroring UOM defaults

## Review items from the previous iteration, and where they went

| Item | Resolution |
|---|---|
| User-model score replaced edge weights instead of blending | Eliminated by design — no walk hook; overrides use existing soft-override scoring |
| Log-prob vs probability space mixing | Eliminated — model is internally probability-space only; API returns a candidate, not a score |
| KN continuation count normalization | Fixed — normalized per reading, not by total unique bigrams |
| Dangling `userModel_` raw pointer in grid | Eliminated — grid holds no model pointer |
| Division by zero | Guarded — discounting only applies when total evidence ≥ discount |
| Silent load corruption | Fixed — per-field validation, skipped-line count surfaced via `LoadStats` |
| UTF-8 decomposition splitting | Removed — the decomposed backoff level no longer exists |
| No capacity/eviction | Fixed — LRU bound like UOM |

## Verification

- 11 new tests in `ContextualUserModelTest.cpp` (KN behavior, generalization threshold, decay, eviction, persistence round-trip, malformed-load, walk-based observe/suggest)
- Full `McBopomofoLMLibTest` suite passes; pbxproj lints OK
- Base: `master` (no dependency on other PRs)

KeyHandler integration (replacing `UserOverrideModel` and adding load/save wiring) follows in #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)