### PR TITLE
Add SIMD support for ARM NEON

### DIFF
--- a/Source/Engine/ByteBlockBackedDictionary.cpp
+++ b/Source/Engine/ByteBlockBackedDictionary.cpp
@@ -31,6 +31,16 @@
 #endif
 #endif
 
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+
+#include <cstdint>
+#else
+#error ARM NEON support required
+#endif
+#endif
+
 #include "ByteBlockBackedDictionary.h"
 
 namespace McBopomofo {
@@ -271,6 +281,188 @@ const char* AVX512_FindFirstNULL(const char* ptr, const char* end,
 
 #endif
 
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+
+// Returns the index of the first non-zero byte in v, or 16 if all zero
+static inline int FirstNonZeroLane16(uint8x16_t v) {
+  if (vmaxvq_u8(v) == 0) {
+    return 16;
+  }
+  // Scalar fallback for the position
+  alignas(16) uint8_t tmp[16];
+  vst1q_u8(tmp, v);
+  for (int i = 0; i < 16; ++i) {
+    if (tmp[i]) {
+      return i;
+    }
+  }
+  return 16;
+}
+
+const char* NEON_AdvanceToNextCRLF(const char* ptr, const char* unaligned16End,
+                                   const char* end) {
+  const uint8x16_t lfs = vdupq_n_u8(static_cast<uint8_t>('\n'));
+  const uint8x16_t crs = vdupq_n_u8(static_cast<uint8_t>('\r'));
+
+  while (ptr < unaligned16End) {
+    const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(ptr));
+    const uint8x16_t matchLF = vceqq_u8(block, lfs);
+    const uint8x16_t matchCR = vceqq_u8(block, crs);
+    const uint8x16_t match = vorrq_u8(matchLF, matchCR);
+    const int pos = FirstNonZeroLane16(match);
+    if (pos < 16) {
+      return ptr + pos;
+    }
+    ptr += 16;
+  }
+
+  return AdvanceToNextCRLF(ptr, end);
+}
+
+// Four chars: 0x09 (Tab), 0x0a (LF), 0x0d (CR), 0x20 (Space)
+// Tab maps to 0x01
+// LF maps to 0x02
+// CR maps to 0x04
+// Tab|LF|CR = 0x07
+// Space maps to 0x08
+alignas(16) constexpr uint8_t NEON_LO_NIBBLES_LOOKUP[16] = {
+    0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x01, 0x02, 0x00, 0x00, 0x04, 0x00, 0x00,
+};
+
+alignas(16) constexpr uint8_t NEON_HI_NIBBLES_LOOKUP[16] = {
+    0x07, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+
+const char* NEON_AdvanceToNextNonContentCharacter(const char* ptr,
+                                                  const char* unaligned16End,
+                                                  const char* end) {
+  const uint8x16_t loTbl =
+      vld1q_u8(reinterpret_cast<const uint8_t*>(NEON_LO_NIBBLES_LOOKUP));
+  const uint8x16_t hiTbl =
+      vld1q_u8(reinterpret_cast<const uint8_t*>(NEON_HI_NIBBLES_LOOKUP));
+  const uint8x16_t nibbleMask = vdupq_n_u8(0x0f);
+
+  while (ptr < unaligned16End) {
+    const uint8x16_t input = vld1q_u8(reinterpret_cast<const uint8_t*>(ptr));
+    const uint8x16_t loNibbles = vandq_u8(input, nibbleMask);
+    const uint8x16_t hiNibbles = vandq_u8(vshrq_n_u8(input, 4), nibbleMask);
+    const uint8x16_t lo = vqtbl1q_u8(loTbl, loNibbles);
+    const uint8x16_t hi = vqtbl1q_u8(hiTbl, hiNibbles);
+    const uint8x16_t intersection = vandq_u8(lo, hi);
+    // non-content characters have a non-zero intersection
+    const int pos = FirstNonZeroLane16(intersection);
+    if (pos < 16) {
+      return ptr + pos;
+    }
+    ptr += 16;
+  }
+
+  return AdvanceToNextNonContentCharacter(ptr, end);
+}
+
+constexpr uintptr_t NEON_ALIGN16 = 16;
+constexpr uintptr_t NEON_ALIGN16_MASK = NEON_ALIGN16 - 1;
+
+const char* NEON_FindFirstNULL(const char* ptr, const char* end,
+                               size_t* firstLineNumber = nullptr) {
+  const char* i = ptr;
+  bool found = false;
+
+  // Handle unaligned head
+  if ((reinterpret_cast<uintptr_t>(i) & NEON_ALIGN16_MASK) != 0) {
+    const char* headEnd = reinterpret_cast<const char*>(
+        (reinterpret_cast<uintptr_t>(i) + NEON_ALIGN16_MASK) &
+        ~NEON_ALIGN16_MASK);
+    headEnd = headEnd < end ? headEnd : end;
+    while (i != headEnd) {
+      if (*i == '\0') {
+        found = true;
+        break;
+      }
+      ++i;
+    }
+  }
+
+  if (!found && i != end) {
+    const char* middleEnd = reinterpret_cast<const char*>(
+        reinterpret_cast<uintptr_t>(end) & ~NEON_ALIGN16_MASK);
+    const uint8x16_t zeros = vdupq_n_u8(0);
+    while (i < middleEnd) {
+      const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(i));
+      const uint8x16_t match = vceqq_u8(block, zeros);
+      const int pos = FirstNonZeroLane16(match);
+      if (pos < 16) {
+        i += pos;
+        found = true;
+        break;
+      }
+      i += NEON_ALIGN16;
+    }
+  }
+
+  // Handle tail
+  if (!found) {
+    while (i != end) {
+      if (*i == '\0') {
+        found = true;
+        break;
+      }
+      ++i;
+    }
+  }
+
+  if (!found || firstLineNumber == nullptr) {
+    return i;
+  }
+
+  // Count newlines from ptr to i
+  size_t lineCounter = 1;
+  const char* p = ptr;
+
+  // Scalar head
+  if ((reinterpret_cast<uintptr_t>(p) & NEON_ALIGN16_MASK) != 0) {
+    const char* headEnd = reinterpret_cast<const char*>(
+        (reinterpret_cast<uintptr_t>(p) + NEON_ALIGN16_MASK) &
+        ~NEON_ALIGN16_MASK);
+    headEnd = headEnd < i ? headEnd : i;
+    while (p != headEnd) {
+      if (*p == '\n') {
+        ++lineCounter;
+      }
+      ++p;
+    }
+  }
+
+  // NEON middle
+  if (p != i) {
+    const char* middleEnd = reinterpret_cast<const char*>(
+        reinterpret_cast<uintptr_t>(i) & ~NEON_ALIGN16_MASK);
+    const uint8x16_t linefeeds = vdupq_n_u8(static_cast<uint8_t>('\n'));
+    while (p < middleEnd) {
+      const uint8x16_t block = vld1q_u8(reinterpret_cast<const uint8_t*>(p));
+      const uint8x16_t match = vceqq_u8(block, linefeeds);
+      // Count set bytes
+      lineCounter += vaddvq_u8(vshrq_n_u8(match, 7));
+      p += NEON_ALIGN16;
+    }
+  }
+
+  // Scalar tail
+  while (p != i) {
+    if (*p == '\n') {
+      ++lineCounter;
+    }
+    ++p;
+  }
+
+  *firstLineNumber = lineCounter;
+  return i;
+}
+
+#endif
+
 }  // namespace
 
 void ByteBlockBackedDictionary::clear() {
@@ -305,12 +497,20 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
   if (unaligned32End < ptr) {
     unaligned32End = ptr;
   }
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+  const char* unaligned16End =
+      reinterpret_cast<const char*>(reinterpret_cast<uintptr_t>(end) - 16);
+  if (unaligned16End < ptr) {
+    unaligned16End = ptr;
+  }
 #endif
 
   // Validate that no NULL characters are in the text.
   size_t errorAtLine = 0;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
   const char* ctrlCharPtr = AVX512_FindFirstNULL(ptr, end, &errorAtLine);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+  const char* ctrlCharPtr = NEON_FindFirstNULL(ptr, end, &errorAtLine);
 #else
   const char* ctrlCharPtr = FindFirstNULL(ptr, end, &errorAtLine);
 #endif
@@ -330,8 +530,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       if (*ptr == '#') {
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -339,8 +541,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* keyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -356,8 +560,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* valueStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -405,8 +611,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       if (*ptr == '#') {
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextCRLF(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextCRLF(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextCRLF(ptr, end);
 #endif
@@ -414,8 +622,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* valueStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -430,8 +640,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
       }
 
       const char* maybeKeyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
       ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+      ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
       ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif
@@ -457,8 +669,10 @@ bool ByteBlockBackedDictionary::parse(const char* block, size_t size,
         // More content incoming.
         valueEnd = maybeKeyEnd;
         maybeKeyStart = ptr;
-#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
         ptr = AVX512_AdvanceToNextNonContentCharacter(ptr, unaligned32End, end);
+#elif defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+        ptr = NEON_AdvanceToNextNonContentCharacter(ptr, unaligned16End, end);
 #else
         ptr = AdvanceToNextNonContentCharacter(ptr, end);
 #endif

--- a/Source/Engine/ByteBlockBackedDictionary.cpp
+++ b/Source/Engine/ByteBlockBackedDictionary.cpp
@@ -94,7 +94,8 @@ const char* AdvanceToNextNonContentCharacter(const char* ptr, const char* end) {
   return ptr;
 }
 
-#ifndef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512
+#if !defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512) && \
+    !defined(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
 const char* FindFirstNULL(const char* ptr, const char* end,
                           size_t* firstLineNumber = nullptr) {
   const char* i = ptr;

--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -46,6 +46,19 @@ if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
     endif()
 endif ()
 
+# NEON is supported by default on AArch64 (ARM64), so we can enable it automatically
+# Users can disable it by setting ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON to OFF
+# if (NOT DEFINED ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+#     if (CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+#         message(STATUS "Detected architecture: ${CMAKE_SYSTEM_PROCESSOR}, enabling NEON support automatically")
+#         set(ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON ON)
+#     endif ()
+# endif ()
+
+if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+    target_compile_definitions(McBopomofoLMLib PRIVATE ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON=1)
+endif ()
+
 if (ENABLE_TEST)
         enable_testing()
         if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
@@ -92,17 +105,43 @@ if (ENABLE_TEST)
         )
         add_dependencies(runMcBopomofoLMLibTest McBopomofoLMLibTest)
 
-        # Benchmark for ByteBlockBackedDictionary; not enabled by default
-        #
-        # find_package(benchmark)
-        # add_executable(ByteBlockBackedDictionaryBenchmark
-        #         ByteBlockBackedDictionaryBenchmark.cpp)
-        # target_link_libraries(ByteBlockBackedDictionaryBenchmark McBopomofoLMLib benchmark::benchmark)
+        if (ENABLE_BENCHMARK)
+            set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+            set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+            set(BENCHMARK_VERSION "v1.9.5")
+            MESSAGE(STATUS "Fetching Google Benchmark ${BENCHMARK_VERSION} from GitHub")
+            include(FetchContent)
+            FetchContent_Declare(
+                    benchmark
+                    URL "https://github.com/google/benchmark/archive/refs/tags/${BENCHMARK_VERSION}.zip"
+            )
+            FetchContent_MakeAvailable(benchmark)
 
-        # Stressed benchmark for ParselessLM; not enabled by default
-        #
-        # find_package(benchmark)
-        # add_executable(ParselessLMBenchmark
-        #         ParselessLMBenchmark.cpp)
-        # target_link_libraries(ParselessLMBenchmark McBopomofoLMLib benchmark::benchmark)
+            add_executable(ByteBlockBackedDictionaryBenchmark
+                    ByteBlockBackedDictionaryBenchmark.cpp)
+            target_link_libraries(ByteBlockBackedDictionaryBenchmark McBopomofoLMLib benchmark::benchmark)
+
+            if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON)
+                target_compile_definitions(ByteBlockBackedDictionaryBenchmark PRIVATE ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON=1)
+            endif ()
+            if (ENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512)
+                target_compile_options(ByteBlockBackedDictionaryBenchmark PRIVATE -mavx512f -march=native -DENABLE_EXPERIMENTAL_SIMD_SUPPORT_AVX512=1)
+            endif ()
+
+            add_custom_target(
+                    runByteBlockBackedDictionaryBenchmark
+                    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ByteBlockBackedDictionaryBenchmark
+            )
+            add_dependencies(runByteBlockBackedDictionaryBenchmark ByteBlockBackedDictionaryBenchmark)
+
+            add_executable(ParselessLMBenchmark
+                    ParselessLMBenchmark.cpp)
+            target_link_libraries(ParselessLMBenchmark McBopomofoLMLib benchmark::benchmark)
+
+            add_custom_target(
+                    runParselessLMBenchmark
+                    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ParselessLMBenchmark
+            )
+            add_dependencies(runParselessLMBenchmark ParselessLMBenchmark)
+        endif ()
 endif ()

--- a/Source/Engine/ParselessLMBenchmark.cpp
+++ b/Source/Engine/ParselessLMBenchmark.cpp
@@ -50,7 +50,7 @@ static void BM_ParselessLMFindUnigrams(benchmark::State& state) {
   ParselessLM lm;
   lm.open(kDataPath);
   for (auto _ : state) {
-    lm.unigramsForKey(kUnigramSearchKey);
+    lm.getUnigrams(kUnigramSearchKey);
   }
   lm.close();
 }


### PR DESCRIPTION
This PR adds ARM NEON support by porting the implementation from https://github.com/openvanilla/fcitx5-mcbopomofo/pull/194 and exploring the AArch64/ARM64 support mentioned in https://github.com/openvanilla/fcitx5-mcbopomofo/issues/197.

Since NEON is theoretically supported by all AArch64/ARM64 platforms, it is naturally supported by all Apple Silicon devices. However, as we consider this feature "experimental," I am slightly hesitant about whether it should be automatically enabled when AArch64/ARM64 is detected. For the time being, I have kept the detection logic commented out in CMakeLists, but I would happy to see it enabled by default XDD

## Performance

- MacBook Air M2
  - Apple clang version 17.0.0 (clang-1700.6.3.2)

```
cmake -DENABLE_TEST=ON \
      -DENABLE_BENCHMARK=ON \
      -DENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON=ON \
      -DCMAKE_BUILD_TYPE=Release -S . -B build
```

### Before

```
Running ./ByteBlockBackedDictionaryBenchmark
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 3.40, 3.18, 2.71
------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------
BM_ByteBlockBackedDictionaryParseTest                    3663165 ns      3663089 ns          190
BM_ByteBlockBackedDictionaryValueColumnFirstParseTest    4111712 ns      4111588 ns          170
```

### After

```
Running ./ByteBlockBackedDictionaryBenchmark
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 2.77, 2.34, 2.23
------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------
BM_ByteBlockBackedDictionaryParseTest                    2337093 ns      2337054 ns          296
BM_ByteBlockBackedDictionaryValueColumnFirstParseTest    2770651 ns      2770617 ns          253
```