### PR TITLE
Support Taiwanese Braille as ASII code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,7 @@ This file provides GitHub Copilot-specific coding instructions. For comprehensiv
 
 ## Project Context
 - Input method for macOS built with AppKit/IMKit in Swift and bridged Objective-C++, backed by the C++ language model in `Source/Engine`.
+- The app supports two Taiwanese Braille formats: Unicode and ASCII.
 - Build and run with Xcode target `McBopomofo Installer`; Swift front end pulls helper frameworks from the local `Packages/` directory.
 - Dictionary assets and generation scripts live in `Source/Data`; compiled blobs are stored in `Source/Data/bin`.
 - Tests cover both layers: Swift XCTest-style suites in `McBopomofoTests` and GoogleTest cases in `Source/Engine/*Test.cpp` via CMake.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding assistants when working with code in th
 
 ## Project Overview
 
-McBopomofo (小麥注音輸入法) is a Traditional Chinese input method engine for macOS that enables users to input Traditional Chinese characters using the Bopomofo phonetic system (注音符號). The project is built with Swift (UI/state management), Objective-C++ (bridge layer), and C++ (core engine), using macOS Input Method Kit (IMK) framework.
+McBopomofo (小麥注音輸入法) is a Traditional Chinese input method engine for macOS that enables users to input Traditional Chinese characters using the Bopomofo phonetic system (注音符號). The app also supports two Taiwanese Braille formats, Unicode and ASCII. The project is built with Swift (UI/state management), Objective-C++ (bridge layer), and C++ (core engine), using macOS Input Method Kit (IMK) framework.
 
 ## System Requirements
 
@@ -194,7 +194,7 @@ For dictionary data modifications, see [Wiki: 詞庫開發說明](https://github
 ## Local Packages
 
 The `Packages/` directory contains local Swift Package dependencies:
-- `BopomofoBraille`: Braille output support
+- `BopomofoBraille`: Taiwanese Braille conversion support for both Unicode and ASCII formats
 - `CandidateUI`: Candidate window rendering
 - `ChineseNumbers`: Chinese numeral conversion
 - `FSEventStreamHelper`: File system monitoring

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -2360,7 +2360,7 @@ extension KeyHandlerBopomofoTests {
 
     func testCtrlEnter3() {
         let controlEnterOutput = Preferences.controlEnterOutput
-        Preferences.controlEnterOutput = .braille
+        Preferences.controlEnterOutput = .brailleUnicode
         var state: InputState = InputState.Empty()
         var commitState: InputState?
         let keys = Array("su3").map {

--- a/McBopomofoTests/ServiceProviderTests.swift
+++ b/McBopomofoTests/ServiceProviderTests.swift
@@ -218,6 +218,7 @@ final class ServiceProviderTests {
     @Test(
         "Test coverting Chinese to ASCII Taiwanese Braille, then coverting it back",
         arguments: [
+            ("「」", ""),
             ("由「小麥」的作者", ""),
             ("This is a test", ""),
             ("第1名", "地 1 明"),

--- a/McBopomofoTests/ServiceProviderTests.swift
+++ b/McBopomofoTests/ServiceProviderTests.swift
@@ -135,21 +135,21 @@ final class ServiceProviderTests {
     }
 
     @Test(
-        "Test converting Taiwanese Braille to Chinese",
+        "Test converting Unicode Taiwanese Braille to Chinese",
         arguments: [
             ("⠰⠤⠋⠺⠂⠻⠄⠛⠥⠂⠓⠫⠐⠑⠳⠄⠪⠐⠙⠮⠁⠅⠎⠐⠊⠱⠐⠑⠪⠄⠏⠣⠄⠇⠶⠐⠤⠆", "「台灣人最需要的就是消波塊」")
         ])
-    func testConvertBrailleToChinese(input: String, expected: String) {
+    func testConvertUnicodeBrailleToChinese(input: String, expected: String) {
         LanguageModelManager.loadDataModels()
         let provider = ServiceProvider()
         let helper = ServiceProviderInputHelper()
         provider.delegate = helper as? any ServiceProviderDelegate
-        let output = provider.convertBrailleToChineseText(string: input)
+        let output = provider.convertUnicodeBrailleToChineseText(string: input)
         #expect(output == expected, "\(output)")
     }
 
     @Test(
-        "Test coverting Chinese to Taiwanese Braille, then coverting it back",
+        "Test coverting Chinese to Unicode Taiwanese Braille, then coverting it back",
         arguments: [
             ("由「小麥」的作者", ""),
             ("This is a test", ""),
@@ -163,8 +163,8 @@ final class ServiceProviderTests {
         let provider = ServiceProvider()
         let helper = ServiceProviderInputHelper()
         provider.delegate = helper as? any ServiceProviderDelegate
-        let r1 = provider.convertToBraille(string: input)
-        let r2 = provider.convertBrailleToChineseText(string: r1)
+        let r1 = provider.convertToUnicodeBraille(string: input)
+        let r2 = provider.convertUnicodeBrailleToChineseText(string: r1)
         if expected == "" {
             #expect(r2 == input, "\(r2)")
         } else {
@@ -173,31 +173,83 @@ final class ServiceProviderTests {
     }
 
     @Test(
-        "Test coverting letters to Taiwanese Braille",
+        "Test coverting letters to Unicode Taiwanese Braille",
         arguments: [
             ("This is a test", "⠠⠞⠓⠊⠎ ⠊⠎ ⠁ ⠞⠑⠎⠞"),
             ("This is a test 台灣人最需要的就是消波塊", "⠠⠞⠓⠊⠎ ⠊⠎ ⠁ ⠞⠑⠎⠞ ⠋⠺⠂⠻⠄⠛⠥⠂⠓⠫⠐⠑⠳⠄⠪⠐⠙⠮⠁⠅⠎⠐⠊⠱⠐⠑⠪⠄⠏⠣⠄⠇⠶⠐"),
         ])
-    func testLetters(input: String, expected: String) {
+    func testUnicodeBrailleLetters(input: String, expected: String) {
         LanguageModelManager.loadDataModels()
         let provider = ServiceProvider()
         let helper = ServiceProviderInputHelper()
         provider.delegate = helper as? any ServiceProviderDelegate
-        let result = provider.convertToBraille(string: input)
+        let result = provider.convertToUnicodeBraille(string: input)
         #expect(result == expected)
     }
 
     @Test(
-        "Test coverting digits to Taiwanese Braille",
+        "Test coverting digits to Unicode Taiwanese Braille",
         arguments: [
             ("24", "⠼⠆⠲")
         ])
-    func testDigit(input: String, expected: String) {
+    func testUnicodeBrailleDigit(input: String, expected: String) {
         LanguageModelManager.loadDataModels()
         let provider = ServiceProvider()
         let helper = ServiceProviderInputHelper()
         provider.delegate = helper as? any ServiceProviderDelegate
-        let result = provider.convertToBraille(string: input)
+        let result = provider.convertToUnicodeBraille(string: input)
+        #expect(result == expected)
+    }
+
+    @Test(
+        "Test coverting letters to ASCII Taiwanese Braille",
+        arguments: [
+            ("This is a test", ",this is a test")
+        ])
+    func testASCIIBrailleLetters(input: String, expected: String) {
+        LanguageModelManager.loadDataModels()
+        let provider = ServiceProvider()
+        let helper = ServiceProviderInputHelper()
+        provider.delegate = helper as? any ServiceProviderDelegate
+        let result = provider.convertToASCIIBraille(string: input)
+        #expect(result == expected)
+    }
+
+    @Test(
+        "Test coverting Chinese to ASCII Taiwanese Braille, then coverting it back",
+        arguments: [
+            ("由「小麥」的作者", ""),
+            ("This is a test", ""),
+            ("第1名", "地 1 明"),
+            ("第A名", "地 A 明"),
+            ("第AB名", "地 AB 明"),
+            ("第A1名", "地 A1 明"),
+        ])
+    func testConvertASCIIBrailleThenBack(input: String, expected: String) {
+        LanguageModelManager.loadDataModels()
+        let provider = ServiceProvider()
+        let helper = ServiceProviderInputHelper()
+        provider.delegate = helper as? any ServiceProviderDelegate
+        let r1 = provider.convertToASCIIBraille(string: input)
+        let r2 = provider.convertASCIIBrailleToChineseText(string: r1)
+        if expected == "" {
+            #expect(r2 == input, "\(r2)")
+        } else {
+            #expect(r2 == expected, "\(r2)")
+        }
+    }
+
+    @Test(
+        "Test coverting digits to ASCII Taiwanese Braille",
+        arguments: [
+            ("24", "#24")
+        ])
+    func testASCIIBrailleDigit(input: String, expected: String) {
+        LanguageModelManager.loadDataModels()
+        let provider = ServiceProvider()
+        let helper = ServiceProviderInputHelper()
+        provider.delegate = helper as? any ServiceProviderDelegate
+        let result = provider.convertToASCIIBraille(string: input)
         #expect(result == expected)
     }
 
@@ -227,8 +279,8 @@ final class ServiceProviderTests {
         #expect(read(from: pasteboard) == input)
     }
 
-    @Test("Test convert braille to Chinese service with pasteboard")
-    func testConvertBrailleToChineseServiceWithPasteboard() {
+    @Test("Test convert Unicode braille to Chinese service with pasteboard")
+    func testConvertUnicodeBrailleToChineseServiceWithPasteboard() {
         LanguageModelManager.loadDataModels()
         let provider = ServiceProvider()
         let helper = ServiceProviderInputHelper()
@@ -237,9 +289,24 @@ final class ServiceProviderTests {
         let input = "⠰⠤⠋⠺⠂⠻⠄⠛⠥⠂⠓⠫⠐⠑⠳⠄⠪⠐⠙⠮⠁⠅⠎⠐⠊⠱⠐⠑⠪⠄⠏⠣⠄⠇⠶⠐⠤⠆"
         write(input, to: pasteboard)
 
-        provider.convertBrailleToChineseText(pasteboard, userData: nil, error: nil)
+        provider.convertUnicodeBrailleToChineseText(pasteboard, userData: nil, error: nil)
 
-        #expect(read(from: pasteboard) == provider.convertBrailleToChineseText(string: input))
+        #expect(read(from: pasteboard) == provider.convertUnicodeBrailleToChineseText(string: input))
+    }
+
+    @Test("Test convert ASCII braille to Chinese service with pasteboard")
+    func testConvertASCIIBrailleToChineseServiceWithPasteboard() {
+        LanguageModelManager.loadDataModels()
+        let provider = ServiceProvider()
+        let helper = ServiceProviderInputHelper()
+        provider.delegate = helper as? any ServiceProviderDelegate
+        let pasteboard = makePasteboard()
+        let input = provider.convertToASCIIBraille(string: "「台灣人最需要的就是消波塊」")
+        write(input, to: pasteboard)
+
+        provider.convertASCIIBrailleToChineseText(pasteboard, userData: nil, error: nil)
+
+        #expect(read(from: pasteboard) == provider.convertASCIIBrailleToChineseText(string: input))
     }
 
     @Test("Test convert to annotated text service with pasteboard")

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
@@ -235,7 +235,9 @@ import Foundation
                 output += punctuation.getBraille(by: type)
                 readHead += 1
                 state = .letters
+                continue
             }
+
             if state != .initial {
                 output += " "
             }

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
@@ -319,7 +319,7 @@ import Foundation
                     let start = braille.index(braille.startIndex, offsetBy: readHead)
                     let end = braille.index(braille.startIndex, offsetBy: readHead + i)
                     let substring = braille[start...end]
-                    if let punctuation = DigitRelated(braille: String(substring)) {
+                    if let punctuation = DigitRelated(braille: String(substring), type: type) {
                         nonBpmfText += punctuation.rawValue
                         readHead += i + 1
                         found = true

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
@@ -272,7 +272,9 @@ import Foundation
     /// - Parameter braille: The text in Taiwanese Braille.
     /// - Returns: The tokens.
     @objc(convertBrailleToTokens:type:)
-    public static func convert(brailleToTokens braille: String, type:BrailleType = .unicode) -> [Any] {
+    public static func convert(brailleToTokens braille: String, type: BrailleType = .unicode)
+        -> [Any]
+    {
         var state = ConverterState.initial
         var output: [Any] = []
         var readHead = 0
@@ -358,7 +360,10 @@ import Foundation
                         let start = braille.index(braille.startIndex, offsetBy: readHead)
                         let end = braille.index(braille.startIndex, offsetBy: readHead + i)
                         let substring = braille[start...end]
-                        if let punctuation = HalfWidthPunctuation(braille: String(substring)) {
+                        if let punctuation = HalfWidthPunctuation(
+                            braille: String(substring),
+                            type: type
+                        ) {
                             nonBpmfText += punctuation.rawValue
                             readHead += i + 1
                             found = true
@@ -432,7 +437,10 @@ import Foundation
                     let start = braille.index(braille.startIndex, offsetBy: readHead)
                     let end = braille.index(braille.startIndex, offsetBy: readHead + i)
                     let substring = braille[start...end]
-                    if let punctuation = FullWidthPunctuation(braille: String(substring)) {
+                    if let punctuation = FullWidthPunctuation(
+                        braille: String(substring),
+                        type: type
+                    ) {
                         if state == .initial
                             && punctuation.supposedToBeAtStart == false
                         {
@@ -475,7 +483,10 @@ import Foundation
                     let start = braille.index(braille.startIndex, offsetBy: readHead)
                     let end = braille.index(braille.startIndex, offsetBy: readHead + i)
                     let substring = braille[start...end]
-                    if let punctuation = HalfWidthPunctuation(braille: String(substring)) {
+                    if let punctuation = HalfWidthPunctuation(
+                        braille: String(substring),
+                        type: type
+                    ) {
                         nonBpmfText += punctuation.rawValue
                         readHead += i + 1
                         state = .letters

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
@@ -26,6 +26,42 @@ import Foundation
 /// Convert Bopomofo to Braille and vice versa.
 @objc public class BopomofoBrailleConverter: NSObject {
 
+    private static func numberSign(for type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            "⠼"
+        case .ascii:
+            "#"
+        }
+    }
+
+    private static func uppercaseSign(for type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            "⠠"
+        case .ascii:
+            ","
+        }
+    }
+
+    private static func digit(from string: String, type: BrailleType) -> Digit? {
+        switch type {
+        case .unicode:
+            Digit(braille: string)
+        case .ascii:
+            Digit(rawValue: string)
+        }
+    }
+
+    private static func letter(from string: String, type: BrailleType) -> Letter? {
+        switch type {
+        case .unicode:
+            Letter(braille: string)
+        case .ascii:
+            Letter(rawValue: string.lowercased())
+        }
+    }
+
     private enum ConverterState {
         case initial
         case bpmf
@@ -37,8 +73,8 @@ import Foundation
     ///
     /// - Parameter bopomofo: the input text in Bopomofo.
     /// - Returns: Converted Taiwanese Braille.
-    @objc(convertFromBopomofo:)
-    public static func convert(bopomofo: String) -> String {
+    @objc(convertFromBopomofo:type:)
+    public static func convert(bopomofo: String, type: BrailleType = .unicode) -> String {
         var state = ConverterState.initial
         var output = ""
         var readHead = 0
@@ -69,7 +105,7 @@ import Foundation
                 let substring = String(
                     bopomofo[bopomofo.index(bopomofo.startIndex, offsetBy: readHead)])
                 if let aCase = Digit(rawValue: substring) {
-                    output += aCase.braille
+                    output += aCase.getBraille(by: type)
                     readHead += 1
                     continue
                 }
@@ -80,7 +116,7 @@ import Foundation
                     let end = bopomofo.index(bopomofo.startIndex, offsetBy: readHead + i)
                     let substring = bopomofo[start...end]
                     if let aCase = DigitRelated(rawValue: String(substring)) {
-                        output += aCase.braille
+                        output += aCase.getBraille(by: type)
                         readHead += i + 1
                         found = true
                         break
@@ -99,16 +135,16 @@ import Foundation
                 let lowered = substring.lowercased()
                 if ("a"..."z").contains(lowered) {
                     if ("A"..."Z").contains(substring) {
-                        output += "⠠"
+                        output += uppercaseSign(for: type)
                     }
                     if let aCase = Letter(rawValue: lowered) {
-                        output += aCase.braille
+                        output += aCase.getBraille(by: type)
                     }
                     readHead += 1
                     continue
                 }
                 if let aCase = HalfWidthPunctuation(rawValue: substring) {
-                    output += aCase.braille
+                    output += aCase.getBraille(by: type)
                     readHead += 1
                     continue
                 }
@@ -124,7 +160,10 @@ import Foundation
                     let end = bopomofo.index(bopomofo.startIndex, offsetBy: readHead + i)
                     let substring = bopomofo[start...end]
                     do {
-                        let syllable = try BopomofoSyllable(rawValue: String(substring))
+                        let syllable = try BopomofoSyllable(
+                            rawValue: String(substring),
+                            type: type
+                        )
                         if state != .bpmf && state != .initial {
                             output += " "
                         }
@@ -149,7 +188,7 @@ import Foundation
                     if state != .bpmf && state != .initial {
                         output += " "
                     }
-                    output += punctuation.braille
+                    output += punctuation.getBraille(by: type)
                     readHead += 1
                     state = .bpmf
                     continue
@@ -163,9 +202,9 @@ import Foundation
                 if state != .initial && state != .digits {
                     output += " "
                 }
-                output += "⠼"
+                output += numberSign(for: type)
                 if let aCase = Digit(rawValue: substring) {
-                    output += aCase.braille
+                    output += aCase.getBraille(by: type)
                 }
                 readHead += 1
                 state = ConverterState.digits
@@ -179,10 +218,10 @@ import Foundation
                     output += " "
                 }
                 if ("A"..."Z").contains(substring) {
-                    output += "⠠"
+                    output += uppercaseSign(for: type)
                 }
                 if let aCase = Letter(rawValue: lowered) {
-                    output += aCase.braille
+                    output += aCase.getBraille(by: type)
                 }
                 readHead += 1
                 state = .letters
@@ -193,7 +232,7 @@ import Foundation
                 if state != .initial && state != .letters {
                     output += " "
                 }
-                output += punctuation.braille
+                output += punctuation.getBraille(by: type)
                 readHead += 1
                 state = .letters
             }
@@ -212,10 +251,10 @@ import Foundation
     ///
     /// - Parameter braille: The text in Taiwanese Barille.
     /// - Returns: The converted text in Bopomofo.
-    @objc(convertFromBraille:)
-    public static func convert(braille: String) -> String {
+    @objc(convertFromBraille:type:)
+    public static func convert(braille: String, type: BrailleType = .unicode) -> String {
         var output = ""
-        let tokens = self.convert(brailleToTokens: braille)
+        let tokens = self.convert(brailleToTokens: braille, type: type)
         for token in tokens {
             if let token = token as? BopomofoSyllable {
                 output += token.rawValue
@@ -232,8 +271,8 @@ import Foundation
     ///
     /// - Parameter braille: The text in Taiwanese Braille.
     /// - Returns: The tokens.
-    @objc(convertBrailleToTokens:)
-    public static func convert(brailleToTokens braille: String) -> [Any] {
+    @objc(convertBrailleToTokens:type:)
+    public static func convert(brailleToTokens braille: String, type:BrailleType = .unicode) -> [Any] {
         var state = ConverterState.initial
         var output: [Any] = []
         var readHead = 0
@@ -267,7 +306,7 @@ import Foundation
             if state == .digits {
                 let substring = String(
                     braille[braille.index(braille.startIndex, offsetBy: readHead)])
-                if let digit = Digit(braille: substring) {
+                if let digit = digit(from: substring, type: type) {
                     nonBpmfText += digit.rawValue
                     readHead += 1
                     continue
@@ -295,13 +334,13 @@ import Foundation
                 var substring = String(
                     braille[braille.index(braille.startIndex, offsetBy: readHead)])
                 var isUppercase = false
-                if substring == "⠠" {
+                if substring == uppercaseSign(for: type) {
                     // Uppercase1;
                     isUppercase = true
                     substring = String(
                         braille[braille.index(braille.startIndex, offsetBy: readHead + 1)])
                 }
-                if let letter = Letter(braille: substring) {
+                if let letter = letter(from: substring, type: type) {
                     if isUppercase {
                         nonBpmfText += letter.rawValue.uppercased()
                         readHead += 2
@@ -333,6 +372,19 @@ import Foundation
                 state = .initial
             }
 
+            let substring = String(braille[braille.index(braille.startIndex, offsetBy: readHead)])
+
+            if substring == uppercaseSign(for: type) && readHead + 1 < braille.count {
+                let next = String(
+                    braille[braille.index(braille.startIndex, offsetBy: readHead + 1)])
+                if let letter = letter(from: next, type: type) {
+                    nonBpmfText += letter.rawValue.uppercased()
+                    readHead += 2
+                    state = .letters
+                    continue
+                }
+            }
+
             // BPMF
             do {
                 let target = min(2, length - readHead - 1)
@@ -350,7 +402,10 @@ import Foundation
                         }
 
                         do {
-                            let bpmf = try BopomofoSyllable(braille: String(substring))
+                            let bpmf = try BopomofoSyllable(
+                                braille: String(substring),
+                                type: type
+                            )
                             readHead += i + 1
                             if !nonBpmfText.isEmpty {
                                 output.append(nonBpmfText)
@@ -395,12 +450,10 @@ import Foundation
                 }
             }
 
-            let substring = String(braille[braille.index(braille.startIndex, offsetBy: readHead)])
-
-            if substring == "⠼" {
+            if substring == numberSign(for: type) {
                 let next = String(
                     braille[braille.index(braille.startIndex, offsetBy: readHead + 1)])
-                if let digit = Digit(braille: next) {
+                if let digit = digit(from: next, type: type) {
                     nonBpmfText += digit.rawValue
                     readHead += 2
                     state = .digits
@@ -408,18 +461,7 @@ import Foundation
                 }
             }
 
-            if substring == "⠠" && readHead < braille.count {
-                let next = String(
-                    braille[braille.index(braille.startIndex, offsetBy: readHead + 1)])
-                if let letter = Letter(braille: next) {
-                    nonBpmfText += letter.rawValue.uppercased()
-                    readHead += 2
-                    state = .letters
-                    continue
-                }
-            }
-
-            if let letter = Letter(braille: substring) {
+            if let letter = letter(from: substring, type: type) {
                 nonBpmfText += letter.rawValue
                 readHead += 1
                 state = .letters

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Converter.swift
@@ -24,6 +24,9 @@
 import Foundation
 
 /// Convert Bopomofo to Braille and vice versa.
+///
+/// Note: there is another implementation could be a reference
+/// https://hurthuang.github.io/vi.note/brl/tw-brl-trans/braille-translate-bkline.htm
 @objc public class BopomofoBrailleConverter: NSObject {
 
     private static func numberSign(for type: BrailleType) -> String {

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BopomofoSyllable.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BopomofoSyllable.swift
@@ -29,41 +29,67 @@ private let kMinimalBrailleLength = 2
 private protocol Syllable {
     var bopomofo: String { get }
     var braille: String { get }
+    var brailleAscii: String { get }
     var brailleCode: String { get }
+    func getBraille(by type: BrailleType) -> String
+}
+
+extension Syllable {
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            brailleAscii
+        }
+    }
 }
 
 private protocol Combination {
     var bopomofo: String { get }
     var braille: String { get }
+    var brailleAscii: String { get }
     var brailleCode: String { get }
+    func getBraille(by type: BrailleType) -> String
+}
+
+extension Combination {
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            brailleAscii
+        }
+    }
 }
 
 // MARK: - Syllables
 
 private enum Consonant: String, CaseIterable, Syllable {
 
-    static let bpmfBrailleMap: [Consonant: (String, String)] = [
-        .ㄅ: ("⠕", "135"),
-        .ㄆ: ("⠏", "1234"),
-        .ㄇ: ("⠍", "134"),
-        .ㄈ: ("⠟", "12345"),
-        .ㄉ: ("⠙", "145"),
-        .ㄊ: ("⠋", "124"),
-        .ㄋ: ("⠝", "1345"),
-        .ㄌ: ("⠉", "14"),
-        .ㄍ: ("⠅", "13"),
-        .ㄎ: ("⠇", "123"),
-        .ㄏ: ("⠗", "1235"),
-        .ㄐ: ("⠅", "13"),
-        .ㄑ: ("⠚", "245"),
-        .ㄒ: ("⠑", "15"),
-        .ㄓ: ("⠁", "1"),
-        .ㄔ: ("⠃", "12"),
-        .ㄕ: ("⠊", "24"),
-        .ㄖ: ("⠛", "1245"),
-        .ㄗ: ("⠓", "125"),
-        .ㄘ: ("⠚", "245"),
-        .ㄙ: ("⠑", "15"),
+    static let bpmfBrailleMap: [Consonant: (String, String, String)] = [
+        .ㄅ: ("⠕", "o", "135"),
+        .ㄆ: ("⠏", "p", "1234"),
+        .ㄇ: ("⠍", "m", "134"),
+        .ㄈ: ("⠟", "q", "12345"),
+        .ㄉ: ("⠙", "d", "145"),
+        .ㄊ: ("⠋", "f", "124"),
+        .ㄋ: ("⠝", "n", "1345"),
+        .ㄌ: ("⠉", "c", "14"),
+        .ㄍ: ("⠅", "k", "13"),
+        .ㄎ: ("⠇", "l", "123"),
+        .ㄏ: ("⠗", "r", "1235"),
+        .ㄐ: ("⠅", "k", "13"),
+        .ㄑ: ("⠚", "j", "245"),
+        .ㄒ: ("⠑", "e", "15"),
+        .ㄓ: ("⠁", "a", "1"),
+        .ㄔ: ("⠃", "b", "12"),
+        .ㄕ: ("⠊", "i", "24"),
+        .ㄖ: ("⠛", "g", "1245"),
+        .ㄗ: ("⠓", "h", "125"),
+        .ㄘ: ("⠚", "j", "245"),
+        .ㄙ: ("⠑", "e", "15"),
     ]
 
     fileprivate var bopomofo: String {
@@ -74,8 +100,12 @@ private enum Consonant: String, CaseIterable, Syllable {
         Consonant.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         Consonant.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        Consonant.bpmfBrailleMap[self]!.2
     }
 
     fileprivate var isSingle: Bool {
@@ -111,10 +141,10 @@ private enum Consonant: String, CaseIterable, Syllable {
 }
 
 private enum MiddleVowel: String, CaseIterable, Syllable {
-    static let bpmfBrailleMap: [MiddleVowel: (String, String)] = [
-        .ㄧ: ("⠡", "16"),
-        .ㄨ: ("⠌", "34"),
-        .ㄩ: ("⠳", "1256"),
+    static let bpmfBrailleMap: [MiddleVowel: (String, String, String)] = [
+        .ㄧ: ("⠡", "*", "16"),
+        .ㄨ: ("⠌", "/", "34"),
+        .ㄩ: ("⠳", "|", "1256"),
     ]
     fileprivate var bopomofo: String {
         self.rawValue
@@ -124,8 +154,12 @@ private enum MiddleVowel: String, CaseIterable, Syllable {
         MiddleVowel.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         MiddleVowel.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        MiddleVowel.bpmfBrailleMap[self]!.2
     }
 
     fileprivate func buildCombination(rawValue: String) throws -> Combination {
@@ -151,20 +185,20 @@ private enum MiddleVowel: String, CaseIterable, Syllable {
 }
 
 private enum Vowel: String, CaseIterable, Syllable {
-    static let bpmfBrailleMap: [Vowel: (String, String)] = [
-        .ㄚ: ("⠜", "345"),
-        .ㄛ: ("⠣", "126"),
-        .ㄜ: ("⠮", "2346"),
-        .ㄝ: ("⠢", "26"),
-        .ㄞ: ("⠺", "2456"),
-        .ㄟ: ("⠴", "356"),
-        .ㄠ: ("⠩", "146"),
-        .ㄡ: ("⠷", "12356"),
-        .ㄢ: ("⠧", "1236"),
-        .ㄣ: ("⠥", "136"),
-        .ㄤ: ("⠭", "1346"),
-        .ㄥ: ("⠵", "1356"),
-        .ㄦ: ("⠱", "156"),
+    static let bpmfBrailleMap: [Vowel: (String, String, String)] = [
+        .ㄚ: ("⠜", ">", "345"),
+        .ㄛ: ("⠣", "<", "126"),
+        .ㄜ: ("⠮", "!", "2346"),
+        .ㄝ: ("⠢", "5", "26"),
+        .ㄞ: ("⠺", "w", "2456"),
+        .ㄟ: ("⠴", "0", "356"),
+        .ㄠ: ("⠩", "%", "146"),
+        .ㄡ: ("⠷", "(", "12356"),
+        .ㄢ: ("⠧", "v", "1236"),
+        .ㄣ: ("⠥", "u", "136"),
+        .ㄤ: ("⠭", "x", "1346"),
+        .ㄥ: ("⠵", "z", "1356"),
+        .ㄦ: ("⠱", ":", "156"),
     ]
 
     fileprivate var bopomofo: String {
@@ -175,8 +209,12 @@ private enum Vowel: String, CaseIterable, Syllable {
         Vowel.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         Vowel.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        Vowel.bpmfBrailleMap[self]!.2
     }
 
     case ㄚ = "ㄚ"
@@ -197,17 +235,17 @@ private enum Vowel: String, CaseIterable, Syllable {
 // MARK: - Combination
 
 private enum ㄧ_Combination: String, CaseIterable, Combination {
-    static let bpmfBrailleMap: [ㄧ_Combination: (String, String)] = [
-        .ㄧㄚ: ("⠾", "23456"),
-        .ㄧㄛ: ("⠴", "356"),
-        .ㄧㄝ: ("⠬", "346"),
-        .ㄧㄞ: ("⠢", "26"),
-        .ㄧㄠ: ("⠪", "246"),
-        .ㄧㄡ: ("⠎", "234"),
-        .ㄧㄢ: ("⠞", "2345"),
-        .ㄧㄣ: ("⠹", "1456"),
-        .ㄧㄤ: ("⠨", "46"),
-        .ㄧㄥ: ("⠽", "13456"),
+    static let bpmfBrailleMap: [ㄧ_Combination: (String, String, String)] = [
+        .ㄧㄚ: ("⠾", ")", "23456"),
+        .ㄧㄛ: ("⠴", "0", "356"),
+        .ㄧㄝ: ("⠬", "+", "346"),
+        .ㄧㄞ: ("⠢", "5", "26"),
+        .ㄧㄠ: ("⠪", "{", "246"),
+        .ㄧㄡ: ("⠎", "s", "234"),
+        .ㄧㄢ: ("⠞", "t", "2345"),
+        .ㄧㄣ: ("⠹", "?", "1456"),
+        .ㄧㄤ: ("⠨", ".", "46"),
+        .ㄧㄥ: ("⠽", "y", "13456"),
     ]
 
     fileprivate var bopomofo: String {
@@ -218,8 +256,12 @@ private enum ㄧ_Combination: String, CaseIterable, Combination {
         ㄧ_Combination.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         ㄧ_Combination.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        ㄧ_Combination.bpmfBrailleMap[self]!.2
     }
 
     case ㄧㄚ = "ㄚ"
@@ -235,15 +277,15 @@ private enum ㄧ_Combination: String, CaseIterable, Combination {
 }
 
 private enum ㄨ_Combination: String, CaseIterable, Combination {
-    static let bpmfBrailleMap: [ㄨ_Combination: (String, String)] = [
-        .ㄨㄚ: ("⠔", "35"),
-        .ㄨㄛ: ("⠒", "25"),
-        .ㄨㄞ: ("⠶", "2356"),
-        .ㄨㄟ: ("⠫", "1246"),
-        .ㄨㄢ: ("⠻", "12456"),
-        .ㄨㄣ: ("⠿", "123456"),
-        .ㄨㄤ: ("⠸", "456"),
-        .ㄨㄥ: ("⠯", "12346"),
+    static let bpmfBrailleMap: [ㄨ_Combination: (String, String, String)] = [
+        .ㄨㄚ: ("⠔", "9", "35"),
+        .ㄨㄛ: ("⠒", "3", "25"),
+        .ㄨㄞ: ("⠶", "7", "2356"),
+        .ㄨㄟ: ("⠫", "$", "1246"),
+        .ㄨㄢ: ("⠻", "}", "12456"),
+        .ㄨㄣ: ("⠿", "=", "123456"),
+        .ㄨㄤ: ("⠸", "_", "456"),
+        .ㄨㄥ: ("⠯", "&", "12346"),
     ]
 
     fileprivate var bopomofo: String {
@@ -254,8 +296,12 @@ private enum ㄨ_Combination: String, CaseIterable, Combination {
         ㄨ_Combination.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         ㄨ_Combination.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        ㄨ_Combination.bpmfBrailleMap[self]!.2
     }
 
     case ㄨㄚ = "ㄚ"
@@ -269,11 +315,11 @@ private enum ㄨ_Combination: String, CaseIterable, Combination {
 }
 
 private enum ㄩ_Combination: String, CaseIterable, Combination {
-    static let bpmfBrailleMap: [ㄩ_Combination: (String, String)] = [
-        .ㄩㄝ: ("⠦", "236"),
-        .ㄩㄢ: ("⠘", "45"),
-        .ㄩㄣ: ("⠲", "256"),
-        .ㄩㄥ: ("⠖", "235"),
+    static let bpmfBrailleMap: [ㄩ_Combination: (String, String, String)] = [
+        .ㄩㄝ: ("⠦", "8", "236"),
+        .ㄩㄢ: ("⠘", "~", "45"),
+        .ㄩㄣ: ("⠲", "4", "256"),
+        .ㄩㄥ: ("⠖", "6", "235"),
     ]
 
     fileprivate var bopomofo: String {
@@ -284,8 +330,12 @@ private enum ㄩ_Combination: String, CaseIterable, Combination {
         ㄩ_Combination.bpmfBrailleMap[self]!.0
     }
 
-    fileprivate var brailleCode: String {
+    fileprivate var brailleAscii: String {
         ㄩ_Combination.bpmfBrailleMap[self]!.1
+    }
+
+    fileprivate var brailleCode: String {
+        ㄩ_Combination.bpmfBrailleMap[self]!.2
     }
 
     case ㄩㄝ = "ㄝ"
@@ -298,12 +348,12 @@ private enum ㄩ_Combination: String, CaseIterable, Combination {
 // MARK: - Tone
 
 private enum Tone: String, CaseIterable {
-    static let bpmfBrailleMap: [Tone: (String, String)] = [
-        .tone1: ("⠄", "3"),
-        .tone2: ("⠂", "2"),
-        .tone3: ("⠈", "4"),
-        .tone4: ("⠐", "5"),
-        .tone5: ("⠁", "1"),
+    static let bpmfBrailleMap: [Tone: (String, String, String)] = [
+        .tone1: ("⠄", "'", "3"),
+        .tone2: ("⠂", "1", "2"),
+        .tone3: ("⠈", "`", "4"),
+        .tone4: ("⠐", "\"", "5"),
+        .tone5: ("⠁", "a", "1"),
     ]
 
     fileprivate var bopomofo: String {
@@ -314,8 +364,22 @@ private enum Tone: String, CaseIterable {
         Tone.bpmfBrailleMap[self]!.0
     }
 
+    fileprivate var brailleAscii: String {
+        Tone.bpmfBrailleMap[self]!.1
+    }
+
     fileprivate var brailleCode: String {
         Tone.bpmfBrailleMap[self]!.1
+    }
+
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            brailleAscii
+        }
+
     }
 
     case tone1 = ""
@@ -379,18 +443,48 @@ public struct BopomofoSyllable {
     private static let vowelValues = Set(Vowel.allCases.map { $0.rawValue })
     private static let toneValues = Set(Tone.allCases.map { $0.rawValue })
 
-    private static let consonantBraille = Set(Consonant.allCases.map { $0.braille })
-    private static let middleVowelBraille = Set(MiddleVowel.allCases.map { $0.braille })
-    private static let vowelBraille = Set(Vowel.allCases.map { $0.braille })
-    private static let toneBraille = Set(Tone.allCases.map { $0.braille })
-    private static let ㄧBraille = Set(ㄧ_Combination.allCases.map { $0.braille })
-    private static let ㄨBraille = Set(ㄨ_Combination.allCases.map { $0.braille })
-    private static let ㄩBraille = Set(ㄩ_Combination.allCases.map { $0.braille })
+    private static let consonantBraille = [
+        Set(Consonant.allCases.map { $0.braille }),
+        Set(Consonant.allCases.map { $0.brailleAscii }),
+    ]
+    private static let middleVowelBraille = [
+        Set(MiddleVowel.allCases.map { $0.braille }),
+        Set(MiddleVowel.allCases.map { $0.brailleAscii }),
+    ]
+    private static let vowelBraille = [
+        Set(Vowel.allCases.map { $0.braille }),
+        Set(Vowel.allCases.map { $0.brailleAscii }),
+    ]
+    private static let toneBraille = [
+        Set(Tone.allCases.map { $0.braille }),
+        Set(Tone.allCases.map { $0.brailleAscii }),
+    ]
+    private static let ㄧBraille = [
+        Set(ㄧ_Combination.allCases.map { $0.braille }),
+        Set(ㄧ_Combination.allCases.map { $0.brailleAscii }),
+    ]
+    private static let ㄨBraille = [
+        Set(ㄨ_Combination.allCases.map { $0.braille }),
+        Set(ㄨ_Combination.allCases.map { $0.brailleAscii }),
+    ]
+    private static let ㄩBraille = [
+        Set(ㄩ_Combination.allCases.map { $0.braille }),
+        Set(ㄩ_Combination.allCases.map { $0.brailleAscii }),
+    ]
+
+    private static func braille<S: Syllable>(for value: S, type: BrailleType) -> String {
+        value.getBraille(by: type)
+    }
+
+    private static func braille<C: Combination>(for value: C, type: BrailleType) -> String {
+        value.getBraille(by: type)
+    }
 
     public var rawValue: String
     public var braille: String
+    public var type: BrailleType
 
-    public init(rawValue: String) throws {
+    public init(rawValue: String, type: BrailleType = .unicode) throws {
         if rawValue.count < kMinimalBopomofoLength {
             throw BopomofoSyllableError.invalidLength
         }
@@ -442,19 +536,21 @@ public struct BopomofoSyllable {
         }
 
         self.rawValue = rawValue
-        self.braille = BopomofoSyllable.makeBraille(consonant, middleVowel, vowel, tone)
+        self.braille = BopomofoSyllable.makeBraille(consonant, middleVowel, vowel, tone, type)
+        self.type = type
     }
 
-    public init(braille: String) throws {
+    public init(braille: String, type: BrailleType = .unicode) throws {
 
         if braille.count < kMinimalBrailleLength {
             throw BopomofoSyllableError.invalidLength
         }
 
         func shouldConnectWithYiOrYv(_ next: String) -> Bool {
-            return next == MiddleVowel.ㄧ.braille || next == MiddleVowel.ㄩ.braille
-                || BopomofoSyllable.ㄧBraille.contains(next)
-                || BopomofoSyllable.ㄩBraille.contains(next)
+            return next == MiddleVowel.ㄧ.getBraille(by: type)
+                || next == MiddleVowel.ㄩ.getBraille(by: type)
+                || BopomofoSyllable.ㄧBraille[type.rawValue].contains(next)
+                || BopomofoSyllable.ㄩBraille[type.rawValue].contains(next)
         }
 
         var consonant: Consonant?
@@ -466,14 +562,14 @@ public struct BopomofoSyllable {
         for (index, c) in string.enumerated() {
             let s = String(c)
             switch s {
-            case "⠱":
+            case Vowel.ㄦ.getBraille(by: type):
                 if index == 0 {
                     vowel = .ㄦ
                 }
                 if let consonant, consonant.isSingle == false {
                     throw BopomofoSyllableError.other
                 }
-            case "⠁":  // ㄓ or tone5
+            case Consonant.ㄓ.getBraille(by: type):  // ㄓ or tone5
                 if index == 0 {
                     consonant = Consonant.ㄓ
                 } else {
@@ -485,7 +581,7 @@ public struct BopomofoSyllable {
                     }
                     tone = .tone5
                 }
-            case "⠑":  // ㄙ and ㄒ
+            case Consonant.ㄒ.getBraille(by: type):  // ㄙ and ㄒ
                 if consonant != nil {
                     throw BopomofoSyllableError.duplicatedConsonant
                 }
@@ -500,7 +596,7 @@ public struct BopomofoSyllable {
                 } else {
                     consonant = .ㄙ
                 }
-            case "⠚":  // ㄑ and ㄘ
+            case Consonant.ㄑ.getBraille(by: type):  // ㄑ and ㄘ
                 if consonant != nil {
                     throw BopomofoSyllableError.duplicatedConsonant
                 }
@@ -515,7 +611,7 @@ public struct BopomofoSyllable {
                 } else {
                     consonant = .ㄘ
                 }
-            case "⠅":  // ㄍ and ㄐ
+            case Consonant.ㄐ.getBraille(by: type):  // ㄍ and ㄐ
                 if consonant != nil {
                     throw BopomofoSyllableError.duplicatedConsonant
                 }
@@ -529,7 +625,11 @@ public struct BopomofoSyllable {
                 } else {
                     consonant = .ㄍ
                 }
-            case _ where BopomofoSyllable.consonantBraille.contains(s):
+            case _
+            where
+                BopomofoSyllable
+                .consonantBraille[type.rawValue]
+                .contains(s):
                 if consonant != nil {
                     throw BopomofoSyllableError.duplicatedConsonant
                 }
@@ -537,9 +637,13 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.consonantShouldBeAtFront
                 }
                 consonant = Consonant.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
-            case _ where BopomofoSyllable.middleVowelBraille.contains(s):
+            case _
+            where
+                BopomofoSyllable
+                .middleVowelBraille[type.rawValue]
+                .contains(s):
                 if middleVowel != nil {
                     throw BopomofoSyllableError.middleVowelAlreadySet
                 }
@@ -547,9 +651,13 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.vowelAlreadySet
                 }
                 middleVowel = MiddleVowel.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
-            case _ where BopomofoSyllable.vowelBraille.contains(s):
+            case _
+            where
+                BopomofoSyllable
+                .vowelBraille[type.rawValue]
+                .contains(s):
                 if middleVowel != nil {
                     throw BopomofoSyllableError.middleVowelAlreadySet
                 }
@@ -557,9 +665,9 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.vowelAlreadySet
                 }
                 vowel = Vowel.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
-            case _ where BopomofoSyllable.ㄧBraille.contains(s):
+            case _ where BopomofoSyllable.ㄧBraille[type.rawValue].contains(s):
                 if middleVowel != nil {
                     throw BopomofoSyllableError.middleVowelAlreadySet
                 }
@@ -567,14 +675,14 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.vowelAlreadySet
                 }
                 let combination = ㄧ_Combination.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
                 guard let combination = combination else {
                     throw BopomofoSyllableError.other
                 }
                 middleVowel = MiddleVowel.ㄧ
                 vowel = Vowel(rawValue: combination.rawValue)
-            case _ where BopomofoSyllable.ㄨBraille.contains(s):
+            case _ where BopomofoSyllable.ㄨBraille[type.rawValue].contains(s):
                 if middleVowel != nil {
                     throw BopomofoSyllableError.middleVowelAlreadySet
                 }
@@ -582,14 +690,14 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.vowelAlreadySet
                 }
                 let combination = ㄨ_Combination.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
                 guard let combination = combination else {
                     throw BopomofoSyllableError.other
                 }
                 middleVowel = MiddleVowel.ㄨ
                 vowel = Vowel(rawValue: combination.rawValue)
-            case _ where BopomofoSyllable.ㄩBraille.contains(s):
+            case _ where BopomofoSyllable.ㄩBraille[type.rawValue].contains(s):
                 if middleVowel != nil {
                     throw BopomofoSyllableError.middleVowelAlreadySet
                 }
@@ -597,7 +705,7 @@ public struct BopomofoSyllable {
                     throw BopomofoSyllableError.vowelAlreadySet
                 }
                 let combination = ㄩ_Combination.allCases.first { aCase in
-                    aCase.braille == s
+                    BopomofoSyllable.braille(for: aCase, type: type) == s
                 }
                 guard let combination = combination else {
                     throw BopomofoSyllableError.other
@@ -605,12 +713,16 @@ public struct BopomofoSyllable {
                 middleVowel = MiddleVowel.ㄩ
                 vowel = Vowel(rawValue: combination.rawValue)
 
-            case _ where BopomofoSyllable.toneBraille.contains(s):
+            case _
+            where
+                BopomofoSyllable
+                .toneBraille[type.rawValue]
+                .contains(s):
                 if tone != nil {
                     throw BopomofoSyllableError.toneAlreadySet
                 }
                 tone = Tone.allCases.first { aCase in
-                    aCase.braille == s
+                    aCase.getBraille(by: type) == s
                 }
             default:
                 throw BopomofoSyllableError.invalidCharacter
@@ -623,6 +735,7 @@ public struct BopomofoSyllable {
 
         self.braille = braille
         self.rawValue = BopomofoSyllable.makeRawValue(consonant, middleVowel, vowel, tone)
+        self.type = type
     }
 
     static private func makeRawValue(
@@ -639,27 +752,29 @@ public struct BopomofoSyllable {
         _ consonant: Consonant?,
         _ middleVowel: MiddleVowel?,
         _ vowel: Vowel?,
-        _ tone: Tone
+        _ tone: Tone,
+        _ type: BrailleType = .unicode
     ) -> String {
         var output = ""
         if let consonant {
-            output += consonant.braille
+            output += consonant.getBraille(by: type)
         }
         if let vowel {
             if let middleVowel {
                 let c = try? middleVowel.buildCombination(rawValue: vowel.rawValue)
-                output += c?.braille ?? ""
+                output += c?.getBraille(by: type) ?? ""
             } else {
-                output += vowel.braille
+                output += vowel.getBraille(by: type)
             }
         } else if let middleVowel {
-            output += middleVowel.braille
+            output += middleVowel.getBraille(by: type)
         } else if let consonant, consonant.isSingle {
-            // ㄭ
-            output += "⠱"
+            // ㄭ, which is duplicated with ㄦ, is represented as ㄭ in Braille.
+            let suffix = Vowel.ㄦ.getBraille(by: type)
+            output += suffix
         }
 
-        output += tone.braille
+        output += tone.getBraille(by: type)
         return output
     }
 }

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BopomofoSyllable.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BopomofoSyllable.swift
@@ -27,40 +27,23 @@ private let kMinimalBopomofoLength = 1
 private let kMinimalBrailleLength = 2
 
 private protocol Syllable {
-    var bopomofo: String { get }
-    var braille: String { get }
-    var brailleAscii: String { get }
-    var brailleCode: String { get }
     func getBraille(by type: BrailleType) -> String
-}
-
-extension Syllable {
-    func getBraille(by type: BrailleType) -> String {
-        switch type {
-        case .unicode:
-            braille
-        case .ascii:
-            brailleAscii
-        }
-    }
 }
 
 private protocol Combination {
-    var bopomofo: String { get }
-    var braille: String { get }
-    var brailleAscii: String { get }
-    var brailleCode: String { get }
     func getBraille(by type: BrailleType) -> String
 }
 
-extension Combination {
-    func getBraille(by type: BrailleType) -> String {
-        switch type {
-        case .unicode:
-            braille
-        case .ascii:
-            brailleAscii
-        }
+private func braille(
+    unicode: String,
+    ascii: String,
+    by type: BrailleType
+) -> String {
+    switch type {
+    case .unicode:
+        unicode
+    case .ascii:
+        ascii
     }
 }
 
@@ -92,20 +75,9 @@ private enum Consonant: String, CaseIterable, Syllable {
         .ㄙ: ("⠑", "e", "15"),
     ]
 
-    fileprivate var bopomofo: String {
-        self.rawValue
-    }
-
-    fileprivate var braille: String {
-        Consonant.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        Consonant.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        Consonant.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = Consonant.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     fileprivate var isSingle: Bool {
@@ -146,20 +118,10 @@ private enum MiddleVowel: String, CaseIterable, Syllable {
         .ㄨ: ("⠌", "/", "34"),
         .ㄩ: ("⠳", "|", "1256"),
     ]
-    fileprivate var bopomofo: String {
-        self.rawValue
-    }
 
-    fileprivate var braille: String {
-        MiddleVowel.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        MiddleVowel.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        MiddleVowel.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = MiddleVowel.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     fileprivate func buildCombination(rawValue: String) throws -> Combination {
@@ -201,20 +163,9 @@ private enum Vowel: String, CaseIterable, Syllable {
         .ㄦ: ("⠱", ":", "156"),
     ]
 
-    fileprivate var bopomofo: String {
-        self.rawValue
-    }
-
-    fileprivate var braille: String {
-        Vowel.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        Vowel.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        Vowel.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = Vowel.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     case ㄚ = "ㄚ"
@@ -248,20 +199,9 @@ private enum ㄧ_Combination: String, CaseIterable, Combination {
         .ㄧㄥ: ("⠽", "y", "13456"),
     ]
 
-    fileprivate var bopomofo: String {
-        "ㄧ" + self.rawValue
-    }
-
-    fileprivate var braille: String {
-        ㄧ_Combination.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        ㄧ_Combination.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        ㄧ_Combination.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = ㄧ_Combination.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     case ㄧㄚ = "ㄚ"
@@ -288,20 +228,9 @@ private enum ㄨ_Combination: String, CaseIterable, Combination {
         .ㄨㄥ: ("⠯", "&", "12346"),
     ]
 
-    fileprivate var bopomofo: String {
-        "ㄨ" + self.rawValue
-    }
-
-    fileprivate var braille: String {
-        ㄨ_Combination.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        ㄨ_Combination.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        ㄨ_Combination.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = ㄨ_Combination.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     case ㄨㄚ = "ㄚ"
@@ -322,20 +251,9 @@ private enum ㄩ_Combination: String, CaseIterable, Combination {
         .ㄩㄥ: ("⠖", "6", "235"),
     ]
 
-    fileprivate var bopomofo: String {
-        "ㄩ" + self.rawValue
-    }
-
-    fileprivate var braille: String {
-        ㄩ_Combination.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        ㄩ_Combination.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        ㄩ_Combination.bpmfBrailleMap[self]!.2
+    fileprivate func getBraille(by type: BrailleType) -> String {
+        let pair = ㄩ_Combination.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     case ㄩㄝ = "ㄝ"
@@ -356,30 +274,9 @@ private enum Tone: String, CaseIterable {
         .tone5: ("⠁", "a", "1"),
     ]
 
-    fileprivate var bopomofo: String {
-        return self.rawValue
-    }
-
-    fileprivate var braille: String {
-        Tone.bpmfBrailleMap[self]!.0
-    }
-
-    fileprivate var brailleAscii: String {
-        Tone.bpmfBrailleMap[self]!.1
-    }
-
-    fileprivate var brailleCode: String {
-        Tone.bpmfBrailleMap[self]!.1
-    }
-
     func getBraille(by type: BrailleType) -> String {
-        switch type {
-        case .unicode:
-            braille
-        case .ascii:
-            brailleAscii
-        }
-
+        let pair = Tone.bpmfBrailleMap[self]!
+        return braille(unicode: pair.0, ascii: pair.1, by: type)
     }
 
     case tone1 = ""
@@ -444,32 +341,32 @@ public struct BopomofoSyllable {
     private static let toneValues = Set(Tone.allCases.map { $0.rawValue })
 
     private static let consonantBraille = [
-        Set(Consonant.allCases.map { $0.braille }),
-        Set(Consonant.allCases.map { $0.brailleAscii }),
+        Set(Consonant.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(Consonant.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let middleVowelBraille = [
-        Set(MiddleVowel.allCases.map { $0.braille }),
-        Set(MiddleVowel.allCases.map { $0.brailleAscii }),
+        Set(MiddleVowel.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(MiddleVowel.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let vowelBraille = [
-        Set(Vowel.allCases.map { $0.braille }),
-        Set(Vowel.allCases.map { $0.brailleAscii }),
+        Set(Vowel.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(Vowel.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let toneBraille = [
-        Set(Tone.allCases.map { $0.braille }),
-        Set(Tone.allCases.map { $0.brailleAscii }),
+        Set(Tone.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(Tone.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let ㄧBraille = [
-        Set(ㄧ_Combination.allCases.map { $0.braille }),
-        Set(ㄧ_Combination.allCases.map { $0.brailleAscii }),
+        Set(ㄧ_Combination.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(ㄧ_Combination.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let ㄨBraille = [
-        Set(ㄨ_Combination.allCases.map { $0.braille }),
-        Set(ㄨ_Combination.allCases.map { $0.brailleAscii }),
+        Set(ㄨ_Combination.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(ㄨ_Combination.allCases.map { $0.getBraille(by: .ascii) }),
     ]
     private static let ㄩBraille = [
-        Set(ㄩ_Combination.allCases.map { $0.braille }),
-        Set(ㄩ_Combination.allCases.map { $0.brailleAscii }),
+        Set(ㄩ_Combination.allCases.map { $0.getBraille(by: .unicode) }),
+        Set(ㄩ_Combination.allCases.map { $0.getBraille(by: .ascii) }),
     ]
 
     private static func braille<S: Syllable>(for value: S, type: BrailleType) -> String {

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BrailleType.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/BrailleType.swift
@@ -1,0 +1,4 @@
+@objc public enum BrailleType: Int {
+    case unicode = 0
+    case ascii = 1
+}

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
@@ -28,7 +28,7 @@ enum Digit: String, CaseIterable {
 
     init?(braille: String) {
         let aCase = Digit.allCases.first { aCase in
-            aCase.braille == braille
+            aCase.getBraille(by: .unicode) == braille
         }
         if let aCase {
             self = aCase
@@ -38,38 +38,34 @@ enum Digit: String, CaseIterable {
     }
 
     var digit: String {
-        return rawValue
-    }
-
-    var braille: String {
-        switch self {
-        case .zero:
-            "⠴"
-        case .one:
-            "⠂"
-        case .two:
-            "⠆"
-        case .three:
-            "⠒"
-        case .four:
-            "⠲"
-        case .five:
-            "⠢"
-        case .six:
-            "⠖"
-        case .seven:
-            "⠶"
-        case .eight:
-            "⠦"
-        case .nine:
-            "⠔"
-        }
+        rawValue
     }
 
     func getBraille(by type: BrailleType) -> String {
         switch type {
         case .unicode:
-            braille
+            switch self {
+            case .zero:
+                "⠴"
+            case .one:
+                "⠂"
+            case .two:
+                "⠆"
+            case .three:
+                "⠒"
+            case .four:
+                "⠲"
+            case .five:
+                "⠢"
+            case .six:
+                "⠖"
+            case .seven:
+                "⠶"
+            case .eight:
+                "⠦"
+            case .nine:
+                "⠔"
+            }
         case .ascii:
             rawValue
         }
@@ -90,7 +86,7 @@ enum Digit: String, CaseIterable {
 enum DigitRelated: String, CaseIterable {
     init?(braille: String) {
         let aCase = DigitRelated.allCases.first { aCase in
-            aCase.braille == braille
+            aCase.getBraille(by: .unicode) == braille
         }
         if let aCase {
             self = aCase
@@ -99,34 +95,26 @@ enum DigitRelated: String, CaseIterable {
         }
     }
 
-    var braille: String {
-        switch self {
-        case .point:
-            "⠨"
-        case .percent:
-            "⠈⠴"
-        case .celsius:
-            "⠘⠨⠡ ⠰⠠⠉"
-        }
-    }
-
-    var brailleAscii: String {
-        switch self {
-        case .point:
-            "."
-        case .percent:
-            "%"
-        case .celsius:
-            "~.* ;,c"
-        }
-    }
-
     func getBraille(by type: BrailleType) -> String {
         switch type {
         case .unicode:
-            braille
+            switch self {
+            case .point:
+                "⠨"
+            case .percent:
+                "⠈⠴"
+            case .celsius:
+                "⠘⠨⠡ ⠰⠠⠉"
+            }
         case .ascii:
-            brailleAscii
+            switch self {
+            case .point:
+                "."
+            case .percent:
+                "%"
+            case .celsius:
+                "~.* ;,c"
+            }
         }
     }
 

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
@@ -66,6 +66,15 @@ enum Digit: String, CaseIterable {
         }
     }
 
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            rawValue
+        }
+    }
+
     case zero = "0"
     case one = "1"
     case two = "2"
@@ -99,7 +108,26 @@ enum DigitRelated: String, CaseIterable {
         case .celsius:
             "⠘⠨⠡ ⠰⠠⠉"
         }
+    }
 
+    var brailleAscii: String {
+        switch self {
+        case .point:
+            "."
+        case .percent:
+            "%"
+        case .celsius:
+            "~.* ;,c"
+        }
+    }
+
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            brailleAscii
+        }
     }
 
     case point = "."

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Digit.swift
@@ -84,9 +84,9 @@ enum Digit: String, CaseIterable {
 }
 
 enum DigitRelated: String, CaseIterable {
-    init?(braille: String) {
+    init?(braille: String, type: BrailleType) {
         let aCase = DigitRelated.allCases.first { aCase in
-            aCase.getBraille(by: .unicode) == braille
+            aCase.getBraille(by: type) == braille
         }
         if let aCase {
             self = aCase

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
@@ -93,6 +93,70 @@ public enum FullWidthPunctuation: String, CaseIterable {
         }
     }
 
+    /// Maps each full-width punctuation to its braille dots and an ASCII sequence used for input.
+    var brailleAscii: String {
+        switch self {
+        case .period:
+            "-"
+        case .dot:
+            "."
+        case .comma:
+            "2"
+        case .semicolon:
+            ";"
+        case .ideographicComma:
+            ","
+        case .questionMark:
+            "?"
+        case .exclamationMark:
+            "l"
+        case .colon:
+            "33"
+        case .personNameMark:
+            "|"
+        case .slash:
+            "-"
+        case .bookNameMark:
+            "~"
+        case .ellipsis:
+            "'''"
+        case .referenceMark:
+            "`#"
+        case .doubleRing:
+            "{o"
+        case .singleQuotationMarkLeft:
+            ";-"
+        case .singleQuotationMarkRight:
+            "-2"
+        case .doubleQuotationMarkLeft:
+            "88"
+        case .doubleQuotationMarkRight:
+            "00"
+        case .parenthesesLeft:
+            "{"
+        case .parenthesesRight:
+            "o"
+        case .bracketLeft:
+            "``("
+        case .bracketRight:
+            "``)"
+        case .braceLeft:
+            ".("
+        case .braceRight:
+            ".)"
+        }
+    }
+
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            brailleAscii
+        }
+
+    }
+
     var supposedToBeAtStart: Bool {
         switch self {
         case .singleQuotationMarkLeft:

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
@@ -25,9 +25,9 @@ import Foundation
 
 /// Represents the full-width punctuations
 public enum FullWidthPunctuation: String, CaseIterable {
-    init?(braille: String) {
+    init?(braille: String, type: BrailleType) {
         let aCase = FullWidthPunctuation.allCases.first { aCase in
-            aCase.braille == braille
+            aCase.getBraille(by: type) == braille
         }
         if let aCase {
             self = aCase
@@ -36,125 +36,111 @@ public enum FullWidthPunctuation: String, CaseIterable {
         }
     }
 
-    var bopomofo: String {
-        return rawValue
-    }
-
-    var braille: String {
-        switch self {
-        case .period:
-            "⠤"
-        case .dot:
-            "⠤"
-        case .comma:
-            "⠆"
-        case .semicolon:
-            "⠰"
-        case .ideographicComma:
-            "⠠"
-        case .questionMark:
-            "⠕"
-        case .exclamationMark:
-            "⠇"
-        case .colon:
-            "⠒⠒"
-        case .personNameMark:
-            "⠰⠰"
-        case .slash:
-            "⠐⠂"
-        case .bookNameMark:
-            "⠠⠤"
-        case .ellipsis:
-            "⠐⠐⠐"
-        case .referenceMark:
-            "⠈⠼"
-        case .doubleRing:
-            "⠪⠕"
-        case .singleQuotationMarkLeft:
-            "⠰⠤"
-        case .singleQuotationMarkRight:
-            "⠤⠆"
-        case .doubleQuotationMarkLeft:
-            "⠰⠤⠰⠤"
-        case .doubleQuotationMarkRight:
-            "⠤⠆⠤⠆"
-        case .parenthesesLeft:
-            "⠪"
-        case .parenthesesRight:
-            "⠕"
-        case .bracketLeft:
-            "⠯"
-        case .bracketRight:
-            "⠽"
-        case .braceLeft:
-            "⠦"
-        case .braceRight:
-            "⠴"
-        }
-    }
-
-    /// Maps each full-width punctuation to its braille dots and an ASCII sequence used for input.
-    var brailleAscii: String {
-        switch self {
-        case .period:
-            "-"
-        case .dot:
-            "."
-        case .comma:
-            "2"
-        case .semicolon:
-            ";"
-        case .ideographicComma:
-            ","
-        case .questionMark:
-            "?"
-        case .exclamationMark:
-            "l"
-        case .colon:
-            "33"
-        case .personNameMark:
-            "|"
-        case .slash:
-            "-"
-        case .bookNameMark:
-            "~"
-        case .ellipsis:
-            "'''"
-        case .referenceMark:
-            "`#"
-        case .doubleRing:
-            "{o"
-        case .singleQuotationMarkLeft:
-            ";-"
-        case .singleQuotationMarkRight:
-            "-2"
-        case .doubleQuotationMarkLeft:
-            "88"
-        case .doubleQuotationMarkRight:
-            "00"
-        case .parenthesesLeft:
-            "{"
-        case .parenthesesRight:
-            "o"
-        case .bracketLeft:
-            "``("
-        case .bracketRight:
-            "``)"
-        case .braceLeft:
-            ".("
-        case .braceRight:
-            ".)"
-        }
-    }
-
     func getBraille(by type: BrailleType) -> String {
         switch type {
         case .unicode:
-            braille
+            switch self {
+            case .period:
+                "⠤"
+            case .dot:
+                "⠤"
+            case .comma:
+                "⠆"
+            case .semicolon:
+                "⠰"
+            case .ideographicComma:
+                "⠠"
+            case .questionMark:
+                "⠕"
+            case .exclamationMark:
+                "⠇"
+            case .colon:
+                "⠒⠒"
+            case .personNameMark:
+                "⠰⠰"
+            case .slash:
+                "⠐⠂"
+            case .bookNameMark:
+                "⠠⠤"
+            case .ellipsis:
+                "⠐⠐⠐"
+            case .referenceMark:
+                "⠈⠼"
+            case .doubleRing:
+                "⠪⠕"
+            case .singleQuotationMarkLeft:
+                "⠰⠤"
+            case .singleQuotationMarkRight:
+                "⠤⠆"
+            case .doubleQuotationMarkLeft:
+                "⠰⠤⠰⠤"
+            case .doubleQuotationMarkRight:
+                "⠤⠆⠤⠆"
+            case .parenthesesLeft:
+                "⠪"
+            case .parenthesesRight:
+                "⠕"
+            case .bracketLeft:
+                "⠯"
+            case .bracketRight:
+                "⠽"
+            case .braceLeft:
+                "⠦"
+            case .braceRight:
+                "⠴"
+            }
         case .ascii:
-            brailleAscii
+            switch self {
+            case .period:
+                "-"
+            case .dot:
+                "."
+            case .comma:
+                "2"
+            case .semicolon:
+                ";"
+            case .ideographicComma:
+                ","
+            case .questionMark:
+                "?"
+            case .exclamationMark:
+                "l"
+            case .colon:
+                "33"
+            case .personNameMark:
+                "|"
+            case .slash:
+                "-"
+            case .bookNameMark:
+                "~"
+            case .ellipsis:
+                "'''"
+            case .referenceMark:
+                "`#"
+            case .doubleRing:
+                "{o"
+            case .singleQuotationMarkLeft:
+                ";-"
+            case .singleQuotationMarkRight:
+                "-2"
+            case .doubleQuotationMarkLeft:
+                "88"
+            case .doubleQuotationMarkRight:
+                "00"
+            case .parenthesesLeft:
+                "{"
+            case .parenthesesRight:
+                "o"
+            case .bracketLeft:
+                "``("
+            case .bracketRight:
+                "``)"
+            case .braceLeft:
+                ".("
+            case .braceRight:
+                ".)"
+            }
         }
-
     }
 
     var supposedToBeAtStart: Bool {

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/FullWidthPunctuation.swift
@@ -110,7 +110,7 @@ public enum FullWidthPunctuation: String, CaseIterable {
             case .personNameMark:
                 "|"
             case .slash:
-                "-"
+                "---"
             case .bookNameMark:
                 "~"
             case .ellipsis:

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/HalfWidthPunctuation.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/HalfWidthPunctuation.swift
@@ -82,6 +82,20 @@ public enum HalfWidthPunctuation: String, CaseIterable {
         }
     }
 
+    var brailleAscii: String {
+        rawValue
+    }
+
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            rawValue
+        }
+
+    }
+
     case period = "."
     case comma = ","
     case semicolon = ";"

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/HalfWidthPunctuation.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/HalfWidthPunctuation.swift
@@ -26,9 +26,9 @@ import Foundation
 /// Represents the half-width punctuations
 public enum HalfWidthPunctuation: String, CaseIterable {
 
-    init?(braille: String) {
+    init?(braille: String, type: BrailleType) {
         let aCase = HalfWidthPunctuation.allCases.first { aCase in
-            aCase.braille == braille
+            aCase.getBraille(by: type) == braille
         }
         if let aCase {
             self = aCase
@@ -37,63 +37,50 @@ public enum HalfWidthPunctuation: String, CaseIterable {
         }
     }
 
-    var bopomofo: String {
-        return rawValue
-    }
-
-    var braille: String {
-        switch self {
-        case .period:
-            "⠲"
-        case .comma:
-            "⠂"
-        case .semicolon:
-            "⠒"
-        case .dash:
-            "⠄"
-        case .questionMark:
-            "⠦"
-        case .exclamationMark:
-            "⠖"
-        case .colon:
-            "⠒"
-        case .slash:
-            "⠤"
-        case .star:
-            "⠔⠔"
-        case .dotDotDot:
-            "⠄⠄⠄"
-        case .singleQuotationMarkLeft:
-            "⠠⠦"
-        case .singleQuotationMarkRight:
-            "⠴⠄"
-        case .doubleQuotationMarkLeft:
-            "⠦"
-        case .doubleQuotationMarkRight:
-            "⠴"
-        case .parenthesesLeft:
-            "⠶"
-        case .parenthesesRight:
-            "⠶"
-        case .bracketLeft:
-            "⠠⠶"
-        case .bracketRight:
-            "⠶⠄"
-        }
-    }
-
-    var brailleAscii: String {
-        rawValue
-    }
-
     func getBraille(by type: BrailleType) -> String {
         switch type {
         case .unicode:
-            braille
+            switch self {
+            case .period:
+                "⠲"
+            case .comma:
+                "⠂"
+            case .semicolon:
+                "⠒"
+            case .dash:
+                "⠄"
+            case .questionMark:
+                "⠦"
+            case .exclamationMark:
+                "⠖"
+            case .colon:
+                "⠒"
+            case .slash:
+                "⠤"
+            case .star:
+                "⠔⠔"
+            case .dotDotDot:
+                "⠄⠄⠄"
+            case .singleQuotationMarkLeft:
+                "⠠⠦"
+            case .singleQuotationMarkRight:
+                "⠴⠄"
+            case .doubleQuotationMarkLeft:
+                "⠦"
+            case .doubleQuotationMarkRight:
+                "⠴"
+            case .parenthesesLeft:
+                "⠶"
+            case .parenthesesRight:
+                "⠶"
+            case .bracketLeft:
+                "⠠⠶"
+            case .bracketRight:
+                "⠶⠄"
+            }
         case .ascii:
             rawValue
         }
-
     }
 
     case period = "."

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Letter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Letter.swift
@@ -57,7 +57,7 @@ public enum Letter: String, CaseIterable {
 
     init?(braille: String) {
         let aCase = Letter.allCases.first { aCase in
-            aCase.braille == braille
+            aCase.getBraille(by: .unicode) == braille
         }
         if let aCase {
             self = aCase
@@ -66,28 +66,12 @@ public enum Letter: String, CaseIterable {
         }
     }
 
-    var bopomofo: String {
-        return rawValue
-    }
-
-    var braille: String {
-        Letter.bpmfBrailleMap[self]!.0
-    }
-
-    var bralleAscii: String {
-        return rawValue
-    }
-
-    var brailleCode: String {
-        Letter.bpmfBrailleMap[self]!.1
-    }
-
     func getBraille(by type: BrailleType) -> String {
         switch type {
         case .unicode:
-            braille
+            Letter.bpmfBrailleMap[self]!.0
         case .ascii:
-            bralleAscii
+            rawValue
         }
     }
 

--- a/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Letter.swift
+++ b/Packages/BopomofoBraille/Sources/BopomofoBraille/Tokens/Letter.swift
@@ -74,8 +74,21 @@ public enum Letter: String, CaseIterable {
         Letter.bpmfBrailleMap[self]!.0
     }
 
+    var bralleAscii: String {
+        return rawValue
+    }
+
     var brailleCode: String {
         Letter.bpmfBrailleMap[self]!.1
+    }
+
+    func getBraille(by type: BrailleType) -> String {
+        switch type {
+        case .unicode:
+            braille
+        case .ascii:
+            bralleAscii
+        }
     }
 
     case a = "a"

--- a/Packages/BopomofoBraille/Tests/BopomofoBrailleTests/BopomofoBrailleTests.swift
+++ b/Packages/BopomofoBraille/Tests/BopomofoBrailleTests/BopomofoBrailleTests.swift
@@ -117,4 +117,20 @@ final class BopomofoBrailleTests {
         #expect(output == "ABcd")
     }
 
+    @Test(
+        "Test ASCII Braille yv combinations",
+        arguments: [
+            ("ㄩㄝˋ", "8\""),
+            ("ㄩㄢˋ", "~\""),
+            ("ㄩㄣˋ", "4\""),
+            ("ㄩㄥˋ", "6\""),
+        ])
+    func testAsciiYvCombinations(input: String, expected: String) {
+        let braille = BopomofoBrailleConverter.convert(bopomofo: input, type: .ascii)
+        #expect(braille == expected)
+
+        let output = BopomofoBrailleConverter.convert(braille: expected, type: .ascii)
+        #expect(output == input)
+    }
+
 }

--- a/Packages/BopomofoBraille/Tests/BopomofoBrailleTests/BopomofoBrailleTests.swift
+++ b/Packages/BopomofoBraille/Tests/BopomofoBrailleTests/BopomofoBrailleTests.swift
@@ -87,4 +87,34 @@ final class BopomofoBrailleTests {
         }
     }
 
+    @Test(
+        "Test ASCII Braille conversion",
+        arguments: [
+            ("k*\"", "ㄐㄧˋ"),
+            ("c!a", "ㄌㄜ˙"),
+            ("/`", "ㄨˇ"),
+        ])
+    func testAsciiBrailleReversed(input: String, expected: String) {
+        let output = BopomofoBrailleConverter.convert(braille: input, type: .ascii)
+        #expect(output == expected)
+    }
+
+    @Test("Test ASCII Braille digit sign")
+    func testAsciiDigitSign() {
+        let braille = BopomofoBrailleConverter.convert(bopomofo: "123", type: .ascii)
+        #expect(braille == "#123")
+
+        let output = BopomofoBrailleConverter.convert(braille: "#123", type: .ascii)
+        #expect(output == "123")
+    }
+
+    @Test("Test ASCII Braille uppercase sign")
+    func testAsciiUppercaseSign() {
+        let braille = BopomofoBrailleConverter.convert(bopomofo: "ABcd", type: .ascii)
+        #expect(braille == ",a,bcd")
+
+        let output = BopomofoBrailleConverter.convert(braille: ",a,bcd", type: .ascii)
+        #expect(output == "ABcd")
+    }
+
 }

--- a/Source/Base.lproj/MainMenu.xib
+++ b/Source/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="401" y="295" width="475" height="567"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1049"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1050"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="475" height="567"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -547,7 +547,8 @@
                                 <menuItem title="Off" state="on" id="bAf-tJ-tnK"/>
                                 <menuItem title="Bopomofo Readings" tag="1" id="X6F-Wk-ZkH"/>
                                 <menuItem title="HTML Ruby" tag="2" id="ZwE-fD-480"/>
-                                <menuItem title="Taiwanese Braille" tag="3" id="JEj-fm-gxW"/>
+                                <menuItem title="Taiwanese Braille Unicode" tag="3" id="JEj-fm-gxW"/>
+                                <menuItem title="Taiwanese Braille ASCII" tag="5" id="9kV-LJ-jbA"/>
                                 <menuItem title="Hanyu Pinyin" tag="4" id="sV1-fA-YT0"/>
                             </items>
                         </menu>
@@ -635,11 +636,11 @@
             <point key="canvasLocation" x="131" y="-92"/>
         </view>
         <customView id="7EY-3X-sVm">
-            <rect key="frame" x="0.0" y="0.0" width="477" height="329"/>
+            <rect key="frame" x="0.0" y="0.0" width="478" height="329"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="jIf-hP-5m5">
-                    <rect key="frame" x="18" y="293" width="137" height="16"/>
+                    <rect key="frame" x="19" y="293" width="137" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="User Phrase Location:" id="Sc6-Rd-pOy">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -647,7 +648,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z8D-qk-sAN">
-                    <rect key="frame" x="20" y="252" width="95" height="24"/>
+                    <rect key="frame" x="21" y="252" width="95" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Default" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="avu-Uo-JGI" id="Kln-Ca-WBd">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -667,7 +668,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VEv-3b-PV4">
-                    <rect key="frame" x="127" y="252" width="290" height="25"/>
+                    <rect key="frame" x="128" y="252" width="290" height="25"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="6kS-fE-Kz7">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -679,7 +680,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="svr-IJ-6mz">
-                    <rect key="frame" x="20" y="170" width="439" height="28"/>
+                    <rect key="frame" x="20" y="170" width="440" height="28"/>
                     <textFieldCell key="cell" id="Vz3-KS-1rk">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">You can specify the folder to store user phrases to the folder of Google Drive, DropBox and so on so you can backup the phrases.</string>
@@ -688,7 +689,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dY1-Wz-mrw">
-                    <rect key="frame" x="425" y="252" width="32" height="24"/>
+                    <rect key="frame" x="426" y="252" width="32" height="24"/>
                     <buttonCell key="cell" type="bevel" bezelStyle="rounded" image="NSFolder" imagePosition="overlaps" alignment="center" imageScaling="proportionallyDown" inset="2" id="cyL-Sf-xhj">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -699,7 +700,7 @@
                     </connections>
                 </button>
                 <button horizontalHuggingPriority="249" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="OKJ-84-kIv">
-                    <rect key="frame" x="127" y="227" width="330" height="21"/>
+                    <rect key="frame" x="128" y="227" width="330" height="21"/>
                     <buttonCell key="cell" type="bevel" title="Button" bezelStyle="rounded" imagePosition="overlaps" alignment="left" controlSize="small" imageScaling="proportionallyDown" inset="2" id="wCH-YR-bl5">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystem"/>
@@ -709,10 +710,10 @@
                     </connections>
                 </button>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="5ce-rm-tsn">
-                    <rect key="frame" x="20" y="147" width="433" height="5"/>
+                    <rect key="frame" x="21" y="147" width="433" height="5"/>
                 </box>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="133" translatesAutoresizingMaskIntoConstraints="NO" id="HkV-PJ-yTW">
-                    <rect key="frame" x="18" y="113" width="437" height="16"/>
+                    <rect key="frame" x="19" y="113" width="437" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="After Adding a New Phrase:" id="wGR-0A-cqv">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -720,7 +721,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="LVc-PG-N32">
-                    <rect key="frame" x="20" y="83" width="249" height="16"/>
+                    <rect key="frame" x="21" y="83" width="249" height="16"/>
                     <buttonCell key="cell" type="check" title="Run a shell script" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="DaH-1b-AEw">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -730,7 +731,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FMN-EJ-wzd">
-                    <rect key="frame" x="62" y="57" width="391" height="24"/>
+                    <rect key="frame" x="62" y="57" width="392" height="24"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="Sbq-JE-A4U">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -749,7 +750,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="435" translatesAutoresizingMaskIntoConstraints="NO" id="0R5-DI-uXK">
-                    <rect key="frame" x="20" y="20" width="439" height="28"/>
+                    <rect key="frame" x="20" y="20" width="440" height="28"/>
                     <textFieldCell key="cell" title="You can run a script to use git to backup your phrases. The script will run in the folder of your user phrases folder." id="byk-Br-x2Z">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -24,6 +24,7 @@
 #include "McBopomofoLM.h"
 
 #include <algorithm>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <string>
@@ -361,3 +362,4 @@ void McBopomofoLM::loadPhraseReplacementMap(const char* data, size_t length) {
 }
 
 }  // namespace McBopomofo
+

--- a/Source/Engine/McBopomofoLM.cpp
+++ b/Source/Engine/McBopomofoLM.cpp
@@ -24,7 +24,6 @@
 #include "McBopomofoLM.h"
 
 #include <algorithm>
-#include <iterator>
 #include <limits>
 #include <memory>
 #include <string>

--- a/Source/Engine/VariantAnnotator.cpp
+++ b/Source/Engine/VariantAnnotator.cpp
@@ -103,26 +103,36 @@ VariantAnnotator::Result VariantAnnotator::annotateSingleCharacter(
   if (!variant.empty()) {
     // If variant != value, a variant selector must have been used.
     bool selectorUsed = variant != value;
-    return Result{.annotatedString = variant,
-                  .hasVariantSelectors = selectorUsed};
+    Result r;
+    r.annotatedString = variant;
+    r.hasVariantSelectors = selectorUsed;
+    return r;
   }
 
   // Now try the fallback.
   variant = findUnannotatedVariant(value);
   if (variant.empty() || variant == reading) {
-    return Result{.annotatedString = value};
+    Result r;
+    r.annotatedString = value;
+    return r;
   }
 
   std::string puaBlock = findCombinedPUABopomofoReading(reading);
   if (!puaBlock.empty()) {
     // The string is the value + Variant 0 selector + the Bopomofo block in PUA.
-    return Result{.annotatedString = variant + puaBlock,
-                  .hasVariantSelectors = true,
-                  .hasPUACodePoints = true};
+    Result r;
+    r.annotatedString = variant + puaBlock;
+    r.hasVariantSelectors = true;
+    r.hasPUACodePoints = true;
+    return r;
   }
 
-  // Only the unannotated Variant 0 is found.
-  return Result{.annotatedString = variant, .hasVariantSelectors = true};
+  {
+    Result r;
+    r.annotatedString = variant;
+    r.hasVariantSelectors = true;
+    return r;
+  }
 }
 
 VariantAnnotator::CombinedResult VariantAnnotator::annotate(
@@ -189,3 +199,4 @@ void VariantAnnotator::closeMemoryMapFiles() {
 }
 
 }  // namespace McBopomofo
+

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -414,7 +414,9 @@ std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
   for (size_t i = 1, len = spans_[loc].maxLength(); i <= len; ++i) {
     NodePtr ptr = spans_[loc].nodeOf(i);
     if (ptr != nullptr) {
-      ReadingGrid::NodeInSpan element{.node = std::move(ptr), .spanIndex = loc};
+      ReadingGrid::NodeInSpan element;
+      element.node = std::move(ptr);
+      element.spanIndex = loc;
       results.emplace_back(std::move(element));
     }
   }
@@ -426,7 +428,9 @@ std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
     for (size_t j = beginLen; j <= endLen; ++j) {
       NodePtr ptr = spans_[i].nodeOf(j);
       if (ptr != nullptr) {
-        ReadingGrid::NodeInSpan element{.node = std::move(ptr), .spanIndex = i};
+        ReadingGrid::NodeInSpan element;
+        element.node = std::move(ptr);
+        element.spanIndex = i;
         results.emplace_back(std::move(element));
       }
     }

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -686,8 +686,11 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             case ControlEnterOutputHtmlRuby:
                 string = [self _currentHtmlRuby];
                 break;
-            case ControlEnterOutputBraille:
-                string = [self _currentBraille];
+            case ControlEnterOutputBrailleUnicode:
+                string = [self _currentBraille:BrailleTypeUnicode];
+                break;
+            case ControlEnterOutputBrailleAscii:
+                string = [self _currentBraille:BrailleTypeAscii];
                 break;
             case ControlEnterOutputHanyuPinyin:
                 string = [self _currentHanyuPinyin];
@@ -1160,7 +1163,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     return [NSString stringWithUTF8String:composed.c_str()];
 }
 
-- (NSString *)_currentBraille
+- (NSString *)_currentBraille:(BrailleType)type
 {
     NSMutableString *composingBuffer = [[NSMutableString alloc] init];
     for (const auto& node : _latestWalk.nodes) {
@@ -1168,7 +1171,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         std::string reading = node->reading();
         if (reading[0] == '_') {
             NSString *punctuation = [[NSString alloc] initWithUTF8String:value.c_str()];
-            NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:punctuation];
+            NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:punctuation type: type];
             [composingBuffer appendString:converted];
         } else {
             std::string delimiter = "-";
@@ -1177,12 +1180,12 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             while ((pos = reading.find(delimiter)) != std::string::npos) {
                 token = reading.substr(0, pos);
                 NSString *tokenString = [[NSString alloc] initWithUTF8String:token.c_str()];
-                NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:tokenString];
+                NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:tokenString type: type];
                 [composingBuffer appendString:converted];
                 reading.erase(0, pos + delimiter.length());
             }
             NSString *tokenString = [[NSString alloc] initWithUTF8String:reading.c_str()];
-            NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:tokenString];
+            NSString *converted = [BopomofoBrailleConverter convertFromBopomofo:tokenString type: type];
             [composingBuffer appendString:converted];
         }
     }

--- a/Source/McBopomofo-Info.plist
+++ b/Source/McBopomofo-Info.plist
@@ -215,10 +215,10 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Convert Text to Taiwanese Braille</string>
+				<string>Convert Text to Unicode Taiwanese Braille</string>
 			</dict>
 			<key>NSMessage</key>
-			<string>convertToBraille</string>
+			<string>convertToUnicodeBraille</string>
 			<key>NSRequiredContext</key>
 			<dict/>
 			<key>NSReturnTypes</key>
@@ -236,10 +236,52 @@
 			<key>NSMenuItem</key>
 			<dict>
 				<key>default</key>
-				<string>Convert Taiwanese Braille to Text</string>
+				<string>Convert Text to ASCII Taiwanese Braille</string>
 			</dict>
 			<key>NSMessage</key>
-			<string>convertBrailleToChineseText</string>
+			<string>convertToASCIIBraille</string>
+			<key>NSRequiredContext</key>
+			<dict/>
+			<key>NSReturnTypes</key>
+			<array>
+				<string>NSPasteboardTypeString</string>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSPasteboardTypeString</string>
+				<string>NSStringPboardType</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Convert Unicode Taiwanese Braille to Text</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>convertUnicodeBrailleToChineseText</string>
+			<key>NSRequiredContext</key>
+			<dict/>
+			<key>NSReturnTypes</key>
+			<array>
+				<string>NSPasteboardTypeString</string>
+				<string>NSStringPboardType</string>
+			</array>
+			<key>NSSendTypes</key>
+			<array>
+				<string>NSPasteboardTypeString</string>
+				<string>NSStringPboardType</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Convert ASCII Taiwanese Braille to Text</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>convertASCIIBrailleToChineseText</string>
 			<key>NSRequiredContext</key>
 			<dict/>
 			<key>NSReturnTypes</key>

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -460,8 +460,9 @@ extension Preferences {
     case off = 0
     case bpmfReading = 1
     case htmlRuby = 2
-    case braille = 3
+    case brailleUnicode = 3
     case hanyuPinyin = 4
+    case brailleAscii = 5
 }
 
 extension ControlEnterOutput {
@@ -470,7 +471,8 @@ extension ControlEnterOutput {
         case .off: "Off"
         case .bpmfReading: "Bopomofo Reading"
         case .htmlRuby: "HTML Ruby Text"
-        case .braille: "Taiwan Braille"
+        case .brailleUnicode: "Taiwan Braille (Unicode)"
+        case .brailleAscii: "Taiwan Braille (Ascii)"
         case .hanyuPinyin: "Hanyu Pinyin"
         }
     }

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -471,8 +471,8 @@ extension ControlEnterOutput {
         case .off: "Off"
         case .bpmfReading: "Bopomofo Reading"
         case .htmlRuby: "HTML Ruby Text"
-        case .brailleUnicode: "Taiwan Braille (Unicode)"
-        case .brailleAscii: "Taiwan Braille (Ascii)"
+        case .brailleUnicode: "Taiwanese Braille (Unicode)"
+        case .brailleAscii: "Taiwanese Braille (ASCII)"
         case .hanyuPinyin: "Hanyu Pinyin"
         }
     }

--- a/Source/ServiceProvider.swift
+++ b/Source/ServiceProvider.swift
@@ -389,29 +389,48 @@ extension ServiceProvider {
 
     // MARK: - Braille
 
-    func convertToBraille(string: String) -> String {
+    private func convertToBraille(string: String, type: BrailleType) -> String {
         process(string: string, addSpace: true, convertEachCharacter: false) {
-            BopomofoBrailleConverter.convert(bopomofo: $1)
+            BopomofoBrailleConverter.convert(bopomofo: $1, type: type)
         } readingNotFoundCallback: {
-            BopomofoBrailleConverter.convert(bopomofo: $0)
+            BopomofoBrailleConverter.convert(bopomofo: $0, type: type)
         }
     }
 
-    /// Converts selected text to Taiwanese Braille.
-    @objc func convertToBraille(
+    func convertToUnicodeBraille(string: String) -> String {
+        convertToBraille(string: string, type: .unicode)
+    }
+
+    /// Converts selected text to Unicode Taiwanese Braille.
+    @objc func convertToUnicodeBraille(
         _ pasteboard: NSPasteboard, userData _: String?, error _: NSErrorPointer
     ) {
         transformPasteboardString(pasteboard, maximumLength: kMaxLength) { string in
             string.components(separatedBy: "\n").map { input in
-                convertToBraille(string: input)
+                convertToUnicodeBraille(string: input)
             }.joined(separator: "\n")
         }
     }
 
-    func convertBrailleToChineseText(string: String) -> String {
+    func convertToASCIIBraille(string: String) -> String {
+        convertToBraille(string: string, type: .ascii)
+    }
+
+    /// Converts selected text to ASCII Taiwanese Braille.
+    @objc func convertToASCIIBraille(
+        _ pasteboard: NSPasteboard, userData _: String?, error _: NSErrorPointer
+    ) {
+        transformPasteboardString(pasteboard, maximumLength: kMaxLength) { string in
+            string.components(separatedBy: "\n").map { input in
+                convertToASCIIBraille(string: input)
+            }.joined(separator: "\n")
+        }
+    }
+
+    private func convertBrailleToChineseText(string: String, type: BrailleType) -> String {
         delegate?.serviceProvider(didRequestReset: self)
         var output = ""
-        let tokens = BopomofoBrailleConverter.convert(brailleToTokens: string)
+        let tokens = BopomofoBrailleConverter.convert(brailleToTokens: string, type: type)
 
         for token in tokens {
             switch token {
@@ -432,12 +451,29 @@ extension ServiceProvider {
         return output
     }
 
-    /// Converts the selected Taiwanese Braille to Chinese text.
-    @objc func convertBrailleToChineseText(
+    func convertUnicodeBrailleToChineseText(string: String) -> String {
+        convertBrailleToChineseText(string: string, type: .unicode)
+    }
+
+    /// Converts the selected Unicode Taiwanese Braille to Chinese text.
+    @objc func convertUnicodeBrailleToChineseText(
         _ pasteboard: NSPasteboard, userData _: String?, error _: NSErrorPointer
     ) {
         transformPasteboardString(pasteboard, skipIfOutputIsEmpty: true) { string in
-            convertBrailleToChineseText(string: string)
+            convertUnicodeBrailleToChineseText(string: string)
+        }
+    }
+
+    func convertASCIIBrailleToChineseText(string: String) -> String {
+        convertBrailleToChineseText(string: string, type: .ascii)
+    }
+
+    /// Converts the selected ASCII Taiwanese Braille to Chinese text.
+    @objc func convertASCIIBrailleToChineseText(
+        _ pasteboard: NSPasteboard, userData _: String?, error _: NSErrorPointer
+    ) {
+        transformPasteboardString(pasteboard, skipIfOutputIsEmpty: true) { string in
+            convertASCIIBrailleToChineseText(string: string)
         }
     }
 

--- a/Source/en.lproj/ServicesMenu.strings
+++ b/Source/en.lproj/ServicesMenu.strings
@@ -3,5 +3,7 @@
 "Add Hanyu Pinyin to Text" = "Add Hanyu Pinyin to Text";
 "Convert Text to Bopomofo Readings" = "Convert Text to Bopomofo Readings";
 "Convert Text to Hanyu Pinyin" = "Convert Text to Hanyu Pinyin";
-"Convert Text to Taiwanese Braille" = "Convert Text to Taiwanese Braille";
-"Convert Taiwanese Braille to Text" = "Convert Taiwanese Braille to Text";
+"Convert Text to Unicode Taiwanese Braille" = "Convert Text to Unicode Taiwanese Braille";
+"Convert Text to ASCII Taiwanese Braille" = "Convert Text to ASCII Taiwanese Braille";
+"Convert Unicode Taiwanese Braille to Text" = "Convert Unicode Taiwanese Braille to Text";
+"Convert ASCII Taiwanese Braille to Text" = "Convert ASCII Taiwanese Braille to Text";

--- a/Source/zh-Hant.lproj/ServicesMenu.strings
+++ b/Source/zh-Hant.lproj/ServicesMenu.strings
@@ -3,5 +3,7 @@
 "Add Hanyu Pinyin to Text" = "將選定的文字加上漢語拼音";
 "Convert Text to Bopomofo Readings" = "將中文轉換成注音";
 "Convert Text to Hanyu Pinyin" = "將中文轉換成漢語拼音";
-"Convert Text to Taiwanese Braille" = "將中文轉換成台灣點字";
-"Convert Taiwanese Braille to Text" = "將台灣點字轉換成中文";
+"Convert Text to Unicode Taiwanese Braille" = "將中文轉換成 Unicode 台灣點字";
+"Convert Text to ASCII Taiwanese Braille" = "將中文轉換成 ASCII 台灣點字";
+"Convert Unicode Taiwanese Braille to Text" = "將 Unicode 台灣點字轉換成中文";
+"Convert ASCII Taiwanese Braille to Text" = "將 ASCII 台灣點字轉換成中文";

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="489" y="334" width="433" height="575"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1049"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1050"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="433" height="575"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -505,7 +505,8 @@
                                 <menuItem title="關閉" state="on" id="4VD-Kh-SxN"/>
                                 <menuItem title="注音符號" tag="1" id="eyd-n5-aYf"/>
                                 <menuItem title="HTML旁注標記" tag="2" id="fS8-3m-elO"/>
-                                <menuItem title="台灣點字" tag="3" id="xYc-er-OPo"/>
+                                <menuItem title="台灣點字 (Unicode)" tag="3" id="xYc-er-OPo"/>
+                                <menuItem title="台灣點字 (ASCII)" tag="5" id="sBI-Yu-2NO"/>
                                 <menuItem title="漢語拼音" tag="4" id="Yv7-rt-txE"/>
                             </items>
                         </menu>


### PR DESCRIPTION
The PR refactors the Taiwanese Braille module to support Braille code as ASCII code. To view the result, it requires fonts like https://www.tsbvi.edu/campus-resources/accessibility/braille-and-asl-fonts

See https://en.wikipedia.org/wiki/Braille_ASCII

The PR also upgrade to Xcode 26.4 and LLVM 21 and fix several syntax error as well.

AI generated contents are as below:

----

This pull request adds comprehensive support for both Unicode and ASCII Taiwanese Braille formats throughout the codebase, including the core conversion logic, tests, and documentation. It introduces new functions and parameters to distinguish between the two formats and expands test coverage to ensure correctness for both. The documentation is also updated to clarify the dual-format support.

**Braille Format Support Enhancements**

* The `BopomofoBrailleConverter` in `Converter.swift` now supports both Unicode and ASCII Taiwanese Braille formats. New helper functions and parameters (`BrailleType`) are introduced to select the format, and all relevant conversion logic is updated to handle both. [[1]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaR29-R64) [[2]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL40-R77) [[3]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL72-R108) [[4]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL83-R119) [[5]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL102-R147) [[6]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL127-R166) [[7]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL152-R191) [[8]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL166-R207) [[9]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL182-R224) [[10]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL196-R235) [[11]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL215-R257) [[12]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL235-R277) [[13]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL270-R311) [[14]](diffhunk://#diff-6ab387284cfd8dc527a8c8b4d23a1ac6e0ab8af045bdc3e9e381be91a57c94aaL298-R345)

**Test Suite Expansion**

* Test cases in `ServiceProviderTests.swift` are expanded to cover both Unicode and ASCII Braille conversions, including round-trip and service/pasteboard scenarios. New test functions and updated naming clarify the format being tested. [[1]](diffhunk://#diff-51d79a3ddcd82836e8c10cfe2dd79bbde7a7baf6b187e4a75b1f8edae73aba5dL138-R152) [[2]](diffhunk://#diff-51d79a3ddcd82836e8c10cfe2dd79bbde7a7baf6b187e4a75b1f8edae73aba5dL166-R167) [[3]](diffhunk://#diff-51d79a3ddcd82836e8c10cfe2dd79bbde7a7baf6b187e4a75b1f8edae73aba5dL176-R253) [[4]](diffhunk://#diff-51d79a3ddcd82836e8c10cfe2dd79bbde7a7baf6b187e4a75b1f8edae73aba5dL230-R284) [[5]](diffhunk://#diff-51d79a3ddcd82836e8c10cfe2dd79bbde7a7baf6b187e4a75b1f8edae73aba5dL240-R310)
* The test for Ctrl+Enter output in `KeyHandlerBopomofoTests.swift` is updated to use `.brailleUnicode` for clarity and correctness.

**Documentation Updates**

* The project overview in `AGENTS.md` and `.github/copilot-instructions.md` is updated to state explicit support for both Unicode and ASCII Taiwanese Braille formats. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L7-R7) [[2]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R32)
* The description of the `BopomofoBraille` package in `AGENTS.md` is clarified to specify conversion support for both formats.

These changes ensure the app and its libraries robustly support both major Taiwanese Braille encoding standards, with clear documentation and thorough test coverage.

