### PR TITLE
Further fine-tune Gemini code review settings

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,11 +1,13 @@
 have_fun: false
 code_review:
   disable: false
-  comment_severity_threshold: HIGH
-  max_review_comments: -1
+  comment_severity_threshold: CRITICAL
+  max_review_comments: 5
   pull_request_opened:
     help: false
     summary: false
     code_review: true
     include_drafts: false
-ignore_patterns: []
+ignore_patterns:
+  - Source/Data/*.txt
+  - Source/Data/*.list


### PR DESCRIPTION
* Ignore database source since Gemini only tells us "unable to generate a review [...] due to file types involved not being currently supported."
* Only generate a maximum of 5 critical issues to focus.