### PR TITLE
Fix the key to cancel the punctuation list.

### DIFF
--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -3003,7 +3003,10 @@ extension KeyHandlerBopomofoTests {
             state = newState
         } errorCallback: {
         }
-        XCTAssertTrue(state is InputState.Empty, "\(state)")
+        XCTAssertTrue(
+            state is InputState.EmptyIgnoringPreviousState,
+            "\(state)"
+        )
     }
 
     func testBacktickThenBackspace() {
@@ -3027,7 +3030,10 @@ extension KeyHandlerBopomofoTests {
             state = newState
         } errorCallback: {
         }
-        XCTAssertTrue(state is InputState.Empty, "\(state)")
+        XCTAssertTrue(
+            state is InputState.EmptyIgnoringPreviousState,
+            "\(state)"
+        )
     }
 
     func testBacktickThenBacktick() {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1651,6 +1651,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             }
 
             if (_grid->length() == 0) {
+                [self clear];
                 InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
                 stateCallback(empty);
             } else {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1649,8 +1649,9 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             } else {
                 _grid->deleteReadingBeforeCursor();
             }
+
             if (_grid->length() == 0) {
-                InputStateEmpty *empty = [[InputStateEmpty alloc] init];
+                InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
                 stateCallback(empty);
             } else {
                 [self _walk];


### PR DESCRIPTION
When a user press ESC key while showing the punctuation list, it is expected that the inserted space should disappear. Currently the space would be inserted, and the PR fixes the issue.