### PR TITLE
Fix nodiscard warning in variant annotator test

### DIFF
--- a/Source/Engine/VariantAnnotatorTest.cpp
+++ b/Source/Engine/VariantAnnotatorTest.cpp
@@ -137,9 +137,10 @@ TEST(VariantAnnotatorTest, AnnotateCharactersWithMismatchedArguments) {
   GTEST_SKIP();
 #endif
   auto annotator = CreateLoadedAnnotator();
-  EXPECT_DEATH((annotator->annotate({"個", "人", "一", "個", "人", "一", "個"},
-                                    {"ㄍㄜˋ", "ㄖㄣˊ"})),
-               "values.+readings");
+  EXPECT_DEATH(
+      (static_cast<void>(annotator->annotate(
+          {"個", "人", "一", "個", "人", "一", "個"}, {"ㄍㄜˋ", "ㄖㄣˊ"}))),
+      "values.+readings");
 }
 
 TEST(VariantAnnotatorTest, AnnotateCharactersWithAllDefaults) {


### PR DESCRIPTION
This PR updates the `VariantAnnotatorTest` death test to explicitly discard the `annotate()` return value with `static_cast<void>`. The test only verifies the assertion failure for mismatched argument counts, so the returned `VariantAnnotator::CombinedResult` is intentionally unused. This keeps the test behavior unchanged while removing the compiler warning for the `[[nodiscard]]` return value.

PS. the formatting differs from the surrounding context because it is produced by clang-format.

## Warning

```
[ 63%] Building CXX object CMakeFiles/McBopomofoLMLibTest.dir/VariantAnnotatorTest.cpp.o
/Users/chiahong/Documents/McBopomofo/Source/Engine/VariantAnnotatorTest.cpp:140:17: warning: ignoring return value of function
      declared with 'nodiscard' attribute [-Wunused-result]
  140 |   EXPECT_DEATH((annotator->annotate({"個", "人", "一", "個", "人", "一", "個"},
      |                 ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  141 |                                     {"ㄍㄜˋ", "ㄖㄣˊ"})),
      |                                     ~~~~~~~~~~~~~~~~~~
/Users/chiahong/Documents/McBopomofo/Source/Engine/build/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:190:15: note:
      expanded from macro 'EXPECT_DEATH'
  190 |   EXPECT_EXIT(statement, ::testing::internal::ExitedUnsuccessfully, matcher)
      |               ^~~~~~~~~
/Users/chiahong/Documents/McBopomofo/Source/Engine/build/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:179:21: note:
      expanded from macro 'EXPECT_EXIT'
  179 |   GTEST_DEATH_TEST_(statement, predicate, matcher, GTEST_NONFATAL_FAILURE_)
      |                     ^~~~~~~~~
/Users/chiahong/Documents/McBopomofo/Source/Engine/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:243:47: note:
      expanded from macro 'GTEST_DEATH_TEST_'
  243 |           GTEST_EXECUTE_DEATH_TEST_STATEMENT_(statement, gtest_dt);            \
      |                                               ^~~~~~~~~
/Users/chiahong/Documents/McBopomofo/Source/Engine/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:200:52: note:
      expanded from macro 'GTEST_EXECUTE_DEATH_TEST_STATEMENT_'
  200 |     GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_(statement);               \
      |                                                    ^~~~~~~~~
/Users/chiahong/Documents/McBopomofo/Source/Engine/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-internal.h:1354:5: note:
      expanded from macro 'GTEST_SUPPRESS_UNREACHABLE_CODE_WARNING_BELOW_'
 1354 |     statement;                                                    \
      |     ^~~~~~~~~
1 warning generated.
```