### PR TITLE
Reduce the amount of candidates in the auto trggered associated phrases in the smart mode

### DIFF
--- a/McBopomofoTests/AssociatedPhrasesTests.swift
+++ b/McBopomofoTests/AssociatedPhrasesTests.swift
@@ -120,8 +120,8 @@ final class AssociatedPhrasesTests {
         #expect(inputting.composingBuffer == result)
     }
 
-    @Test("Test building associated phrase state honors parameter object fields")
-    func testBuildingAssociatedPhrasesStateHonorsParameterObjectFields() {
+    @Test("Test building associated phrase state honors supported parameter object fields")
+    func testBuildingAssociatedPhrasesStateHonorsSupportedParameterObjectFields() {
         let state = typeKeys("u6")
         let params = BuildAssociatedPhraseParams()
         params.previousState = state
@@ -131,7 +131,6 @@ final class AssociatedPhrasesTests {
         params.candidateIndex = 1
         params.useVerticalMode = true
         params.autoTriggered = true
-        params.maxCadnidates = 1
 
         guard
             let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
@@ -147,7 +146,7 @@ final class AssociatedPhrasesTests {
         #expect(associatedPhrases.selectedIndex == 1)
         #expect(associatedPhrases.useVerticalMode)
         #expect(associatedPhrases.autoTriggered)
-        #expect(associatedPhrases.candidates.count == 1)
+        #expect(associatedPhrases.candidates.count > 0)
     }
 
 }

--- a/McBopomofoTests/AssociatedPhrasesTests.swift
+++ b/McBopomofoTests/AssociatedPhrasesTests.swift
@@ -72,7 +72,7 @@ final class AssociatedPhrasesTests {
         params.value = value
         params.candidateIndex = 0
         params.useVerticalMode = false
-        params.useShiftKey = false
+        params.autoTriggered = false
         guard
             let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
                 as? InputState.AssociatedPhrases
@@ -98,7 +98,7 @@ final class AssociatedPhrasesTests {
         params.value = input
         params.candidateIndex = 0
         params.useVerticalMode = false
-        params.useShiftKey = false
+        params.autoTriggered = false
         guard
             let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
                 as? InputState.AssociatedPhrases
@@ -130,7 +130,7 @@ final class AssociatedPhrasesTests {
         params.value = "一"
         params.candidateIndex = 1
         params.useVerticalMode = true
-        params.useShiftKey = true
+        params.autoTriggered = true
         params.maxCadnidates = 1
 
         guard
@@ -146,7 +146,7 @@ final class AssociatedPhrasesTests {
         #expect(associatedPhrases.prefixValue == "一")
         #expect(associatedPhrases.selectedIndex == 1)
         #expect(associatedPhrases.useVerticalMode)
-        #expect(associatedPhrases.useShiftKey)
+        #expect(associatedPhrases.autoTriggered)
         #expect(associatedPhrases.candidates.count == 1)
     }
 

--- a/McBopomofoTests/AssociatedPhrasesTests.swift
+++ b/McBopomofoTests/AssociatedPhrasesTests.swift
@@ -43,16 +43,9 @@ final class AssociatedPhrasesTests {
         Preferences.chineseConversionEnabled = chineseConversionEnabled
     }
 
-    @Test(
-        "Test building an associated phrase from characters",
-        arguments: [
-            ("u6", "ㄧ", "一")
-        ])
-    func testBuildingAssociatedPhrasesState(keySequence: String, reading: String, value: String) {
+    private func typeKeys(_ keySequence: String) -> InputState {
         var state: InputState = InputState.Empty()
-        let keys = Array(keySequence).map {
-            String($0)
-        }
+        let keys = Array(keySequence).map(String.init)
         for key in keys {
             let input = KeyHandlerInput(
                 inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
@@ -62,6 +55,16 @@ final class AssociatedPhrasesTests {
             } errorCallback: {
             }
         }
+        return state
+    }
+
+    @Test(
+        "Test building an associated phrase from characters",
+        arguments: [
+            ("u6", "ㄧ", "一")
+        ])
+    func testBuildingAssociatedPhrasesState(keySequence: String, reading: String, value: String) {
+        let state = typeKeys(keySequence)
         let params = BuildAssociatedPhraseParams()
         params.previousState = state
         params.prefixCursorIndex = 1
@@ -87,19 +90,7 @@ final class AssociatedPhrasesTests {
             ("《", "《》"),
         ])
     func testAssociatedPhrasesStatePunctuation1(input: String, result: String) {
-        var state: InputState = InputState.Empty()
-        let keys = Array("{").map {
-            String($0)
-        }
-        for key in keys {
-            let input = KeyHandlerInput(
-                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
-                isVerticalMode: false)
-            handler.handle(input: input, state: state) { newState in
-                state = newState
-            } errorCallback: {
-            }
-        }
+        let state = typeKeys("{")
         let params = BuildAssociatedPhraseParams()
         params.previousState = state
         params.prefixCursorIndex = 1
@@ -127,6 +118,36 @@ final class AssociatedPhrasesTests {
             return
         }
         #expect(inputting.composingBuffer == result)
+    }
+
+    @Test("Test building associated phrase state honors parameter object fields")
+    func testBuildingAssociatedPhrasesStateHonorsParameterObjectFields() {
+        let state = typeKeys("u6")
+        let params = BuildAssociatedPhraseParams()
+        params.previousState = state
+        params.prefixCursorIndex = 1
+        params.reading = "ㄧ"
+        params.value = "一"
+        params.candidateIndex = 1
+        params.useVerticalMode = true
+        params.useShiftKey = true
+        params.maxCadnidates = 1
+
+        guard
+            let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
+                as? InputState.AssociatedPhrases
+        else {
+            Issue.record("There should be an associated phrase state")
+            return
+        }
+
+        #expect(associatedPhrases.prefixCursorIndex == 1)
+        #expect(associatedPhrases.prefixReading == "ㄧ")
+        #expect(associatedPhrases.prefixValue == "一")
+        #expect(associatedPhrases.selectedIndex == 1)
+        #expect(associatedPhrases.useVerticalMode)
+        #expect(associatedPhrases.useShiftKey)
+        #expect(associatedPhrases.candidates.count == 1)
     }
 
 }

--- a/McBopomofoTests/AssociatedPhrasesTests.swift
+++ b/McBopomofoTests/AssociatedPhrasesTests.swift
@@ -62,10 +62,16 @@ final class AssociatedPhrasesTests {
             } errorCallback: {
             }
         }
+        let params = BuildAssociatedPhraseParams()
+        params.previousState = state
+        params.prefixCursorIndex = 1
+        params.reading = reading
+        params.value = value
+        params.candidateIndex = 0
+        params.useVerticalMode = false
+        params.useShiftKey = false
         guard
-            let associatedPhrases = handler.buildAssociatedPhraseState(
-                withPreviousState: state, prefixCursorAt: 1, reading: reading, value: value,
-                selectedCandidateIndex: 0, useVerticalMode: false, useShiftKey: false)
+            let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
                 as? InputState.AssociatedPhrases
         else {
             Issue.record("There should be an associated phrase state")
@@ -94,11 +100,16 @@ final class AssociatedPhrasesTests {
             } errorCallback: {
             }
         }
+        let params = BuildAssociatedPhraseParams()
+        params.previousState = state
+        params.prefixCursorIndex = 1
+        params.reading = "_punctuation_{"
+        params.value = input
+        params.candidateIndex = 0
+        params.useVerticalMode = false
+        params.useShiftKey = false
         guard
-            let associatedPhrases = handler.buildAssociatedPhraseState(
-                withPreviousState: state, prefixCursorAt: 1, reading: "_punctuation_{",
-                value: input,
-                selectedCandidateIndex: 0, useVerticalMode: false, useShiftKey: false)
+            let associatedPhrases = handler.buildAssociatedPhraseState(with: params)
                 as? InputState.AssociatedPhrases
         else {
             Issue.record("There should be an associated phrase state")

--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -1275,9 +1275,12 @@ class KeyHandlerBopomofoTests: XCTestCase {
 
     func testInputSpace() {
         let enabled = Preferences.chooseCandidateUsingSpace
+        let associatedPhrases = Preferences.associatedPhrasesEnabled
         Preferences.chooseCandidateUsingSpace = false
+        Preferences.associatedPhrasesEnabled = false
         defer {
             Preferences.chooseCandidateUsingSpace = enabled
+            Preferences.associatedPhrasesEnabled = associatedPhrases
         }
 
         var state: InputState = InputState.Empty()
@@ -1333,9 +1336,12 @@ class KeyHandlerBopomofoTests: XCTestCase {
 
     func testInputSpaceInBetween() {
         let enabled = Preferences.chooseCandidateUsingSpace
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
         Preferences.chooseCandidateUsingSpace = false
+        Preferences.associatedPhrasesEnabled = false
         defer {
             Preferences.chooseCandidateUsingSpace = enabled
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
         }
         var state: InputState = InputState.Empty()
         let keys = Array("su3cl3").map {
@@ -1375,6 +1381,12 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testHomeAndEnd() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
+
         var state: InputState = InputState.Empty()
         let keys = Array("su3cl3").map {
             String($0)
@@ -1570,6 +1582,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testMarkingLeft() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("su3cl3").map {
             String($0)
@@ -1639,6 +1656,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testMarkingRight() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("su3cl3").map {
             String($0)
@@ -1725,6 +1747,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testCancelMarking() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("su3cl3").map {
             String($0)
@@ -1911,6 +1938,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testEscKeyWithCandidate() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("w8 ").map {
             String($0)
@@ -1946,6 +1978,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testHomeKey() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("w8 ").map {
             String($0)
@@ -1974,6 +2011,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testHomeAndEndKey() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("w8 ").map {
             String($0)
@@ -2085,6 +2127,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testLookUpCandidateInDictionaryAndCancelWithTabKey() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("wu0 dj/ ").map {
             String($0)
@@ -2126,6 +2173,11 @@ class KeyHandlerBopomofoTests: XCTestCase {
     }
 
     func testLookUpCandidateInDictionaryAndCancelWithEscKey() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         var state: InputState = InputState.Empty()
         let keys = Array("wu0 dj/ ").map {
             String($0)
@@ -2767,6 +2819,12 @@ extension KeyHandlerBopomofoTests {
     }
 
     func testBopomofoFontAnnotationSupport(input: String, expected: String) {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
+
         let bopomofoFontAnnotationSupportEnabled = Preferences.bopomofoFontAnnotationSupportEnabled
         Preferences.bopomofoFontAnnotationSupportEnabled = true
         defer {
@@ -2925,6 +2983,11 @@ extension KeyHandlerBopomofoTests {
     }
 
     func testInputBufferWithCharactersThenBacktickThenEsc() {
+        let asociatedPhrases = Preferences.associatedPhrasesEnabled
+        Preferences.associatedPhrasesEnabled = false
+        defer {
+            Preferences.associatedPhrasesEnabled = asociatedPhrases
+        }
         // Type something in the buffer, then press ` to enter choosing punctuation list, then ESC to return to inputting state
         var state: InputState = InputState.Empty()
 

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -98,7 +98,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                             if Preferences.beepUponInputError {
                                 NSSound.beep()
                             }
-                        }, useShiftKey: true)
+                        }, useShiftKey: true, maxCandidateCount: 0)
                 }
             default:
                 break

--- a/Source/InputMethodController+CandidateControllerDelegate.swift
+++ b/Source/InputMethodController+CandidateControllerDelegate.swift
@@ -98,7 +98,7 @@ extension McBopomofoInputMethodController: CandidateControllerDelegate {
                             if Preferences.beepUponInputError {
                                 NSSound.beep()
                             }
-                        }, useShiftKey: true, maxCandidateCount: 0)
+                        }, autoTriggered: true, maxCandidateCount: 0)
                 }
             default:
                 break

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -865,19 +865,18 @@ extension McBopomofoInputMethodController {
         let keyLabels =
             candidateKeys.count >= 4
             ? Array(candidateKeys) : Array(Preferences.defaultCandidateKeys)
-        let shouldUseShift =
-            switch state {
-            case let state as InputState.AssociatedPhrases:
-                state.autoTriggered
-            case is InputState.AssociatedPhrasesPlain,
-                is InputState.Number:
-                true
-            default:
-                false
-            }
-        let keyLabelPrefix = shouldUseShift ? "⇧ " : ""
+
+        let keyLabelFormat: (String)->String = switch state {
+        case let state as InputState.AssociatedPhrases where state.autoTriggered:
+            { _ in "⇧ ⏎" }
+        case is InputState.AssociatedPhrasesPlain,
+            is InputState.Number:
+            { "⇧ " + $0 }
+        default:
+            { $0 }
+        }
         gCurrentCandidateController?.keyLabels = keyLabels.map {
-            CandidateKeyLabel(key: String($0), displayedText: keyLabelPrefix + String($0))
+            CandidateKeyLabel(key: String($0), displayedText: keyLabelFormat(String($0)))
         }
 
         gCurrentCandidateController?.delegate = self

--- a/Source/InputMethodController.swift
+++ b/Source/InputMethodController.swift
@@ -868,7 +868,7 @@ extension McBopomofoInputMethodController {
         let shouldUseShift =
             switch state {
             case let state as InputState.AssociatedPhrases:
-                state.useShiftKey
+                state.autoTriggered
             case is InputState.AssociatedPhrasesPlain,
                 is InputState.Number:
                 true

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -604,7 +604,7 @@ class InputState: NSObject {
         @objc private(set) var selectedIndex: Int = 0
         @objc private(set) var candidates: [Candidate] = []
         @objc private(set) var useVerticalMode: Bool = false
-        @objc private(set) var useShiftKey: Bool = false
+        @objc private(set) var autoTriggered: Bool = false
 
         @objc init(
             previousState: NotEmpty, prefixCursorIndex: Int, prefixReading: String,
@@ -618,7 +618,7 @@ class InputState: NSObject {
             self.selectedIndex = selectedIndex
             self.candidates = candidates
             self.useVerticalMode = useVerticalMode
-            self.useShiftKey = useShiftKey
+            self.autoTriggered = useShiftKey
             super.init(
                 composingBuffer: previousState.composingBuffer,
                 cursorIndex: previousState.cursorIndex)

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -609,7 +609,7 @@ class InputState: NSObject {
         @objc init(
             previousState: NotEmpty, prefixCursorIndex: Int, prefixReading: String,
             prefixValue: String,
-            selectedIndex: Int, candidates: [Candidate], useVerticalMode: Bool, useShiftKey: Bool
+            selectedIndex: Int, candidates: [Candidate], useVerticalMode: Bool, autoTriggered: Bool
         ) {
             self.previousState = previousState
             self.prefixCursorIndex = prefixCursorIndex
@@ -618,7 +618,7 @@ class InputState: NSObject {
             self.selectedIndex = selectedIndex
             self.candidates = candidates
             self.useVerticalMode = useVerticalMode
-            self.autoTriggered = useShiftKey
+            self.autoTriggered = autoTriggered
             super.init(
                 composingBuffer: previousState.composingBuffer,
                 cursorIndex: previousState.cursorIndex)
@@ -629,7 +629,7 @@ class InputState: NSObject {
         }
 
         var candidateCount: Int {
-            candidates.count
+            autoTriggered ? 1 : candidates.count
         }
 
         func candidate(at index: Int) -> String {
@@ -638,6 +638,18 @@ class InputState: NSObject {
 
         func reading(at index: Int) -> String? {
             candidates[index].reading
+        }
+
+        @objc
+        func toggle(autoTriggered: Bool) -> AssociatedPhrases {
+            AssociatedPhrases(previousState: previousState,
+                              prefixCursorIndex: prefixCursorIndex,
+                              prefixReading: prefixReading,
+                              prefixValue: prefixValue,
+                              selectedIndex: selectedIndex,
+                              candidates: candidates,
+                              useVerticalMode: useVerticalMode,
+                              autoTriggered: autoTriggered)
         }
 
     }

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -51,7 +51,6 @@ extern InputMode InputModePlainBopomofo;
 @property (assign, nonatomic) NSInteger candidateIndex;
 @property (assign, nonatomic) BOOL useVerticalMode;
 @property (assign, nonatomic) BOOL autoTriggered;
-@property (assign, nonatomic) size_t maxCadnidates;
 @end
 
 @interface KeyHandler : NSObject

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -43,6 +43,17 @@ extern InputMode InputModePlainBopomofo;
 - (BOOL)keyHandlerDidRequestReloadLanguageModel:(KeyHandler *)keyHandler;
 @end
 
+@interface BuildAssociatedPhraseParams: NSObject
+@property (strong, nonatomic) id previousState;
+@property (assign, nonatomic) size_t prefixCursorIndex;
+@property (strong, nonatomic) NSString *reading;
+@property (strong, nonatomic) NSString *value;
+@property (assign, nonatomic) NSInteger candidateIndex;
+@property (assign, nonatomic) BOOL useVerticalMode;
+@property (assign, nonatomic) BOOL useShiftKey;
+@property (assign, nonatomic) size_t maxCadnidates;
+@end
+
 @interface KeyHandler : NSObject
 
 - (BOOL)handleInput:(KeyHandlerInput *)input
@@ -53,7 +64,8 @@ extern InputMode InputModePlainBopomofo;
                         useVerticalMode:(BOOL)useVerticalMode
                           stateCallback:(void (^)(InputState *))stateCallback
                           errorCallback:(void (^)(void))errorCallback
-                            useShiftKey:(BOOL)useShiftKey;
+                            useShiftKey:(BOOL)useShiftKey
+                      maxCandidateCount:(size_t)maxCandidateCount;
 
 - (void)syncWithPreferences;
 - (void)fixNodeWithReading:(NSString *)reading
@@ -75,20 +87,7 @@ extern InputMode InputModePlainBopomofo;
 - (nullable InputState *)buildAssociatedPhrasePlainStateWithReading:(NSString *)reading
                                                               value:(NSString *)value
                                                     useVerticalMode:(BOOL)useVerticalMode;
-- (nullable InputState *)buildAssociatedPhraseStateWithPreviousState:(id)state
-                                                      prefixCursorAt:(size_t)prefixCursorIndex
-                                                             reading:(NSString *)reading
-                                                               value:(NSString *)value
-                                              selectedCandidateIndex:(NSInteger)candidateIndex
-                                                     useVerticalMode:(BOOL)useVerticalMode
-                                                         useShiftKey:(BOOL)useShiftKey;
-- (nullable InputState *)buildAssociatedPhraseStateWithPreviousState:(id)state
-                                      candidateStateOriginalCursorAt:(size_t)candidtaeStateOriginalCursorIndex
-                                                       prefixReading:(NSString *)prefixReading
-                                                               value:(NSString *)prefixValue
-                                              selectedCandidateIndex:(NSInteger)candidateIndex
-                                                     useVerticalMode:(BOOL)useVerticalMode
-                                                         useShiftKey:(BOOL)useShiftKey;
+- (nullable InputState *)buildAssociatedPhraseStateWithParams:(BuildAssociatedPhraseParams *)params;
 
 - (size_t)computeActualCursorIndex:(size_t)cursor;
 

--- a/Source/KeyHandler.h
+++ b/Source/KeyHandler.h
@@ -50,7 +50,7 @@ extern InputMode InputModePlainBopomofo;
 @property (strong, nonatomic) NSString *value;
 @property (assign, nonatomic) NSInteger candidateIndex;
 @property (assign, nonatomic) BOOL useVerticalMode;
-@property (assign, nonatomic) BOOL useShiftKey;
+@property (assign, nonatomic) BOOL autoTriggered;
 @property (assign, nonatomic) size_t maxCadnidates;
 @end
 
@@ -64,7 +64,7 @@ extern InputMode InputModePlainBopomofo;
                         useVerticalMode:(BOOL)useVerticalMode
                           stateCallback:(void (^)(InputState *))stateCallback
                           errorCallback:(void (^)(void))errorCallback
-                            useShiftKey:(BOOL)useShiftKey
+                            autoTriggered:(BOOL)useShiftKey
                       maxCandidateCount:(size_t)maxCandidateCount;
 
 - (void)syncWithPreferences;

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1523,41 +1523,41 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             NSMutableArray *entries = [[NSMutableArray alloc] init];
             NSString *title = @"";
             if (isPlusKey) {
-                InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"")
-                                                                                           callback:^{
-                                                                                               __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                                                               if (!strongSelf) {
-                                                                                                   return;
-                                                                                               }
-                                                                                               [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
-                                                                                               [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                                                                                               [strongSelf _walk];
-                                                                                               InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                                                                                               stateCallback(inputting);
-                                                                                           }];
+                void (^callback)(void) = ^{
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    stateCallback(inputting);
+                };
+                InputStateCustomMenuEntry *boost = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Boost", @"") callback: callback];
                 [entries addObject:boost];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to boost the score of the phrase \"%@\"?", @""), candidate.value];
             } else if (isMinusKey) {
-                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"")
-                                                                                             callback:^{
-                                                                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                                                                                 if (!strongSelf) {
-                                                                                                     return;
-                                                                                                 }
-                                                                                                 [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
-                                                                                                 [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
-                                                                                                 [strongSelf _walk];
-                                                                                                 InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
-                                                                                                 stateCallback(inputting);
-                                                                                             }];
+                void (^callback)(void) = ^{
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
+                    if (!strongSelf) {
+                        return;
+                    }
+                    [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
+                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    [strongSelf _walk];
+                    InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
+                    stateCallback(inputting);
+                };
+                InputStateCustomMenuEntry *exclude = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Exclude", @"") callback:callback];
                 [entries addObject:exclude];
                 title = [NSString stringWithFormat:NSLocalizedString(@"Do you want to exclude the phrase \"%@\"?", @""), candidate.value];
             }
-            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"")
-                                                                                        callback:^{
-                                                                                            stateCallback(currentState);
-                                                                                            gCurrentCandidateController.selectedCandidateIndex = index;
-                                                                                        }];
+            void (^cancalCallback)(void) = ^{
+                stateCallback(currentState);
+                gCurrentCandidateController.selectedCandidateIndex = index;
+            };
+            InputStateCustomMenuEntry *cancel = [[InputStateCustomMenuEntry alloc] initWithTitle:NSLocalizedString(@"Cancel", @"") callback:cancalCallback];
             [entries addObject:cancel];
 
             InputStateCustomMenu *confirm = [[InputStateCustomMenu alloc] initWithComposingBuffer:[currentState composingBuffer] cursorIndex:[currentState cursorIndex] title:title entries:entries previousState:currentState selectedIndex:index];
@@ -1758,6 +1758,10 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (isPageDown) {
+        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) {
+            return NO;
+        }
+
         BOOL updated = [gCurrentCandidateController showNextPage];
         if (!updated) {
             errorCallback();
@@ -1766,6 +1770,10 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (isPageUp) {
+        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) {
+            return NO;
+        }
+
         BOOL updated = [gCurrentCandidateController showPreviousPage];
         if (!updated) {
             errorCallback();
@@ -1773,10 +1781,25 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
+    NSInteger candidateCount = 0;
+    if ([state conformsToProtocol:@protocol(CandidateProvider)]) {
+        candidateCount = ((id<CandidateProvider>)state).candidateCount;
+    }
+
+
     if (input.isLeft) {
         if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey] && input.isShiftHold) {
-                return NO;
+            if ([(InputStateAssociatedPhrases *)state useShiftKey] ) {
+                if ([gCurrentCandidateController isKindOfClass:[VTHorizontalCandidateController class]]) {
+                    if (gCurrentCandidateController.selectedCandidateIndex == 0) {
+                        return NO;
+                    }
+                } else {
+                    return NO;
+                }
+                if (input.isShiftHold) {
+                    return NO;
+                }
             }
         }
 
@@ -1804,8 +1827,17 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     if (input.isRight) {
         if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey] && input.isShiftHold) {
-                return NO;
+            if ([(InputStateAssociatedPhrases *)state useShiftKey] ) {
+                if ([gCurrentCandidateController isKindOfClass:[VTHorizontalCandidateController class]]) {
+                    if (gCurrentCandidateController.selectedCandidateIndex == candidateCount - 1) {
+                        return NO;
+                    }
+                } else {
+                    return NO;
+                }
+                if (input.isShiftHold) {
+                    return NO;
+                }
             }
         }
 
@@ -1869,11 +1901,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         }
 
         return YES;
-    }
-
-    NSInteger candidateCount = 0;
-    if ([state conformsToProtocol:@protocol(CandidateProvider)]) {
-        candidateCount = ((id<CandidateProvider>)state).candidateCount;
     }
 
     if (!candidateCount) {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -362,7 +362,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     // if the composing buffer is empty and there's no reading, and there is some function key combination, we ignore it
     BOOL isFunctionKey = (input.isCommandHold || input.isOptionHold || input.isNumericPad) || input.isControlHotKey;
-    if (![state isKindOfClass:[InputStateNotEmpty class]] && ![state isKindOfClass:[InputStateAssociatedPhrasesPlain class]] && !([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) && isFunctionKey) {
+    if (![state isKindOfClass:[InputStateNotEmpty class]] && ![state isKindOfClass:[InputStateAssociatedPhrasesPlain class]] && !([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state autoTriggered]) && isFunctionKey) {
         return NO;
     }
 
@@ -419,7 +419,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         if (result) {
             return YES;
         }
-        if ([(InputStateAssociatedPhrases *)state useShiftKey]) {
+        if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
             state = [self buildInputtingState];
             stateCallback(state);
         } else {
@@ -544,7 +544,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         stateCallback(inputting);
 
         if (_inputMode == InputModeBopomofo && Preferences.associatedPhrasesEnabled) {
-            [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES maxCandidateCount:2];
+            [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback autoTriggered:YES maxCandidateCount:2];
         } else if (_inputMode == InputModePlainBopomofo) {
             InputStateChoosingCandidate *choosingCandidates = [self _buildCandidateStateFromInputtingState:inputting useVerticalMode:input.useVerticalMode];
 
@@ -708,7 +708,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         }
         if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold &&
             [state isKindOfClass:[InputStateInputting class]]) {
-            return [self handleAssociatedPhraseWithState:(InputStateInputting *)state useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:NO maxCandidateCount:0];
+            return [self handleAssociatedPhraseWithState:(InputStateInputting *)state useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback autoTriggered:NO maxCandidateCount:0];
         }
         return [self _handleEnterWithState:state stateCallback:stateCallback errorCallback:errorCallback];
     }
@@ -1279,7 +1279,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     stateCallback(inputting);
 
     if (_inputMode == InputModeBopomofo && Preferences.associatedPhrasesEnabled) {
-        [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES maxCandidateCount:0];
+        [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:useVerticalMode stateCallback:stateCallback errorCallback:errorCallback autoTriggered:YES maxCandidateCount:0];
     } else if (_inputMode == InputModePlainBopomofo && _bpmfReadingBuffer->isEmpty()) {
         InputStateChoosingCandidate *candidateState = [self _buildCandidateStateFromInputtingState:(InputStateInputting *)[self buildInputtingState] useVerticalMode:useVerticalMode];
 
@@ -1588,7 +1588,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             stateCallback(newState);
             return YES;
         } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey]) {
+            if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
                 return NO;
             }
         }
@@ -1621,7 +1621,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
             stateCallback(empty);
         } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey]) {
+            if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
                 return NO;
             }
 
@@ -1676,7 +1676,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         // Find associated phrases from the chosen candidate.
 
         if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey]) {
+            if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
                 if (input.isShiftHold) {
                     [self.delegate keyHandler:self didSelectCandidateAtIndex:gCurrentCandidateController.selectedCandidateIndex candidateController:gCurrentCandidateController];
                     return YES;
@@ -1710,7 +1710,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 params.value = prefixValue;
                 params.candidateIndex = 0;
                 params.useVerticalMode = current.useVerticalMode;
-                params.useShiftKey = NO;
+                params.autoTriggered = NO;
                 params.maxCadnidates = NSIntegerMax;
                 InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
                 if (newState) {
@@ -1735,7 +1735,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     // Handle space key
     if (charCode == 32 && [state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-        if ([(InputStateAssociatedPhrases *)state useShiftKey]) {
+        if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
             return NO;
         }
     }
@@ -1758,7 +1758,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (isPageDown) {
-        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) {
+        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state autoTriggered]) {
             return NO;
         }
 
@@ -1770,7 +1770,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (isPageUp) {
-        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state useShiftKey]) {
+        if ([state isKindOfClass:[InputStateAssociatedPhrases class]] && [(InputStateAssociatedPhrases *)state autoTriggered]) {
             return NO;
         }
 
@@ -1789,7 +1789,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     if (input.isLeft) {
         if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey] ) {
+            if ([(InputStateAssociatedPhrases *)state autoTriggered] ) {
                 if ([gCurrentCandidateController isKindOfClass:[VTHorizontalCandidateController class]]) {
                     if (gCurrentCandidateController.selectedCandidateIndex == 0) {
                         return NO;
@@ -1827,7 +1827,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
     if (input.isRight) {
         if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state useShiftKey] ) {
+            if ([(InputStateAssociatedPhrases *)state autoTriggered] ) {
                 if ([gCurrentCandidateController isKindOfClass:[VTHorizontalCandidateController class]]) {
                     if (gCurrentCandidateController.selectedCandidateIndex == candidateCount - 1) {
                         return NO;
@@ -1921,7 +1921,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         [state isKindOfClass:[InputStateNumber class]]) {
         useInputTextIgnoringModifiers = YES;
     } else if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-        useInputTextIgnoringModifiers = [(InputStateAssociatedPhrases *)state useShiftKey];
+        useInputTextIgnoringModifiers = [(InputStateAssociatedPhrases *)state autoTriggered];
     }
 
     if (useInputTextIgnoringModifiers) {
@@ -2226,7 +2226,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                         useVerticalMode:(BOOL)useVerticalMode
                           stateCallback:(void (^)(InputState *))stateCallback
                           errorCallback:(void (^)(void))errorCallback
-                            useShiftKey:(BOOL)useShiftKey
+                          autoTriggered:(BOOL)autoTriggered
                       maxCandidateCount:(size_t)maxCandidateCount
 {
     size_t cursor = _grid->cursor();
@@ -2329,7 +2329,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         params.value = actualValue;
         params.candidateIndex = 0;
         params.useVerticalMode = useVerticalMode;
-        params.useShiftKey = useShiftKey;
+        params.autoTriggered = autoTriggered;
         params.maxCadnidates = maxCandidateCount;
         InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
         if (newState) {
@@ -2337,7 +2337,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
     }
-    if (!useShiftKey) {
+    if (!autoTriggered) {
         errorCallback();
     }
     return YES;
@@ -2642,7 +2642,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             break;
         }
     }
-    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:params.previousState prefixCursorIndex:params.prefixCursorIndex prefixReading:params.reading prefixValue:params.value selectedIndex:params.candidateIndex candidates:array useVerticalMode:params.useVerticalMode useShiftKey:params.useShiftKey];
+    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:params.previousState prefixCursorIndex:params.prefixCursorIndex prefixReading:params.reading prefixValue:params.value selectedIndex:params.candidateIndex candidates:array useVerticalMode:params.useVerticalMode useShiftKey:params.autoTriggered];
     return associatedPhrases;
 }
 
@@ -2709,6 +2709,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 @synthesize value;
 @synthesize candidateIndex;
 @synthesize useVerticalMode;
-@synthesize useShiftKey;
+@synthesize autoTriggered;
 @synthesize maxCadnidates;
 @end

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1383,6 +1383,22 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     UniChar charCode = input.charCode;
     VTCandidateController *gCurrentCandidateController = [self.delegate candidateControllerForKeyHandler:self];
 
+    if ([state isKindOfClass:[InputStateAssociatedPhrases class]] &&
+        [(InputStateAssociatedPhrases *)state autoTriggered]
+        ) {
+        if (input.isTab) {
+            InputStateAssociatedPhrases *exapneded = [(InputStateAssociatedPhrases *)state toggleWithAutoTriggered:NO];
+            stateCallback(exapneded);
+            return YES;
+        }
+        if (input.isShiftHold && (charCode == 13 || input.isEnter)) {
+            [self.delegate keyHandler:self didSelectCandidateAtIndex:gCurrentCandidateController.selectedCandidateIndex candidateController:gCurrentCandidateController];
+            return YES;
+        }
+        return NO;
+    }
+
+
     if ([state isKindOfClass:[InputChoosingPunctuationList class]]) {
         if ([input.inputText isEqualToString:@"`"]) {
             if (Preferences.selectPhraseAfterCursorAsCandidate) {
@@ -1673,17 +1689,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     if (charCode == 13 || input.isEnter) {
-        // Find associated phrases from the chosen candidate.
-
-        if ([state isKindOfClass:[InputStateAssociatedPhrases class]]) {
-            if ([(InputStateAssociatedPhrases *)state autoTriggered]) {
-                if (input.isShiftHold) {
-                    [self.delegate keyHandler:self didSelectCandidateAtIndex:gCurrentCandidateController.selectedCandidateIndex candidateController:gCurrentCandidateController];
-                    return YES;
-                }
-                return NO;
-            }
-        }
 
         if ([state isKindOfClass:[InputStateNumber class]]) {
             InputStateNumber *numberState = (InputStateNumber *)state;
@@ -1695,33 +1700,34 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             return YES;
         }
 
-        if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold) {
-            if ([state isKindOfClass:[InputStateChoosingCandidate class]]) {
-                InputStateChoosingCandidate *current = (InputStateChoosingCandidate *)state;
-                NSInteger selectedCandidateIndex = gCurrentCandidateController.selectedCandidateIndex;
-                InputStateCandidate *candidate = current.candidates[selectedCandidateIndex];
-                NSString *prefixReading = candidate.reading;
-                NSString *prefixValue = candidate.value;
+        // Find associated phrases from the chosen candidate.
 
-                BuildAssociatedPhraseParams *params = [[BuildAssociatedPhraseParams alloc] init];
-                params.previousState = current;
-                params.prefixCursorIndex = [self computeActualCursorIndex:current.originalCursorIndex];
-                params.reading = prefixReading;
-                params.value = prefixValue;
-                params.candidateIndex = 0;
-                params.useVerticalMode = current.useVerticalMode;
-                params.autoTriggered = NO;
-                params.maxCadnidates = NSIntegerMax;
-                InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
-                if (newState) {
-                    stateCallback(newState);
-                } else {
-                    errorCallback();
-                }
-                return YES;
+        if (Preferences.shiftEnterEnabled &&
+            _inputMode == InputModeBopomofo &&
+            input.isShiftHold &&
+            [state isKindOfClass:[InputStateChoosingCandidate class]]) {
+            InputStateChoosingCandidate *current = (InputStateChoosingCandidate *)state;
+            NSInteger selectedCandidateIndex = gCurrentCandidateController.selectedCandidateIndex;
+            InputStateCandidate *candidate = current.candidates[selectedCandidateIndex];
+            NSString *prefixReading = candidate.reading;
+            NSString *prefixValue = candidate.value;
+
+            BuildAssociatedPhraseParams *params = [[BuildAssociatedPhraseParams alloc] init];
+            params.previousState = current;
+            params.prefixCursorIndex = [self computeActualCursorIndex:current.originalCursorIndex];
+            params.reading = prefixReading;
+            params.value = prefixValue;
+            params.candidateIndex = 0;
+            params.useVerticalMode = current.useVerticalMode;
+            params.autoTriggered = NO;
+            InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
+            if (newState) {
+                stateCallback(newState);
+            } else {
+                errorCallback();
             }
+            return YES;
         }
-
         if ([state isKindOfClass:[InputStateAssociatedPhrasesPlain class]]) {
             [self clear];
             InputStateEmptyIgnoringPreviousState *empty = [[InputStateEmptyIgnoringPreviousState alloc] init];
@@ -2330,7 +2336,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         params.candidateIndex = 0;
         params.useVerticalMode = useVerticalMode;
         params.autoTriggered = autoTriggered;
-        params.maxCadnidates = maxCandidateCount;
         InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
         if (newState) {
             stateCallback(newState);
@@ -2619,7 +2624,6 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     NSMutableArray<InputStateCandidate *> *array = [NSMutableArray array];
-    size_t added = 0;
     for (const auto& phrase : phrases) {
         std::string combinedReading = McBopomofo::AssociatedPhrasesV2::CombineReadings(phrase.readings);
         NSString *candidateReading = @(combinedReading.c_str());
@@ -2637,12 +2641,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
         InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:displayText rawValue:candidateValue];
         [array addObject:candidate];
-        added++;
-        if (params.maxCadnidates > 0 && added >= params.maxCadnidates) {
-            break;
-        }
     }
-    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:params.previousState prefixCursorIndex:params.prefixCursorIndex prefixReading:params.reading prefixValue:params.value selectedIndex:params.candidateIndex candidates:array useVerticalMode:params.useVerticalMode useShiftKey:params.autoTriggered];
+    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:params.previousState prefixCursorIndex:params.prefixCursorIndex prefixReading:params.reading prefixValue:params.value selectedIndex:params.candidateIndex candidates:array useVerticalMode:params.useVerticalMode autoTriggered:params.autoTriggered];
     return associatedPhrases;
 }
 
@@ -2710,5 +2710,4 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 @synthesize candidateIndex;
 @synthesize useVerticalMode;
 @synthesize autoTriggered;
-@synthesize maxCadnidates;
 @end

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -544,7 +544,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         stateCallback(inputting);
 
         if (_inputMode == InputModeBopomofo && Preferences.associatedPhrasesEnabled) {
-            [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES];
+            [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES maxCandidateCount:2];
         } else if (_inputMode == InputModePlainBopomofo) {
             InputStateChoosingCandidate *choosingCandidates = [self _buildCandidateStateFromInputtingState:inputting useVerticalMode:input.useVerticalMode];
 
@@ -708,7 +708,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         }
         if (Preferences.shiftEnterEnabled && _inputMode == InputModeBopomofo && input.isShiftHold &&
             [state isKindOfClass:[InputStateInputting class]]) {
-            return [self handleAssociatedPhraseWithState:(InputStateInputting *)state useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:NO];
+            return [self handleAssociatedPhraseWithState:(InputStateInputting *)state useVerticalMode:input.useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:NO maxCandidateCount:0];
         }
         return [self _handleEnterWithState:state stateCallback:stateCallback errorCallback:errorCallback];
     }
@@ -1279,7 +1279,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     stateCallback(inputting);
 
     if (_inputMode == InputModeBopomofo && Preferences.associatedPhrasesEnabled) {
-        [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES];
+        [self handleAssociatedPhraseWithState:(InputStateInputting *)inputting useVerticalMode:useVerticalMode stateCallback:stateCallback errorCallback:errorCallback useShiftKey:YES maxCandidateCount:0];
     } else if (_inputMode == InputModePlainBopomofo && _bpmfReadingBuffer->isEmpty()) {
         InputStateChoosingCandidate *candidateState = [self _buildCandidateStateFromInputtingState:(InputStateInputting *)[self buildInputtingState] useVerticalMode:useVerticalMode];
 
@@ -1702,7 +1702,17 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                 InputStateCandidate *candidate = current.candidates[selectedCandidateIndex];
                 NSString *prefixReading = candidate.reading;
                 NSString *prefixValue = candidate.value;
-                InputState *newState = [self buildAssociatedPhraseStateWithPreviousState:current candidateStateOriginalCursorAt:current.originalCursorIndex prefixReading:prefixReading value:prefixValue selectedCandidateIndex:selectedCandidateIndex useVerticalMode:current.useVerticalMode useShiftKey:NO];
+
+                BuildAssociatedPhraseParams *params = [[BuildAssociatedPhraseParams alloc] init];
+                params.previousState = current;
+                params.prefixCursorIndex = [self computeActualCursorIndex:current.originalCursorIndex];
+                params.reading = prefixReading;
+                params.value = prefixValue;
+                params.candidateIndex = 0;
+                params.useVerticalMode = current.useVerticalMode;
+                params.useShiftKey = NO;
+                params.maxCadnidates = NSIntegerMax;
+                InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
                 if (newState) {
                     stateCallback(newState);
                 } else {
@@ -2190,6 +2200,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                           stateCallback:(void (^)(InputState *))stateCallback
                           errorCallback:(void (^)(void))errorCallback
                             useShiftKey:(BOOL)useShiftKey
+                      maxCandidateCount:(size_t)maxCandidateCount
 {
     size_t cursor = _grid->cursor();
 
@@ -2284,7 +2295,16 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
         NSString *combinedReading = @(McBopomofo::AssociatedPhrasesV2::CombineReadings(rdSlice).c_str());
         NSString *actualValue = @(value.str().c_str());
-        InputState *newState = [self buildAssociatedPhraseStateWithPreviousState:state prefixCursorAt:prefixCursorIndex reading:combinedReading value:actualValue selectedCandidateIndex:0 useVerticalMode:useVerticalMode useShiftKey:useShiftKey];
+        BuildAssociatedPhraseParams *params = [[BuildAssociatedPhraseParams alloc] init];
+        params.previousState = state;
+        params.prefixCursorIndex = prefixCursorIndex;
+        params.reading = combinedReading;
+        params.value = actualValue;
+        params.candidateIndex = 0;
+        params.useVerticalMode = useVerticalMode;
+        params.useShiftKey = useShiftKey;
+        params.maxCadnidates = maxCandidateCount;
+        InputState *newState = [self buildAssociatedPhraseStateWithParams:params];
         if (newState) {
             stateCallback(newState);
             return YES;
@@ -2554,18 +2574,12 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     return nil;
 }
 
-- (nullable InputState *)buildAssociatedPhraseStateWithPreviousState:(id)state
-                                                      prefixCursorAt:(size_t)prefixCursorIndex
-                                                             reading:(NSString *)reading
-                                                               value:(NSString *)value
-                                              selectedCandidateIndex:(NSInteger)candidateIndex
-                                                     useVerticalMode:(BOOL)useVerticalMode
-                                                         useShiftKey:(BOOL)useShiftKey
+- (nullable InputState *)buildAssociatedPhraseStateWithParams:(BuildAssociatedPhraseParams *)params
 {
     BOOL scToTc = Preferences.chineseConversionEnabled && Preferences.chineseConversionStyle == ChineseConversionStyleModel;
 
-    std::vector<std::string> splitReadings = McBopomofo::AssociatedPhrasesV2::SplitReadings(std::string(reading.UTF8String));
-    NSString *actualValue = value;
+    std::vector<std::string> splitReadings = McBopomofo::AssociatedPhrasesV2::SplitReadings(std::string(params.reading.UTF8String));
+    NSString *actualValue = params.value;
     if (scToTc) {
         // The data is in Traditional Chinese, and so if ChineseConversionStyleModel is enabled, we need to convert the prefix back.
         actualValue = [[OpenCCBridge sharedInstance] convertToTraditional:actualValue];
@@ -2578,6 +2592,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     }
 
     NSMutableArray<InputStateCandidate *> *array = [NSMutableArray array];
+    size_t added = 0;
     for (const auto& phrase : phrases) {
         std::string combinedReading = McBopomofo::AssociatedPhrasesV2::CombineReadings(phrase.readings);
         NSString *candidateReading = @(combinedReading.c_str());
@@ -2595,20 +2610,13 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
         InputStateCandidate *candidate = [[InputStateCandidate alloc] initWithReading:candidateReading value:candidateValue displayText:displayText rawValue:candidateValue];
         [array addObject:candidate];
+        added++;
+        if (params.maxCadnidates > 0 && added >= params.maxCadnidates) {
+            break;
+        }
     }
-    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:state prefixCursorIndex:prefixCursorIndex prefixReading:reading prefixValue:value selectedIndex:candidateIndex candidates:array useVerticalMode:useVerticalMode useShiftKey:useShiftKey];
+    InputStateAssociatedPhrases *associatedPhrases = [[InputStateAssociatedPhrases alloc] initWithPreviousState:params.previousState prefixCursorIndex:params.prefixCursorIndex prefixReading:params.reading prefixValue:params.value selectedIndex:params.candidateIndex candidates:array useVerticalMode:params.useVerticalMode useShiftKey:params.useShiftKey];
     return associatedPhrases;
-}
-
-- (nullable InputState *)buildAssociatedPhraseStateWithPreviousState:(id)state
-                                      candidateStateOriginalCursorAt:(size_t)candidtaeStateOriginalCursorIndex
-                                                       prefixReading:(NSString *)prefixReading
-                                                               value:(NSString *)prefixValue
-                                              selectedCandidateIndex:(NSInteger)candidateIndex
-                                                     useVerticalMode:(BOOL)useVerticalMode
-                                                         useShiftKey:(BOOL)useShiftKey
-{
-    return [self buildAssociatedPhraseStateWithPreviousState:state prefixCursorAt:[self computeActualCursorIndex:candidtaeStateOriginalCursorIndex] reading:prefixReading value:prefixValue selectedCandidateIndex:candidateIndex useVerticalMode:useVerticalMode useShiftKey:useShiftKey];
 }
 
 - (NSArray<NSString *> *)collectUserFileIssues
@@ -2665,4 +2673,15 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
     return updatedState;
 }
 
+@end
+
+@implementation BuildAssociatedPhraseParams
+@synthesize previousState;
+@synthesize prefixCursorIndex;
+@synthesize reading;
+@synthesize value;
+@synthesize candidateIndex;
+@synthesize useVerticalMode;
+@synthesize useShiftKey;
+@synthesize maxCadnidates;
 @end


### PR DESCRIPTION
We have implemented a feature to show associated phrases in smart Bopomofo mode. However, the feature is quite annoying since it always gives too many candidates.

The PR reduces the candidates. Not it only shows one candidate and a user can use Shift+Enter to commit it to the composing buffer. If a user wants more candidates, he or she can use the Tab key to show the full candidate list.

<img width="177" height="213" alt="image" src="https://github.com/user-attachments/assets/d2b296e6-7d1c-4b32-9315-b223a1624340" />
