### PR TITLE
Fix mmap failure handling in MemoryMappedFile

### DIFF
--- a/Source/Engine/MemoryMappedFile.cpp
+++ b/Source/Engine/MemoryMappedFile.cpp
@@ -68,10 +68,11 @@ bool MemoryMappedFile::open(const char* path) {
   length_ = static_cast<size_t>(sb.st_size);
 
   data_ = mmap(nullptr, length_, PROT_READ, MAP_SHARED, fd_, 0);
-  if (data_ == nullptr) {
+  if (data_ == MAP_FAILED) {
     ::close(fd_);
     fd_ = -1;
     length_ = 0;
+    data_ = nullptr;
     return false;
   }
 

--- a/Source/Engine/MemoryMappedFileTest.cpp
+++ b/Source/Engine/MemoryMappedFileTest.cpp
@@ -124,4 +124,43 @@ TEST(MemoryMappedFileTest, BasicFunctionalities) {
   EXPECT_EQ(mf5.data(), nullptr);
 }
 
+TEST(MemoryMappedFileTest, EmptyFile) {
+  std::filesystem::path tmp_file_path =
+      std::filesystem::temp_directory_path() /
+      "org.openvanilla.mcbopomofo.memorymappedfiletest-empty-file";
+  std::filesystem::remove(tmp_file_path);
+  std::ofstream out(tmp_file_path, std::ios::binary);
+  out.close();
+
+  MemoryMappedFile mf;
+  EXPECT_FALSE(mf.open(tmp_file_path.c_str()));
+  EXPECT_EQ(mf.length(), 0);
+  EXPECT_EQ(mf.data(), nullptr);
+
+  mf.close();
+  EXPECT_EQ(mf.length(), 0);
+  EXPECT_EQ(mf.data(), nullptr);
+
+  std::filesystem::remove(tmp_file_path);
+}
+
+TEST(MemoryMappedFileTest, MmapFailure) {
+  std::filesystem::path tmp_dir_path =
+      std::filesystem::temp_directory_path() /
+      "org.openvanilla.mcbopomofo.memorymappedfiletest-mmap-failure";
+  std::filesystem::remove_all(tmp_dir_path);
+  ASSERT_TRUE(std::filesystem::create_directory(tmp_dir_path));
+
+  MemoryMappedFile mf;
+  EXPECT_FALSE(mf.open(tmp_dir_path.c_str()));
+  EXPECT_EQ(mf.length(), 0);
+  EXPECT_EQ(mf.data(), nullptr);
+
+  mf.close();
+  EXPECT_EQ(mf.length(), 0);
+  EXPECT_EQ(mf.data(), nullptr);
+
+  std::filesystem::remove_all(tmp_dir_path);
+}
+
 }  // namespace McBopomofo


### PR DESCRIPTION
This PR fixes `MemoryMappedFile::open()` to check `mmap()` failures correctly.

```
$ man mmap

RETURN VALUES
     Upon successful completion, mmap() returns a pointer to the mapped region.  Otherwise, a value of
     MAP_FAILED is returned and errno is set to indicate the error.
```

`mmap()` returns `MAP_FAILED` (`((void *)-1)`) on failure, not `nullptr`. The previous check could treat a failed mapping as a successful open, leaving `data_` with an invalid pointer `0xffffffffffffffff`.

I also added two tests to verify the handling of empty files and failure cases.