### PR TITLE
Avoid shared_ptr copies in Span::nodeOf

### DIFF
--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -577,7 +577,7 @@ void ReadingGrid::Span::removeNodesOfOrLongerThan(size_t length) {
   }
 }
 
-ReadingGrid::NodePtr ReadingGrid::Span::nodeOf(size_t length) const {
+const ReadingGrid::NodePtr& ReadingGrid::Span::nodeOf(size_t length) const {
   assert(length > 0 && length <= kMaximumSpanLength);
   return nodes_[length - 1];
 }

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -216,7 +216,7 @@ class ReadingGrid {
     void clear();
     void add(const NodePtr& node);
     void removeNodesOfOrLongerThan(size_t length);
-    [[nodiscard]] NodePtr nodeOf(size_t length) const;
+    [[nodiscard]] const NodePtr& nodeOf(size_t length) const;
     [[nodiscard]] size_t maxLength() const { return maxLength_; }
 
    protected:


### PR DESCRIPTION
This PR is a follow-up to #777. After that refactor, I kept looking into the remaining hot path and found that `Span::nodeOf()` was still returning `NodePtr` by value. Since `NodePtr` is a `std::shared_ptr<Node>`, every call to `nodeOf()` copied a `shared_ptr`, causing unnecessary atomic reference count updates (which are very expensive) while walking the grid.

This PR changes `Span::nodeOf()` to return `const NodePtr&` instead. The method only returns an existing entry from the span's internal node array, so there is no need to create a new `shared_ptr` owner each time.

This is a small API-level change, but it removes a surprisingly expensive operation from the hottest loop XDD 

## Performance

- MacBook Air M2
- Release mode
- `runGramambular2Test` stress test

### Before

| Round 1 | Round 2 | Round 3 |
| ------- | ------- | ------- |
| 199 us  | 209 us  | 203 us  |

### After

| Round 1 | Round 2 | Round 3 |
| ------- | ------- | ------- |
| 132 us  | 145 us  | 125 us  |