### PR TITLE
refactor(engine): derive span length from language model maxKeyLength

### DIFF
--- a/Source/Engine/gramambular2/language_model.h
+++ b/Source/Engine/gramambular2/language_model.h
@@ -41,6 +41,10 @@ class LanguageModel {
   virtual std::vector<Unigram> getUnigrams(const std::string& reading) = 0;
   virtual bool hasUnigrams(const std::string& reading) = 0;
 
+  // The maximum reading key length, in syllables, that this model can match.
+  // Returns 0 if unknown, in which case the grid uses its default span length.
+  virtual size_t maxKeyLength() const { return 0; }
+
   // An immutable unigram with an actual value, along with a score, which is
   // usually a log probability from a language model.
   class Unigram {

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -294,7 +294,7 @@ void ReadingGrid::removeAffectedNodes(size_t loc) {
   if (spans_.empty()) {
     return;
   }
-  size_t affectedLength = kMaximumSpanLength - 1;
+  size_t affectedLength = maxSpanLength_ - 1;
   size_t begin = loc <= affectedLength ? 0 : loc - affectedLength;
   size_t end = loc >= 1 ? loc - 1 : 0;
   for (size_t i = begin; i <= end; ++i) {
@@ -334,13 +334,12 @@ bool ReadingGrid::hasNodeAt(size_t loc, size_t readingLen,
 }
 
 void ReadingGrid::update() {
-  size_t begin =
-      (cursor_ <= kMaximumSpanLength) ? 0 : cursor_ - kMaximumSpanLength;
-  size_t end = cursor_ + kMaximumSpanLength;
+  size_t begin = (cursor_ <= maxSpanLength_) ? 0 : cursor_ - maxSpanLength_;
+  size_t end = cursor_ + maxSpanLength_;
   end = std::min(end, readings_.size());
 
   for (size_t pos = begin; pos < end; pos++) {
-    for (size_t len = 1; len <= kMaximumSpanLength && pos + len <= end; len++) {
+    for (size_t len = 1; len <= maxSpanLength_ && pos + len <= end; len++) {
       std::string combinedReading =
           combineReading(readings_.begin() + static_cast<ptrdiff_t>(pos),
                          readings_.begin() + static_cast<ptrdiff_t>(pos + len));
@@ -419,7 +418,7 @@ std::vector<ReadingGrid::NodeInSpan> ReadingGrid::overlappingNodesAt(
     }
   }
 
-  size_t begin = loc - std::min(loc, kMaximumSpanLength - 1);
+  size_t begin = loc - std::min(loc, maxSpanLength_ - 1);
   for (size_t i = begin; i < loc; ++i) {
     size_t beginLen = loc - i + 1;
     size_t endLen = spans_[i].maxLength();
@@ -541,28 +540,31 @@ std::vector<std::string> ReadingGrid::WalkResult::readingsAsStrings() const {
 }
 
 void ReadingGrid::Span::clear() {
-  nodes_.fill(nullptr);
+  nodes_.clear();
   maxLength_ = 0;
 }
 
 void ReadingGrid::Span::add(const ReadingGrid::NodePtr& node) {
-  assert(node->spanningLength() > 0 &&
-         node->spanningLength() <= kMaximumSpanLength);
-  nodes_[node->spanningLength() - 1] = node;
+  assert(node->spanningLength() > 0);
+  size_t index = node->spanningLength() - 1;
+  if (index >= nodes_.size()) {
+    nodes_.resize(index + 1);
+  }
+  nodes_[index] = node;
   maxLength_ = std::max(maxLength_, node->spanningLength());
 }
 
 void ReadingGrid::Span::removeNodesOfOrLongerThan(size_t length) {
-  assert(length > 0 && length <= kMaximumSpanLength);
-  for (size_t i = length - 1; i < kMaximumSpanLength; ++i) {
+  assert(length > 0);
+  for (size_t i = length - 1; i < nodes_.size(); ++i) {
     nodes_[i] = nullptr;
   }
   maxLength_ = 0;
-  if (length == 1) {
+  if (length == 1 || nodes_.empty()) {
     return;
   }
 
-  size_t i = length - 2;
+  size_t i = std::min(length - 2, nodes_.size() - 1);
   while (true) {
     if (nodes_[i] != nullptr) {
       maxLength_ = i + 1;
@@ -578,7 +580,11 @@ void ReadingGrid::Span::removeNodesOfOrLongerThan(size_t length) {
 }
 
 const ReadingGrid::NodePtr& ReadingGrid::Span::nodeOf(size_t length) const {
-  assert(length > 0 && length <= kMaximumSpanLength);
+  assert(length > 0);
+  static const NodePtr kNullNode = nullptr;
+  if (length - 1 >= nodes_.size()) {
+    return kNullNode;
+  }
   return nodes_[length - 1];
 }
 

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -24,7 +24,6 @@
 #ifndef SRC_ENGINE_GRAMAMBULAR2_READING_GRID_H_
 #define SRC_ENGINE_GRAMAMBULAR2_READING_GRID_H_
 
-#include <array>
 #include <cassert>
 #include <cstdint>
 #include <functional>
@@ -51,8 +50,11 @@ namespace Formosa::Gramambular2 {
 // the maximum likelihood estimation (MLE) for the hidden values.
 class ReadingGrid {
  public:
-  explicit ReadingGrid(std::shared_ptr<LanguageModel> lm)
-      : lm_(std::move(lm)) {}
+  explicit ReadingGrid(std::shared_ptr<LanguageModel> lm) : lm_(std::move(lm)) {
+    size_t lmMaxKeyLength = lm_.maxKeyLength();
+    maxSpanLength_ =
+        lmMaxKeyLength > 0 ? lmMaxKeyLength : kDefaultMaxSpanLength;
+  }
 
   void clear();
 
@@ -75,8 +77,13 @@ class ReadingGrid {
   // Delete the reading after the cursor, like Del. Cursor is unmoved.
   bool deleteReadingAfterCursor();
 
-  static constexpr size_t kMaximumSpanLength = 8;
+  static constexpr size_t kDefaultMaxSpanLength = 8;
   static constexpr char kDefaultSeparator[] = "-";
+
+  // The maximum span length used by this grid. Derived from the language
+  // model's maxKeyLength(), or kDefaultMaxSpanLength if the model does not
+  // report one.
+  [[nodiscard]] size_t maxSpanLength() const { return maxSpanLength_; }
 
   // A Node consists of a set of unigrams, a reading, and a spanning length.
   // The spanning length denotes the length of the node in the grid. The grid
@@ -220,7 +227,7 @@ class ReadingGrid {
     [[nodiscard]] size_t maxLength() const { return maxLength_; }
 
    protected:
-    std::array<NodePtr, kMaximumSpanLength> nodes_;
+    std::vector<NodePtr> nodes_;
     size_t maxLength_ = 0;
   };
 
@@ -233,6 +240,7 @@ class ReadingGrid {
     }
     std::vector<Unigram> getUnigrams(const std::string& reading) override;
     bool hasUnigrams(const std::string& reading) override;
+    size_t maxKeyLength() const override { return lm_->maxKeyLength(); }
 
    protected:
     std::shared_ptr<LanguageModel> lm_;
@@ -246,6 +254,7 @@ class ReadingGrid {
 
  protected:
   size_t cursor_ = 0;
+  size_t maxSpanLength_ = kDefaultMaxSpanLength;
   std::string separator_ = kDefaultSeparator;
   std::vector<std::string> readings_;
   std::vector<Span> spans_;

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -189,13 +189,13 @@ TEST(ReadingGridTest, Span) {
   ASSERT_EQ(span.nodeOf(1), n1);
   ASSERT_EQ(span.nodeOf(2), nullptr);
   ASSERT_EQ(span.nodeOf(3), n3);
-  ASSERT_EQ(span.nodeOf(ReadingGrid::kMaximumSpanLength), nullptr);
+  ASSERT_EQ(span.nodeOf(ReadingGrid::kDefaultMaxSpanLength), nullptr);
   span.clear();
   ASSERT_EQ(span.maxLength(), 0);
   ASSERT_EQ(span.nodeOf(1), nullptr);
   ASSERT_EQ(span.nodeOf(2), nullptr);
   ASSERT_EQ(span.nodeOf(3), nullptr);
-  ASSERT_EQ(span.nodeOf(ReadingGrid::kMaximumSpanLength), nullptr);
+  ASSERT_EQ(span.nodeOf(ReadingGrid::kDefaultMaxSpanLength), nullptr);
 
   span.add(n1);
   span.add(n3);
@@ -208,13 +208,53 @@ TEST(ReadingGridTest, Span) {
   ASSERT_EQ(span.maxLength(), 0);
   ASSERT_EQ(span.nodeOf(1), nullptr);
 
-#ifndef NDEBUG
+  // Spans grow dynamically: lengths beyond kDefaultMaxSpanLength are
+  // supported, and out-of-range lookups return nullptr instead of asserting.
   auto n10 = std::make_shared<ReadingGrid::Node>("", 10, lm.getUnigrams(""));
-  ASSERT_DEATH({ (void)span.add(n10); }, "Assertion");
+  span.add(n10);
+  ASSERT_EQ(span.maxLength(), 10);
+  ASSERT_EQ(span.nodeOf(10), n10);
+  ASSERT_EQ(span.nodeOf(ReadingGrid::kDefaultMaxSpanLength + 1), nullptr);
+  ASSERT_EQ(span.nodeOf(11), nullptr);
+
+#ifndef NDEBUG
   ASSERT_DEATH({ (void)span.nodeOf(0); }, "Assertion");
-  ASSERT_DEATH(
-      { (void)span.nodeOf(ReadingGrid::kMaximumSpanLength + 1); }, "Assertion");
 #endif
+}
+
+TEST(ReadingGridTest, DynamicSpanLength) {
+  class LongKeyLM : public SimpleLM {
+   public:
+    explicit LongKeyLM(const char* input) : SimpleLM(input) {}
+    size_t maxKeyLength() const override { return 10; }
+  };
+
+  constexpr char kLongPhraseData[] = R"(
+ㄧ 一 -2.0
+ㄧ-ㄧ-ㄧ-ㄧ-ㄧ-ㄧ-ㄧ-ㄧ-ㄧ-ㄧ 一一一一一一一一一一 -1.0
+)";
+
+  // A model that reports a 10-syllable maximum key length causes the grid to
+  // accept spans longer than kDefaultMaxSpanLength.
+  ReadingGrid grid(std::make_shared<LongKeyLM>(kLongPhraseData));
+  ASSERT_EQ(grid.maxSpanLength(), 10);
+  for (int i = 0; i < 10; i++) {
+    grid.insertReading("ㄧ");
+  }
+  ReadingGrid::WalkResult result = grid.walk();
+  ASSERT_EQ(result.nodes.size(), 1);
+  ASSERT_EQ(result.nodes[0]->spanningLength(), 10);
+  ASSERT_EQ(result.nodes[0]->value(), "一一一一一一一一一一");
+
+  // A model that does not report a maximum key length gets the default, and
+  // the same input is segmented into shorter nodes.
+  ReadingGrid defaultGrid(std::make_shared<SimpleLM>(kLongPhraseData));
+  ASSERT_EQ(defaultGrid.maxSpanLength(), ReadingGrid::kDefaultMaxSpanLength);
+  for (int i = 0; i < 10; i++) {
+    defaultGrid.insertReading("ㄧ");
+  }
+  ReadingGrid::WalkResult defaultResult = defaultGrid.walk();
+  ASSERT_GT(defaultResult.nodes.size(), 1);
 }
 
 TEST(ReadingGridTest, ScoreRankedLanguageModel) {


### PR DESCRIPTION
## Summary

Replaces the refactor portion of #779, per review feedback there: instead of extracting the walk into a strategy interface, this PR makes the **smallest possible standalone change** — span length becomes dynamic, driven by the language model.

- `Span` storage: fixed `std::array<NodePtr, 8>` → `std::vector` grown on demand
- New `LanguageModel::maxKeyLength()`; returning 0 (the default) keeps today's limit of 8, now named `kDefaultMaxSpanLength`
- `ReadingGrid` derives `maxSpanLength()` from the model at construction; grid window math uses it
- `Span::nodeOf()` keeps the const-reference return from #841 (no shared_ptr copies); out-of-range lookups return a null sentinel instead of asserting

The walk algorithm is **untouched** — no strategy abstraction, no behavioral change to the forward-pass DP from #777.

## Why

This is the enabling refactor for a contextual user model (follow-up PRs): user phrases can exceed 8 syllables, and the grid needs to accept nodes of that length when the model supports them. It is split out so it can be reviewed and verified independently.

## Verification

- All 21 baseline tests pass unchanged; new `DynamicSpanLength` test covers a 10-syllable model vs the default
- Perf guard (8001-reading `StressTest`, 3 runs each): master median **1580µs**, this branch **1499µs** — no regression, identical vertex/edge counts (8001/16001)
- No new files, so no CMake/pbxproj changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)