### PR TITLE
Add ARM NEON support for ParselessPhraseDB

### DIFF
--- a/Source/Engine/CMakeLists.txt
+++ b/Source/Engine/CMakeLists.txt
@@ -143,5 +143,15 @@ if (ENABLE_TEST)
                     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ParselessLMBenchmark
             )
             add_dependencies(runParselessLMBenchmark ParselessLMBenchmark)
+
+            add_executable(ParselessPhraseDBBenchmark
+                    ParselessPhraseDBBenchmark.cpp)
+            target_link_libraries(ParselessPhraseDBBenchmark McBopomofoLMLib benchmark::benchmark)
+
+            add_custom_target(
+                    runParselessPhraseDBBenchmark
+                    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/ParselessPhraseDBBenchmark
+            )
+            add_dependencies(runParselessPhraseDBBenchmark ParselessPhraseDBBenchmark)
         endif ()
 endif ()

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -48,8 +48,10 @@ int LastNonZeroLane16(uint8x16_t value) {
   // value must be a comparison mask whose lanes are either 0x00 or 0xff.
   // Reducing indexed lanes avoids a scalar loop that compilers may expand into
   // up to 16 umov and cbnz branch pairs.
-  const uint8x16_t laneIndices = {1, 2,  3,  4,  5,  6,  7,  8,
-                                  9, 10, 11, 12, 13, 14, 15, 16};
+  alignas(16) static constexpr uint8_t kLaneIndices[16] = {
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+  };
+  const uint8x16_t laneIndices = vld1q_u8(kLaneIndices);
   return static_cast<int>(vmaxvq_u8(vandq_u8(value, laneIndices))) - 1;
 }
 

--- a/Source/Engine/ParselessPhraseDB.cpp
+++ b/Source/Engine/ParselessPhraseDB.cpp
@@ -28,7 +28,60 @@
 #include <string>
 #include <vector>
 
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+
+#include <cstdint>
+#else
+#error ARM NEON support required
+#endif
+#endif
+
 namespace McBopomofo {
+
+namespace {
+
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+
+int LastNonZeroLane16(uint8x16_t value) {
+  // value must be a comparison mask whose lanes are either 0x00 or 0xff.
+  // Reducing indexed lanes avoids a scalar loop that compilers may expand into
+  // up to 16 umov and cbnz branch pairs.
+  const uint8x16_t laneIndices = {1, 2,  3,  4,  5,  6,  7,  8,
+                                  9, 10, 11, 12, 13, 14, 15, 16};
+  return static_cast<int>(vmaxvq_u8(vandq_u8(value, laneIndices))) - 1;
+}
+
+#endif
+
+const char* FindLineStart(const char* begin, const char* position) {
+  const char* cursor = position;
+
+#ifdef ENABLE_EXPERIMENTAL_SIMD_SUPPORT_NEON
+  const uint8x16_t linefeeds = vdupq_n_u8(static_cast<uint8_t>('\n'));
+  while (cursor - begin >= 16) {
+    const char* blockStart = cursor - 16;
+    const uint8x16_t block =
+        vld1q_u8(reinterpret_cast<const uint8_t*>(blockStart));
+    const int positionInBlock = LastNonZeroLane16(vceqq_u8(block, linefeeds));
+    if (positionInBlock >= 0) {
+      return blockStart + positionInBlock + 1;
+    }
+    cursor = blockStart;
+  }
+#endif
+
+  while (cursor != begin) {
+    --cursor;
+    if (*cursor == '\n') {
+      return cursor + 1;
+    }
+  }
+  return begin;
+}
+
+}  // namespace
 
 bool ParselessPhraseDB::ValidatePragma(const char* buf, size_t length) {
   if (length < SORTED_PRAGMA_HEADER.length()) {
@@ -114,20 +167,11 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
 
   while (top < bottom) {
     const char* mid = top + ((bottom - top) / 2);
-    const char* ptr = mid;
-
-    if (ptr != begin_) {
-      --ptr;
-    }
-
-    while (ptr != begin_ && *ptr != '\n') {
-      --ptr;
-    }
+    const char* ptr = FindLineStart(begin_, mid);
 
     const char* prev = nullptr;
-    if (*ptr == '\n') {
-      prev = ptr;
-      ++ptr;
+    if (ptr != begin_) {
+      prev = ptr - 1;
     }
 
     // ptr is now in the "current" line we're interested in.
@@ -153,15 +197,7 @@ const char* ParselessPhraseDB::findFirstMatchingLine(
     }
 
     // Move the prev so that it reaches the previous line.
-    if (prev != begin_) {
-      --prev;
-    }
-    while (prev != begin_ && *prev != '\n') {
-      --prev;
-    }
-    if (*prev == '\n') {
-      ++prev;
-    }
+    prev = FindLineStart(begin_, prev);
 
     int prev_cmp = memcmp(prev, key.data(), key.length());
 

--- a/Source/Engine/ParselessPhraseDBBenchmark.cpp
+++ b/Source/Engine/ParselessPhraseDBBenchmark.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 and onwards The McBopomofo Authors.
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+#include <benchmark/benchmark.h>
+
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ParselessPhraseDB.h"
+
+namespace {
+
+constexpr size_t kRowCount = 65536;
+constexpr size_t kQueryCount = 1024;
+constexpr int kKeyIndexWidth = 5;
+constexpr size_t kMinimumValueLength = 16;
+constexpr size_t kMaximumValueLength = 64;
+
+std::string MakeKey(size_t index) {
+  std::ostringstream stream;
+  stream << "key_" << std::setfill('0') << std::setw(kKeyIndexWidth) << index;
+  return stream.str();
+}
+
+std::string MakeRows() {
+  std::ostringstream stream;
+  for (size_t i = 0; i < kRowCount; ++i) {
+    const size_t valueLength =
+        kMinimumValueLength +
+        i % (kMaximumValueLength - kMinimumValueLength + 1);
+    stream << MakeKey(i) << ' ' << std::string(valueLength, 'v') << '\n';
+  }
+  return stream.str();
+}
+
+std::vector<std::string> MakeQueryKeys() {
+  std::vector<std::string> keys;
+  keys.reserve(kQueryCount);
+
+  // Fixed seed so benchmark runs search the same uniformly distributed rows
+  std::mt19937 random(std::mt19937::default_seed);
+  std::uniform_int_distribution<size_t> rowIndex(0, kRowCount - 1);
+  for (size_t i = 0; i < kQueryCount; ++i) {
+    keys.emplace_back(MakeKey(rowIndex(random)));
+  }
+  return keys;
+}
+
+class BenchmarkDataset {
+ public:
+  BenchmarkDataset()
+      : rows_(MakeRows()),
+        database_(rows_.data(), rows_.size()),
+        queryKeys_(MakeQueryKeys()) {}
+
+  const McBopomofo::ParselessPhraseDB& database() const { return database_; }
+  const std::vector<std::string>& queryKeys() const { return queryKeys_; }
+
+ private:
+  std::string rows_;
+  McBopomofo::ParselessPhraseDB database_;
+  std::vector<std::string> queryKeys_;
+};
+
+void BM_ParselessPhraseDBFindFirstMatchingLine(benchmark::State& state) {
+  const BenchmarkDataset dataset;
+  const auto& database = dataset.database();
+  const auto& queryKeys = dataset.queryKeys();
+
+  auto queryKey = queryKeys.begin();
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(database.findFirstMatchingLine(*queryKey));
+    if (++queryKey == queryKeys.end()) {
+      queryKey = queryKeys.begin();
+    }
+  }
+}
+BENCHMARK(BM_ParselessPhraseDBFindFirstMatchingLine);
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/Source/Engine/ParselessPhraseDBTest.cpp
+++ b/Source/Engine/ParselessPhraseDBTest.cpp
@@ -120,6 +120,21 @@ TEST(ParselessPhraseDBTest, FindFirstMatchingLineLongerExample) {
   EXPECT_EQ(first, nullptr);
 }
 
+TEST(ParselessPhraseDBTest, FindFirstMatchingLineWithLongRows) {
+  // Use long rows to verify line-start lookup across multiple 16-byte blocks
+  std::string data = "a " + std::string(127, 'a') + "\n";
+  const size_t firstBOffset = data.size();
+  data += "b " + std::string(255, 'b') + "\n";
+  data += "b " + std::string(63, 'c') + "\n";
+  const size_t cOffset = data.size();
+  data += "c " + std::string(511, 'd');
+  ParselessPhraseDB db(data.c_str(), data.length());
+
+  EXPECT_EQ(db.findFirstMatchingLine("b"), data.data() + firstBOffset);
+  EXPECT_EQ(db.findFirstMatchingLine("c"), data.data() + cOffset);
+  EXPECT_EQ(db.findFirstMatchingLine("d"), nullptr);
+}
+
 TEST(ParselessPhraseDBTest, InvalidConstructorArguments) {
 #ifdef NDEBUG
   GTEST_SKIP();


### PR DESCRIPTION
This is a follow-up to PR #794. It improves phrase database lookup performance by introducing ARM NEON SIMD support for locating line boundaries during binary search.

`ParselessPhraseDB` performs binary search directly over the serialized phrase database. Since each midpoint may land anywhere within a row, the search must first scan backward to find the preceding newline before comparing the row's key. The new NEON path examines 16 bytes at a time while searching for that newline.

## Performance

- MacBook Air M2

### Without SIMD

```
Note: Google Test filter = ParselessPhraseDBTest.StressTest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ParselessPhraseDBTest
[ RUN      ] ParselessPhraseDBTest.StressTest
[       OK ] ParselessPhraseDBTest.StressTest (151 ms)
[----------] 1 test from ParselessPhraseDBTest (151 ms total)
```

```
Running ./ParselessPhraseDBBenchmark
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 1.95, 2.00, 2.19
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_ParselessPhraseDBFindFirstMatchingLine        307 ns          307 ns      2277408
```

### With NEON

```
Note: Google Test filter = ParselessPhraseDBTest.StressTest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ParselessPhraseDBTest
[ RUN      ] ParselessPhraseDBTest.StressTest
[       OK ] ParselessPhraseDBTest.StressTest (128 ms)
[----------] 1 test from ParselessPhraseDBTest (128 ms total)
```

```
Running ./ParselessPhraseDBBenchmark
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 1.68, 2.05, 2.23
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_ParselessPhraseDBFindFirstMatchingLine        178 ns          178 ns      3841932
```

---

分享一下關於 `LastNonZeroLane16`，剛開始是參考 `ByteBlockBackedDictionary` 的 `FirstNonZeroLane16` 寫成這樣：

```cpp
int LastNonZeroLane16(uint8x16_t value) {
  if (vmaxvq_u8(value) == 0) {
    return -1;
  }

  alignas(16) uint8_t lanes[16];
  vst1q_u8(lanes, value);
  for (int i = 15; i >= 0; --i) {
    if (lanes[i] != 0) {
      return i;
    }
  }
  return -1;
}
```

```
Running ./ParselessPhraseDBBenchmark
Run on (8 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x8)
Load Average: 2.79, 2.16, 2.21
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_ParselessPhraseDBFindFirstMatchingLine        226 ns          226 ns      2976089
```

發現 benchmark 雖然有變快，但感覺速度不應該只提升這樣?! 看了一下組語，發現迴圈被編譯器展開成 16 組 `umov + cbnz`。由於每列長度不同，換行符號可能出現在任何 SIMD lane，這些分支或許很難被 branch predictor 穩定預測。

<img src="https://github.com/user-attachments/assets/3d92229b-efdf-4b3b-b0b8-c42e1d3ea399" />
<br><br>

後來改成將比較產生的 mask 與 `{1, 2, ..., 16}` lane index vector 做 `vandq_u8`，再執行一次 `vmaxvq_u8`。最大值減一就是最後命中的 lane index，沒有命中時也會得到 `-1`，因此可以避免原本的 scalar branches。

可能有點 tricky，所以稍微舉個例子。假設目前反向搜尋的 16-byte block 長這樣：
| index |  0   |  1   |  2   |  3   |  4   |  5   |  6   |  7   |  8   |  9   |  10  |  11  |  12  |  13  |  14  |  15  |
| :--------- | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |
| content       |  a   |  b   |  \n  |  c   |  d   |  e   |  f   |  \n  |  g   |  h   |  i   |  j   |  k   |  l   |  m   |  n   |

我們要找最後一個換行，因此答案應該是 lane 7。`vceqq_u8` 比較後，命中的 lane 會是 `0xff`，其他是 `0x00`：
| mask | 0 | 0 | 0xff | 0 | 0 | 0 | 0 | 0xff | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
| indices | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 |

兩者執行 `vandq_u8`：
| masked indices |  0   |  0   |  3   |  0   |  0   |  0   |  0   |  8   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |
| :------------- | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |

再使用 `vmaxvq_u8` 取得所有 lane 中的最大值，再減一，就得到 8 - 1 = 7。

---

如果完全沒有換行：
| masked indices |  0   |  0   |  0  |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |  0   |
| :------------- | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: | :--: |

`vmaxvq_u8` 結果為 0，這也是為什麼 lane index vector 故意用 `{1, ..., 16}` 而非 `{0, ..., 15}`，就是要讓它自然產生 0 - 1 = -1 的效果 XDD