### PR TITLE
Create simple apps that only contains the candidate window and the tooltip to help UI development

### DIFF
--- a/Packages/CandidateUI/Package.swift
+++ b/Packages/CandidateUI/Package.swift
@@ -8,7 +8,11 @@ let package = Package(
     products: [
         .library(
             name: "CandidateUI",
-            targets: ["CandidateUI"])
+            targets: ["CandidateUI"]),
+        .executable(
+            name: "CandidatePreview",
+            targets: ["CandidatePreview"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,6 +24,10 @@ let package = Package(
         .target(
             name: "CandidateUI",
             dependencies: []),
+        .executableTarget(
+            name: "CandidatePreview",
+            dependencies: ["CandidateUI"]
+        ),
         .testTarget(
             name: "CandidateUITests",
             dependencies: ["CandidateUI"]),

--- a/Packages/CandidateUI/Sources/CandidatePreview/CandidatePreview.swift
+++ b/Packages/CandidateUI/Sources/CandidatePreview/CandidatePreview.swift
@@ -1,0 +1,221 @@
+import Cocoa
+import CandidateUI
+
+typealias Candidate = (candidate: String, reading: String)
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    lazy var horizontal: HorizontalCandidateController = .init()
+    lazy var vertical: VerticalCandidateController = .init()
+    var candidates: [Candidate]  = []
+    let simpleCandidates: [Candidate] = [
+        ("天", "ㄊㄧㄢ"),
+        ("生", "ㄕㄥ"),
+        ("我", "ㄨㄛˇ"),
+        ("才", "ㄘㄞˊ"),
+        ("必", "ㄅㄧˋ"),
+        ("有", "ㄧㄡˇ"),
+        ("用", "ㄩㄥˋ"),
+    ]
+
+    let longCandidates: [Candidate] = [
+        ("天", "ㄊㄧㄢ"),
+        ("生", "ㄕㄥ"),
+        ("我", "ㄨㄛˇ"),
+        ("才", "ㄘㄞˊ"),
+        ("必", "ㄅㄧˋ"),
+        ("有", "ㄧㄡˇ"),
+        ("用", "ㄩㄥˋ"),
+        ("千", "ㄑㄧㄢ"),
+        ("金", "ㄐㄧㄣ"),
+        ("散", "ㄙㄢˋ"),
+        ("盡", "ㄐㄧㄣˋ"),
+    ]
+
+    var location: NSPoint {
+        var point = NSPoint(x: 100, y: 100)
+        if let screen = NSScreen.main {
+            let frame = screen.visibleFrame
+            point = NSPoint(x: frame.minX + 300, y: frame.maxY - 20)
+        }
+        return point
+    }
+
+    @objc
+    func showHorizontal() {
+        vertical.visible = false
+        horizontal.tooltip = ""
+        candidates = simpleCandidates
+        horizontal.reloadData()
+        horizontal
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        horizontal.visible = true
+    }
+
+    @objc
+    func showHorizontalWithPages() {
+        vertical.visible = false
+        horizontal.tooltip = ""
+        candidates = longCandidates
+        horizontal.reloadData()
+        horizontal
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        horizontal.visible = true
+    }
+
+    @objc
+    func showHorizontalWithTooltip() {
+        vertical.visible = false
+        horizontal.tooltip = "將進酒"
+        candidates = longCandidates
+        horizontal.reloadData()
+        horizontal
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        horizontal.visible = true
+    }
+
+    @objc
+    func showVertical() {
+        horizontal.visible = false
+        vertical.tooltip = ""
+        candidates = simpleCandidates
+        vertical.reloadData()
+        vertical
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        vertical.visible = true
+    }
+
+    @objc
+    func showVerticalWithPages() {
+        horizontal.visible = false
+        vertical.tooltip = ""
+        candidates = longCandidates
+        vertical.reloadData()
+        vertical
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        vertical.visible = true
+    }
+
+    @objc
+    func showVerticalWithTooltip() {
+        horizontal.visible = false
+        vertical.tooltip = "將進酒"
+        candidates = longCandidates
+        vertical.reloadData()
+        vertical
+            .set(windowTopLeftPoint: location, bottomOutOfScreenAdjustmentHeight: 0)
+        vertical.visible = true
+    }
+
+    @objc
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+        horizontal.delegate = self
+        vertical.delegate = self
+
+        // Create a minimal menu so the app can quit.
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+
+        let appMenu = NSMenu()
+        var item = NSMenuItem(
+            title: "Show Horizontal Candidates (Simple)",
+            action: #selector(showHorizontal),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        item = NSMenuItem(
+            title: "Show Horizontal Candidates (Paged)",
+            action: #selector(showHorizontalWithPages),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        item = NSMenuItem(
+            title: "Show Horizontal Candidates (Tooltip)",
+            action: #selector(showHorizontalWithTooltip),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        appMenu.addItem(NSMenuItem.separator())
+
+        item = NSMenuItem(
+            title: "Show Vertical Candidates (Simple)",
+            action: #selector(showVertical),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        item = NSMenuItem(
+            title: "Show Vertical Candidates (Paged)",
+            action: #selector(showVerticalWithPages),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        item = NSMenuItem(
+            title: "Show Vertical Candidates (Tooltip)",
+            action: #selector(showVerticalWithTooltip),
+            keyEquivalent: ""
+        )
+        item.target = self
+        appMenu.addItem(item)
+
+        appMenu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(title: "Quit TooltipDemoApp", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenu.addItem(quitItem)
+        appMenuItem.submenu = appMenu
+        app.mainMenu = mainMenu
+
+        app.activate(ignoringOtherApps: true)
+        showHorizontal()
+    }
+}
+
+
+extension AppDelegate: CandidateControllerDelegate {
+
+    func candidateCountForController(_ controller: CandidateUI.CandidateController) -> UInt {
+        UInt(candidates.count)
+    }
+
+    func candidateController(_ controller: CandidateUI.CandidateController, candidateAtIndex index: UInt) -> String {
+        candidates[Int(index)].candidate
+    }
+
+    func candidateController(_ controller: CandidateUI.CandidateController, readingAtIndex index: UInt) -> String? {
+        candidates[Int(index)].candidate
+    }
+
+    func candidateController(_ controller: CandidateUI.CandidateController, requestExplanationFor candidate: String, reading: String) -> String? {
+        nil
+    }
+
+    func candidateController(
+        _ controller: CandidateUI.CandidateController,
+        didSelectCandidateAtIndex index: UInt
+    ) {
+    }
+
+}
+
+let delegate = AppDelegate()
+
+@main
+struct TooltipPreviewMain {
+    static func main() {
+        let app = NSApplication.shared
+        app.delegate = delegate
+        app.run()
+    }
+}
+

--- a/Packages/TooltipUI/Package.swift
+++ b/Packages/TooltipUI/Package.swift
@@ -1,25 +1,36 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "TooltipUI",
+    platforms: [
+        .macOS(.v10_15)
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "TooltipUI",
-            targets: ["TooltipUI"]),
+            targets: ["TooltipUI"]
+        ),
+        .executable(
+            name: "TooltipPreview",
+            targets: ["TooltipPreview"]
+        )
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "TooltipUI",
-            dependencies: []),
+            dependencies: []
+        ),
+        .executableTarget(
+            name: "TooltipPreview",
+            dependencies: ["TooltipUI"]
+        ),
     ]
 )

--- a/Packages/TooltipUI/Sources/TooltipPreview/TooltipPreview.swift
+++ b/Packages/TooltipUI/Sources/TooltipPreview/TooltipPreview.swift
@@ -1,0 +1,79 @@
+import Cocoa
+import TooltipUI
+
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    private var tooltipController: TooltipController?
+
+    var tooltipLocation: NSPoint {
+        var point = NSPoint(x: 100, y: 100)
+        if let screen = NSScreen.main {
+            let frame = screen.visibleFrame
+            point = NSPoint(x: frame.minX + 300, y: frame.maxY - 20)
+        }
+        return point
+    }
+
+    var text = "Hello, World!"
+
+    @objc func showTooltip() {
+        tooltipController?.show(tooltip: text, at: tooltipLocation)
+    }
+
+    @objc func hideTooltip() {
+        tooltipController?.hide()
+    }
+
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let app = NSApplication.shared
+        app.setActivationPolicy(.regular)
+
+        let controller = TooltipController()
+        self.tooltipController = controller
+
+        // Create a minimal menu so the app can quit.
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+
+        let appMenu = NSMenu()
+        let showItem = NSMenuItem(
+            title: "Show Tooltip",
+            action: #selector(showTooltip),
+            keyEquivalent: ""
+        )
+        showItem.target = self
+        appMenu.addItem(showItem)
+        let hideItem = NSMenuItem(
+            title: "Hide Tooltip",
+            action: #selector(hideTooltip),
+            keyEquivalent: ""
+        )
+        hideItem.target = self
+        appMenu.addItem(hideItem)
+        appMenu.addItem(NSMenuItem.separator())
+
+        let quitItem = NSMenuItem(title: "Quit TooltipDemoApp", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenu.addItem(quitItem)
+        appMenuItem.submenu = appMenu
+        app.mainMenu = mainMenu
+
+        app.activate(ignoringOtherApps: true)
+        showTooltip()
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+}
+
+let delegate = AppDelegate()
+
+@main
+struct TooltipPreviewMain {
+    static func main() {
+        let app = NSApplication.shared
+        app.delegate = delegate
+        app.run()
+    }
+}


### PR DESCRIPTION
The PR add two simple Mac App build target. One app has only one simple candidate window while another has only one tooltip window.

The PR helps developers to apply new UI design easily. When a developer modifies the UI, he or she can just run these simple apps, but not to kill the input method application and run it again. 