### PR TITLE
feat(input): prefer exact phrase matches for full input

### DIFF
--- a/McBopomofoTests/PreferencesTests.swift
+++ b/McBopomofoTests/PreferencesTests.swift
@@ -193,11 +193,11 @@ final class PreferencesTests {
         #expect(Preferences.phraseReplacementEnabled == true)
     }
 
-    @Test("Test standalone phrase boundary toggle")
-    func testStandalonePhraseBoundaryEnabledKey() {
-        #expect(Preferences.standalonePhraseBoundaryEnabled == false)
-        Preferences.standalonePhraseBoundaryEnabled = true
-        #expect(Preferences.standalonePhraseBoundaryEnabled == true)
+    @Test("Test prefer exact phrase match for full input toggle")
+    func testPreferExactPhraseMatchForFullInputKey() {
+        #expect(Preferences.preferExactPhraseMatchForFullInput == false)
+        Preferences.preferExactPhraseMatchForFullInput = true
+        #expect(Preferences.preferExactPhraseMatchForFullInput == true)
     }
 
     @Test("Test Chinese conversion style setting")

--- a/McBopomofoTests/PreferencesTests.swift
+++ b/McBopomofoTests/PreferencesTests.swift
@@ -193,6 +193,13 @@ final class PreferencesTests {
         #expect(Preferences.phraseReplacementEnabled == true)
     }
 
+    @Test("Test standalone phrase boundary toggle")
+    func testStandalonePhraseBoundaryEnabledKey() {
+        #expect(Preferences.standalonePhraseBoundaryEnabled == false)
+        Preferences.standalonePhraseBoundaryEnabled = true
+        #expect(Preferences.standalonePhraseBoundaryEnabled == true)
+    }
+
     @Test("Test Chinese conversion style setting")
     func testChineseConversionStyle() {
         #expect(Preferences.chineseConversionStyle == .output)

--- a/McBopomofoTests/ServiceProviderTests.swift
+++ b/McBopomofoTests/ServiceProviderTests.swift
@@ -148,6 +148,26 @@ final class ServiceProviderTests {
         #expect(output == expected, "\(output)")
     }
 
+    @Test("Test Unicode Taiwanese Braille service respects exact phrase preference")
+    func testConvertUnicodeBrailleToChineseRespectsExactPhrasePreference() {
+        LanguageModelManager.loadDataModels()
+        let previousValue = Preferences.preferExactPhraseMatchForFullInput
+        defer {
+            Preferences.preferExactPhraseMatchForFullInput = previousValue
+        }
+
+        let provider = ServiceProvider()
+        let helper = ServiceProviderInputHelper()
+        provider.delegate = helper as? any ServiceProviderDelegate
+        let input = provider.convertToUnicodeBraille(string: "字彙")
+
+        Preferences.preferExactPhraseMatchForFullInput = false
+        #expect(provider.convertUnicodeBrailleToChineseText(string: input) == "自會")
+
+        Preferences.preferExactPhraseMatchForFullInput = true
+        #expect(provider.convertUnicodeBrailleToChineseText(string: input) == "字彙")
+    }
+
     @Test(
         "Test coverting Chinese to Unicode Taiwanese Braille, then coverting it back",
         arguments: [

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="401" y="295" width="475" height="567"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1050"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1129"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="475" height="567"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -108,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhe-DC-FkH">
-                    <rect key="frame" x="232" y="526" width="127" height="24"/>
+                    <rect key="frame" x="232" y="526" width="126" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="Standard" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="PTu-Ks-u1l" id="tPE-G4-rho">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -128,7 +128,7 @@
                     </popUpButtonCell>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iZs-U3-CJx">
-                    <rect key="frame" x="232" y="96" width="225" height="16"/>
+                    <rect key="frame" x="232" y="72" width="225" height="16"/>
                     <buttonCell key="cell" type="check" title="ESC key clears entire input buffer" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="04m-pr-CAi">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -154,7 +154,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3oc-Wl-pem">
-                    <rect key="frame" x="93" y="224" width="128" height="16"/>
+                    <rect key="frame" x="93" y="192" width="128" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Candidate Text Size:" id="X0q-Fl-zzQ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -186,8 +186,16 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="o5T-Km-VhT"/>
                     </connections>
                 </matrix>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HzV-qQ-eeF">
+                    <rect key="frame" x="67" y="228" width="154" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Composition Preference:" id="zFa-xQ-S5v">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AvT-mU-HNg">
-                    <rect key="frame" x="232" y="217" width="65" height="24"/>
+                    <rect key="frame" x="232" y="184" width="64" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="64X-UF-Vz6" id="Bsy-hs-5q4">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -212,7 +220,7 @@
                     <rect key="frame" x="20" y="475" width="438" height="5"/>
                 </box>
                 <box horizontalHuggingPriority="234" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Frc-9z-VZe">
-                    <rect key="frame" x="20" y="206" width="445" height="5"/>
+                    <rect key="frame" x="20" y="217" width="445" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9MN-II-LQm">
                     <rect key="frame" x="232" y="339" width="188" height="16"/>
@@ -225,7 +233,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Sp0-2u-7hi">
-                    <rect key="frame" x="101" y="178" width="120" height="16"/>
+                    <rect key="frame" x="101" y="154" width="120" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Letter Keys:" id="ZFO-C0-adO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -233,7 +241,7 @@
                     </textFieldCell>
                 </textField>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s4T-Mw-U2e">
-                    <rect key="frame" x="232" y="156" width="227" height="38"/>
+                    <rect key="frame" x="232" y="132" width="227" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="227" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -258,7 +266,7 @@
                     </connections>
                 </matrix>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIg-XJ-f3T">
-                    <rect key="frame" x="162" y="96" width="59" height="16"/>
+                    <rect key="frame" x="162" y="72" width="59" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC Key:" id="Apl-bu-Zdz">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -291,7 +299,7 @@
                     </connections>
                 </matrix>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="cRR-T6-aMw">
-                    <rect key="frame" x="232" y="57" width="155" height="16"/>
+                    <rect key="frame" x="232" y="50" width="155" height="16"/>
                     <buttonCell key="cell" type="check" title="Beep upon input error" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="rnd-fr-0dm">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -300,8 +308,18 @@
                         <binding destination="32" name="value" keyPath="values.BeepUponInputError" id="2WY-u6-KOB"/>
                     </connections>
                 </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="N8x-cP-kh4">
+                    <rect key="frame" x="232" y="228" width="219" height="16"/>
+                    <buttonCell key="cell" type="check" title="Prefer full-input phrase matches" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="p8m-Bi-eyO">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="32" name="value" keyPath="values.StandalonePhraseBoundaryEnabled" id="D2F-z6-bYt"/>
+                    </connections>
+                </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PLL-ab-6cC">
-                    <rect key="frame" x="232" y="130" width="186" height="16"/>
+                    <rect key="frame" x="232" y="106" width="186" height="16"/>
                     <buttonCell key="cell" type="check" title="Trigger associated phrases" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="AOR-n6-Tmp">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -311,7 +329,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsc-GH-nO2">
-                    <rect key="frame" x="112" y="130" width="109" height="16"/>
+                    <rect key="frame" x="112" y="106" width="109" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter Key:" id="H9E-f1-tBt">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -344,7 +362,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="7dj-MJ-a2i">
-                    <rect key="frame" x="232" y="35" width="218" height="16"/>
+                    <rect key="frame" x="232" y="28" width="218" height="16"/>
                     <buttonCell key="cell" type="check" title="Check for updates automatically" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="W90-DF-5t4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -356,10 +374,10 @@
             </subviews>
             <constraints>
                 <constraint firstItem="1UT-Vk-jJp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="0ca-cg-IAA"/>
-                <constraint firstItem="3oc-Wl-pem" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="336" id="2cD-oj-DlN"/>
+                <constraint firstItem="3oc-Wl-pem" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="368" id="2cD-oj-DlN"/>
                 <constraint firstItem="fxC-25-09x" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="175" id="3SJ-Fn-eib"/>
                 <constraint firstItem="1UT-Vk-jJp" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="26" id="42B-kq-pgX"/>
-                <constraint firstItem="7dj-MJ-a2i" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="525" id="5P9-NO-dim"/>
+                <constraint firstItem="7dj-MJ-a2i" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="532" id="5P9-NO-dim"/>
                 <constraint firstAttribute="trailing" secondItem="MdX-1s-2eC" secondAttribute="trailing" constant="260" id="5hv-cM-NF4"/>
                 <constraint firstItem="9MN-II-LQm" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="221" id="Ayo-7o-LYd"/>
                 <constraint firstItem="7dj-MJ-a2i" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="BTe-U7-wJ5"/>
@@ -367,9 +385,9 @@
                 <constraint firstItem="3oc-Wl-pem" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="CfI-Jq-SdE"/>
                 <constraint firstAttribute="trailing" secondItem="Sp0-2u-7hi" secondAttribute="trailing" constant="259" id="Hk0-AG-WCk"/>
                 <constraint firstItem="eBz-xC-fkE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="IqU-Kt-Ffk"/>
-                <constraint firstItem="cRR-T6-aMw" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="503" id="KKY-Bb-0gf"/>
+                <constraint firstItem="cRR-T6-aMw" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="510" id="KKY-Bb-0gf"/>
                 <constraint firstAttribute="trailing" secondItem="buv-Na-btc" secondAttribute="trailing" constant="259" id="LuQ-5P-IQz"/>
-                <constraint firstItem="Frc-9z-VZe" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="367" id="Mn4-98-Han"/>
+                <constraint firstItem="Frc-9z-VZe" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="356" id="Mn4-98-Han"/>
                 <constraint firstAttribute="trailing" secondItem="YIg-XJ-f3T" secondAttribute="trailing" constant="259" id="NJd-ji-8IG"/>
                 <constraint firstItem="Nma-j4-skB" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="NQs-yF-LmL"/>
                 <constraint firstItem="Pdz-c8-G89" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="NhX-mv-3Te"/>
@@ -382,35 +400,41 @@
                 <constraint firstItem="Pdz-c8-G89" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="288" id="SEE-A0-Yfo"/>
                 <constraint firstItem="AvT-mU-HNg" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="SQV-SI-7Cn"/>
                 <constraint firstAttribute="trailing" secondItem="cb1-du-5Jn" secondAttribute="trailing" constant="30" id="SgJ-Zi-CjY"/>
-                <constraint firstItem="Sp0-2u-7hi" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="382" id="U6b-vk-tOq"/>
+                <constraint firstItem="Sp0-2u-7hi" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="406" id="U6b-vk-tOq"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7dj-MJ-a2i" secondAttribute="trailing" constant="20" symbolic="YES" id="UrK-L8-3Fu"/>
                 <constraint firstItem="8Kb-9o-Czh" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="117" id="WmT-5P-YsF"/>
                 <constraint firstItem="PLL-ab-6cC" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="XMw-VC-jc4"/>
+                <constraint firstItem="N8x-cP-kh4" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="Y77-vm-dng"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="N8x-cP-kh4" secondAttribute="trailing" constant="20" symbolic="YES" id="YYS-dJ-O1S"/>
                 <constraint firstItem="wIs-KO-qx1" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="YhM-cY-5CA"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PLL-ab-6cC" secondAttribute="trailing" constant="20" symbolic="YES" id="Z1c-v0-1WL"/>
                 <constraint firstAttribute="trailing" secondItem="dsc-GH-nO2" secondAttribute="trailing" constant="259" id="ZR5-WY-KYs"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Nma-j4-skB" secondAttribute="trailing" constant="20" symbolic="YES" id="aKG-v6-Ldu"/>
                 <constraint firstItem="wIs-KO-qx1" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="98" id="cW1-Ki-9JJ"/>
                 <constraint firstItem="MdX-1s-2eC" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="249" id="cmR-uY-ec2"/>
-                <constraint firstItem="PLL-ab-6cC" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="430" id="dHa-QZ-e55"/>
+                <constraint firstItem="PLL-ab-6cC" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="454" id="dHa-QZ-e55"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xg9-aU-XIb" secondAttribute="trailing" constant="20" symbolic="YES" id="eUr-jT-cWw"/>
+                <constraint firstItem="N8x-cP-kh4" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="332" id="eol-nj-Fuu"/>
                 <constraint firstItem="buv-Na-btc" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="117" id="f3c-rM-AlB"/>
                 <constraint firstItem="JFW-qA-UTv" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="64" id="f6b-2z-sgR"/>
                 <constraint firstItem="cb1-du-5Jn" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="60" id="g01-IF-OR6"/>
                 <constraint firstAttribute="trailing" secondItem="JFW-qA-UTv" secondAttribute="trailing" constant="259" id="g9U-Gl-mme"/>
                 <constraint firstAttribute="trailing" secondItem="wIs-KO-qx1" secondAttribute="trailing" constant="20" symbolic="YES" id="gDy-0U-zDc"/>
                 <constraint firstItem="MdX-1s-2eC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="jBX-1G-xmI"/>
-                <constraint firstItem="s4T-Mw-U2e" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="382" id="jRl-Os-TT9"/>
+                <constraint firstItem="s4T-Mw-U2e" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="406" id="jRl-Os-TT9"/>
                 <constraint firstItem="fxC-25-09x" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="jk1-xz-5FH"/>
+                <constraint firstAttribute="trailing" secondItem="HzV-qQ-eeF" secondAttribute="trailing" constant="259" id="jpy-s2-aCT"/>
+                <constraint firstItem="HzV-qQ-eeF" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="jqx-f4-6Tu"/>
                 <constraint firstItem="bhe-DC-FkH" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="kiT-R5-IqA"/>
                 <constraint firstAttribute="trailing" secondItem="eBz-xC-fkE" secondAttribute="trailing" constant="258" id="lZz-qL-6Cr"/>
-                <constraint firstItem="iZs-U3-CJx" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="464" id="mIO-44-Zdl"/>
+                <constraint firstItem="iZs-U3-CJx" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="488" id="mIO-44-Zdl"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bhe-DC-FkH" secondAttribute="trailing" constant="20" symbolic="YES" id="mPn-QS-GQe"/>
-                <constraint firstItem="dsc-GH-nO2" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="430" id="pQJ-RA-vgZ"/>
+                <constraint firstItem="dsc-GH-nO2" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="454" id="pQJ-RA-vgZ"/>
                 <constraint firstAttribute="trailing" secondItem="1UT-Vk-jJp" secondAttribute="trailing" constant="259" id="ptA-MP-Z5s"/>
                 <constraint firstItem="9Hh-po-xMG" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="175" id="qgW-D6-q8x"/>
                 <constraint firstItem="9Hh-po-xMG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="r86-2S-vUl"/>
                 <constraint firstItem="buv-Na-btc" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="rnb-c5-r9g"/>
+                <constraint firstItem="HzV-qQ-eeF" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="332" id="rso-i8-yc3"/>
                 <constraint firstItem="Nma-j4-skB" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="149" id="sCh-n7-8gl"/>
                 <constraint firstItem="9MN-II-LQm" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="uOk-2Q-k19"/>
                 <constraint firstItem="YIg-XJ-f3T" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="uiQ-jj-zBe"/>
@@ -423,12 +447,12 @@
                 <constraint firstItem="eBz-xC-fkE" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="288" id="wWJ-y8-5Hx"/>
                 <constraint firstItem="cRR-T6-aMw" firstAttribute="leading" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="232" id="wrw-lI-UUc"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9MN-II-LQm" secondAttribute="trailing" constant="20" symbolic="YES" id="xQ5-dN-2I2"/>
-                <constraint firstItem="AvT-mU-HNg" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="335" id="xRI-op-lAj"/>
+                <constraint firstItem="AvT-mU-HNg" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="368" id="xRI-op-lAj"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cRR-T6-aMw" secondAttribute="trailing" constant="20" symbolic="YES" id="y32-al-DLi"/>
                 <constraint firstItem="dsc-GH-nO2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="YEO-Nr-Xri" secondAttribute="leading" constant="20" symbolic="YES" id="y3p-To-eik"/>
                 <constraint firstItem="xg9-aU-XIb" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="250" id="y6Y-x7-gyl"/>
                 <constraint firstItem="bhe-DC-FkH" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="26" id="ybM-KD-4bn"/>
-                <constraint firstItem="YIg-XJ-f3T" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="464" id="ynS-rH-fd4"/>
+                <constraint firstItem="YIg-XJ-f3T" firstAttribute="top" secondItem="YEO-Nr-Xri" secondAttribute="top" constant="488" id="ynS-rH-fd4"/>
             </constraints>
             <point key="canvasLocation" x="-410.5" y="-333"/>
         </view>
@@ -470,7 +494,7 @@
                     </connections>
                 </matrix>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NGh-Dn-Qpf">
-                    <rect key="frame" x="246" y="226" width="124" height="16"/>
+                    <rect key="frame" x="247" y="210" width="123" height="32"/>
                     <buttonCell key="cell" type="check" title="Input Big 5 Code" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="9wE-js-xtM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>

--- a/Source/Base.lproj/preferences.xib
+++ b/Source/Base.lproj/preferences.xib
@@ -315,7 +315,7 @@
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="32" name="value" keyPath="values.StandalonePhraseBoundaryEnabled" id="D2F-z6-bYt"/>
+                        <binding destination="32" name="value" keyPath="values.PreferExactPhraseMatchForFullInput" id="D2F-z6-bYt"/>
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PLL-ab-6cC">

--- a/Source/Engine/UserOverrideModelTest.cpp
+++ b/Source/Engine/UserOverrideModelTest.cpp
@@ -21,7 +21,9 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 // OTHER DEALINGS IN THE SOFTWARE.
 
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "UserOverrideModel.h"
 #include "gtest/gtest.h"
@@ -117,6 +119,57 @@ TEST(UserOverrideModelTest, LRUBehavior) {
   // def evicted.
   v = uom.suggest("def", kFakeNow + kHalflife * 7);
   ASSERT_TRUE(v.empty());
+}
+
+TEST(UserOverrideModelTest, RemembersExactPhraseReplacement) {
+  class TestLM : public Formosa::Gramambular2::LanguageModel {
+   public:
+    std::vector<Unigram> getUnigrams(const std::string& reading) override {
+      if (reading == "zi") {
+        return {Unigram("自", -2.75471392), Unigram("字", -3.40268807)};
+      }
+      if (reading == "hui") {
+        return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
+      }
+      if (reading == "zi-hui") {
+        return {Unigram("字彙", -5.86913810),
+                Unigram("自會", -6.48892685)};
+      }
+      return {};
+    }
+
+    bool hasUnigrams(const std::string& reading) override {
+      return reading == "zi" || reading == "hui" || reading == "zi-hui";
+    }
+  };
+
+  using Formosa::Gramambular2::ReadingGrid;
+
+  UserOverrideModel uom(kCapacity, kHalflife);
+  auto languageModel = std::make_shared<TestLM>();
+
+  ReadingGrid observedGrid(languageModel);
+  observedGrid.setPreferExactPhraseMatchForFullInput(true);
+  ASSERT_TRUE(observedGrid.insertReading("zi"));
+  ASSERT_TRUE(observedGrid.insertReading("hui"));
+  ReadingGrid::WalkResult beforeOverride = observedGrid.walk();
+  ASSERT_EQ(beforeOverride.valuesAsStrings(), (std::vector<std::string>{"字彙"}));
+
+  ASSERT_TRUE(observedGrid.overrideCandidate(
+      1, ReadingGrid::Candidate("zi-hui", "自會")));
+  ReadingGrid::WalkResult afterOverride = observedGrid.walk();
+  ASSERT_EQ(afterOverride.valuesAsStrings(), (std::vector<std::string>{"自會"}));
+  uom.observe(beforeOverride, afterOverride, 1, kFakeNow);
+
+  ReadingGrid queryGrid(languageModel);
+  queryGrid.setPreferExactPhraseMatchForFullInput(true);
+  ASSERT_TRUE(queryGrid.insertReading("zi"));
+  ASSERT_TRUE(queryGrid.insertReading("hui"));
+  ReadingGrid::WalkResult exactWalk = queryGrid.walk();
+  ASSERT_EQ(exactWalk.valuesAsStrings(), (std::vector<std::string>{"字彙"}));
+
+  UserOverrideModel::Suggestion suggestion = uom.suggest(exactWalk, 1, kFakeNow);
+  ASSERT_EQ(suggestion.candidate, "自會");
 }
 
 }  // namespace McBopomofo

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -205,7 +205,8 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   // When the whole composing buffer is itself a known phrase, prefer that
   // phrase. Once the same phrase is only part of a longer buffer, normal lattice
   // scoring applies. Explicit user overrides still take precedence.
-  if (!hasOverriddenNode && readingLen > 1 && readingLen <= kMaximumSpanLength) {
+  if (standalonePhraseBoundaryEnabled_ && !hasOverriddenNode && readingLen > 1 &&
+      readingLen <= kMaximumSpanLength) {
     const ReadingGrid::NodePtr& standalonePhrase = spans_[0].nodeOf(readingLen);
     if (standalonePhrase != nullptr) {
       result.nodes = {standalonePhrase};

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -205,8 +205,8 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   // When the whole composing buffer is itself a known phrase, prefer that
   // phrase. Once the same phrase is only part of a longer buffer, normal lattice
   // scoring applies. Explicit user overrides still take precedence.
-  if (preferExactPhraseMatchForFullInput_ && !hasOverriddenNode && readingLen > 1 &&
-      readingLen <= kMaximumSpanLength) {
+  if (preferExactPhraseMatchForFullInput_ && !hasOverriddenNode &&
+      readingLen > 1 && readingLen <= kMaximumSpanLength) {
     const ReadingGrid::NodePtr& fullInputPhrase = spans_[0].nodeOf(readingLen);
     if (fullInputPhrase != nullptr) {
       result.nodes = {fullInputPhrase};

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -120,6 +120,19 @@ int64_t GetEpochNowInMicroseconds() {
   return timestamp;
 }
 
+bool HasOverriddenNode(const std::vector<ReadingGrid::Span>& spans) {
+  for (const ReadingGrid::Span& span : spans) {
+    const size_t maxSpanLen = span.maxLength();
+    for (size_t spanLen = 1; spanLen <= maxSpanLen; ++spanLen) {
+      const ReadingGrid::NodePtr& node = span.nodeOf(spanLen);
+      if (node != nullptr && node->isOverridden()) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 }  // namespace
 
 // Find the weightiest path in the grid graph. The path represents the most
@@ -137,6 +150,22 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   }
   int64_t start = GetEpochNowInMicroseconds();
 
+  const size_t readingLen = readings_.size();
+  // When the whole composing buffer is itself a known phrase, prefer that
+  // phrase before running Viterbi. Once the same phrase is only part of a
+  // longer buffer, normal lattice scoring applies. Explicit user overrides
+  // still take precedence.
+  if (preferExactPhraseMatchForFullInput_ && readingLen > 1 &&
+      readingLen <= kMaximumSpanLength) {
+    const ReadingGrid::NodePtr& fullInputPhrase = spans_[0].nodeOf(readingLen);
+    if (fullInputPhrase != nullptr && !HasOverriddenNode(spans_)) {
+      result.nodes = {fullInputPhrase};
+      result.totalReadings = fullInputPhrase->spanningLength();
+      result.elapsedMicroseconds = GetEpochNowInMicroseconds() - start;
+      return result;
+    }
+  }
+
   // Defines a state in the DP table. This structure tracks the maximum
   // accumulated score and the back-pointer required for path reconstruction in
   // the Viterbi algorithm.
@@ -146,7 +175,6 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
     double maxScore = -std::numeric_limits<double>::infinity();
   };
 
-  const size_t readingLen = readings_.size();
   std::vector<State> viterbi(readingLen + 1);
   viterbi[0].maxScore = 0.0;
 
@@ -198,21 +226,6 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   std::reverse(result.nodes.begin(), result.nodes.end());
   assert(totalReadingLen == readingLen);
   result.totalReadings = totalReadingLen;
-
-  const bool hasOverriddenNode = std::any_of(
-      result.nodes.begin(), result.nodes.end(),
-      [](const ReadingGrid::NodePtr& node) { return node->isOverridden(); });
-  // When the whole composing buffer is itself a known phrase, prefer that
-  // phrase. Once the same phrase is only part of a longer buffer, normal lattice
-  // scoring applies. Explicit user overrides still take precedence.
-  if (preferExactPhraseMatchForFullInput_ && !hasOverriddenNode &&
-      readingLen > 1 && readingLen <= kMaximumSpanLength) {
-    const ReadingGrid::NodePtr& fullInputPhrase = spans_[0].nodeOf(readingLen);
-    if (fullInputPhrase != nullptr) {
-      result.nodes = {fullInputPhrase};
-      result.totalReadings = fullInputPhrase->spanningLength();
-    }
-  }
 
   result.elapsedMicroseconds = GetEpochNowInMicroseconds() - start;
   return result;

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -199,6 +199,20 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   assert(totalReadingLen == readingLen);
   result.totalReadings = totalReadingLen;
 
+  const bool hasOverriddenNode = std::any_of(
+      result.nodes.begin(), result.nodes.end(),
+      [](const ReadingGrid::NodePtr& node) { return node->isOverridden(); });
+  // When the whole composing buffer is itself a known phrase, prefer that
+  // phrase. Once the same phrase is only part of a longer buffer, normal lattice
+  // scoring applies. Explicit user overrides still take precedence.
+  if (!hasOverriddenNode && readingLen > 1 && readingLen <= kMaximumSpanLength) {
+    const ReadingGrid::NodePtr& standalonePhrase = spans_[0].nodeOf(readingLen);
+    if (standalonePhrase != nullptr) {
+      result.nodes = {standalonePhrase};
+      result.totalReadings = standalonePhrase->spanningLength();
+    }
+  }
+
   result.elapsedMicroseconds = GetEpochNowInMicroseconds() - start;
   return result;
 }

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -205,12 +205,12 @@ ReadingGrid::WalkResult ReadingGrid::walk() {
   // When the whole composing buffer is itself a known phrase, prefer that
   // phrase. Once the same phrase is only part of a longer buffer, normal lattice
   // scoring applies. Explicit user overrides still take precedence.
-  if (standalonePhraseBoundaryEnabled_ && !hasOverriddenNode && readingLen > 1 &&
+  if (preferExactPhraseMatchForFullInput_ && !hasOverriddenNode && readingLen > 1 &&
       readingLen <= kMaximumSpanLength) {
-    const ReadingGrid::NodePtr& standalonePhrase = spans_[0].nodeOf(readingLen);
-    if (standalonePhrase != nullptr) {
-      result.nodes = {standalonePhrase};
-      result.totalReadings = standalonePhrase->spanningLength();
+    const ReadingGrid::NodePtr& fullInputPhrase = spans_[0].nodeOf(readingLen);
+    if (fullInputPhrase != nullptr) {
+      result.nodes = {fullInputPhrase};
+      result.totalReadings = fullInputPhrase->spanningLength();
     }
   }
 

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -66,6 +66,14 @@ class ReadingGrid {
 
   void setReadingSeparator(const std::string& separator);
 
+  [[nodiscard]] bool standalonePhraseBoundaryEnabled() const {
+    return standalonePhraseBoundaryEnabled_;
+  }
+
+  void setStandalonePhraseBoundaryEnabled(bool enabled) {
+    standalonePhraseBoundaryEnabled_ = enabled;
+  }
+
   bool insertReading(const std::string& reading);
 
   // Delete the reading before the cursor, like Backspace. Cursor will decrement
@@ -250,6 +258,7 @@ class ReadingGrid {
   std::vector<std::string> readings_;
   std::vector<Span> spans_;
   ScoreRankedLanguageModel lm_;
+  bool standalonePhraseBoundaryEnabled_ = false;
 
   // Internal methods for maintaining the grid.
 

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -66,12 +66,12 @@ class ReadingGrid {
 
   void setReadingSeparator(const std::string& separator);
 
-  [[nodiscard]] bool standalonePhraseBoundaryEnabled() const {
-    return standalonePhraseBoundaryEnabled_;
+  [[nodiscard]] bool preferExactPhraseMatchForFullInput() const {
+    return preferExactPhraseMatchForFullInput_;
   }
 
-  void setStandalonePhraseBoundaryEnabled(bool enabled) {
-    standalonePhraseBoundaryEnabled_ = enabled;
+  void setPreferExactPhraseMatchForFullInput(bool enabled) {
+    preferExactPhraseMatchForFullInput_ = enabled;
   }
 
   bool insertReading(const std::string& reading);
@@ -258,7 +258,7 @@ class ReadingGrid {
   std::vector<std::string> readings_;
   std::vector<Span> spans_;
   ScoreRankedLanguageModel lm_;
-  bool standalonePhraseBoundaryEnabled_ = false;
+  bool preferExactPhraseMatchForFullInput_ = false;
 
   // Internal methods for maintaining the grid.
 

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -291,11 +291,42 @@ TEST(ReadingGridTest, StandalonePhrasePrefersWholeInputPhrase) {
   };
 
   ReadingGrid grid(std::make_shared<TestLM>());
+  grid.setStandalonePhraseBoundaryEnabled(true);
   ASSERT_TRUE(grid.insertReading("zi"));
   ASSERT_TRUE(grid.insertReading("hui"));
 
   ReadingGrid::WalkResult result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"字彙"}));
+}
+
+TEST(ReadingGridTest, StandalonePhraseBoundaryCanBeDisabled) {
+  class TestLM : public LanguageModel {
+   public:
+    std::vector<Unigram> getUnigrams(const std::string& reading) override {
+      if (reading == "zi") {
+        return {Unigram("自", -2.75471392), Unigram("字", -3.40268807)};
+      }
+      if (reading == "hui") {
+        return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
+      }
+      if (reading == "zi-hui") {
+        return {Unigram("字彙", -5.86892118)};
+      }
+      return {};
+    }
+
+    bool hasUnigrams(const std::string& reading) override {
+      return reading == "zi" || reading == "hui" || reading == "zi-hui";
+    }
+  };
+
+  ReadingGrid grid(std::make_shared<TestLM>());
+  ASSERT_FALSE(grid.standalonePhraseBoundaryEnabled());
+  ASSERT_TRUE(grid.insertReading("zi"));
+  ASSERT_TRUE(grid.insertReading("hui"));
+
+  ReadingGrid::WalkResult result = grid.walk();
+  ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"自", "會"}));
 }
 
 TEST(ReadingGridTest, StandalonePhraseDoesNotBoostPrefixInLongerInput) {
@@ -324,6 +355,7 @@ TEST(ReadingGridTest, StandalonePhraseDoesNotBoostPrefixInLongerInput) {
   };
 
   ReadingGrid grid(std::make_shared<TestLM>());
+  grid.setStandalonePhraseBoundaryEnabled(true);
   ASSERT_TRUE(grid.insertReading("zi"));
   ASSERT_TRUE(grid.insertReading("hui"));
   ASSERT_TRUE(grid.insertReading("zai"));

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -269,7 +269,7 @@ TEST(ReadingGridTest, BasicOperations) {
   ASSERT_EQ(grid.spans().size(), 0);
 }
 
-TEST(ReadingGridTest, StandalonePhrasePrefersWholeInputPhrase) {
+TEST(ReadingGridTest, PreferExactPhraseMatchForFullInput) {
   class TestLM : public LanguageModel {
    public:
     std::vector<Unigram> getUnigrams(const std::string& reading) override {
@@ -291,7 +291,7 @@ TEST(ReadingGridTest, StandalonePhrasePrefersWholeInputPhrase) {
   };
 
   ReadingGrid grid(std::make_shared<TestLM>());
-  grid.setStandalonePhraseBoundaryEnabled(true);
+  grid.setPreferExactPhraseMatchForFullInput(true);
   ASSERT_TRUE(grid.insertReading("zi"));
   ASSERT_TRUE(grid.insertReading("hui"));
 
@@ -299,7 +299,7 @@ TEST(ReadingGridTest, StandalonePhrasePrefersWholeInputPhrase) {
   ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"字彙"}));
 }
 
-TEST(ReadingGridTest, StandalonePhraseBoundaryCanBeDisabled) {
+TEST(ReadingGridTest, PreferExactPhraseMatchForFullInputCanBeDisabled) {
   class TestLM : public LanguageModel {
    public:
     std::vector<Unigram> getUnigrams(const std::string& reading) override {
@@ -321,7 +321,7 @@ TEST(ReadingGridTest, StandalonePhraseBoundaryCanBeDisabled) {
   };
 
   ReadingGrid grid(std::make_shared<TestLM>());
-  ASSERT_FALSE(grid.standalonePhraseBoundaryEnabled());
+  ASSERT_FALSE(grid.preferExactPhraseMatchForFullInput());
   ASSERT_TRUE(grid.insertReading("zi"));
   ASSERT_TRUE(grid.insertReading("hui"));
 
@@ -329,7 +329,7 @@ TEST(ReadingGridTest, StandalonePhraseBoundaryCanBeDisabled) {
   ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"自", "會"}));
 }
 
-TEST(ReadingGridTest, StandalonePhraseDoesNotBoostPrefixInLongerInput) {
+TEST(ReadingGridTest, ExactPhraseMatchDoesNotBoostPrefixInLongerInput) {
   class TestLM : public LanguageModel {
    public:
     std::vector<Unigram> getUnigrams(const std::string& reading) override {
@@ -355,7 +355,7 @@ TEST(ReadingGridTest, StandalonePhraseDoesNotBoostPrefixInLongerInput) {
   };
 
   ReadingGrid grid(std::make_shared<TestLM>());
-  grid.setStandalonePhraseBoundaryEnabled(true);
+  grid.setPreferExactPhraseMatchForFullInput(true);
   ASSERT_TRUE(grid.insertReading("zi"));
   ASSERT_TRUE(grid.insertReading("hui"));
   ASSERT_TRUE(grid.insertReading("zai"));

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -269,6 +269,70 @@ TEST(ReadingGridTest, BasicOperations) {
   ASSERT_EQ(grid.spans().size(), 0);
 }
 
+TEST(ReadingGridTest, StandalonePhrasePrefersWholeInputPhrase) {
+  class TestLM : public LanguageModel {
+   public:
+    std::vector<Unigram> getUnigrams(const std::string& reading) override {
+      if (reading == "zi") {
+        return {Unigram("自", -2.75471392), Unigram("字", -3.40268807)};
+      }
+      if (reading == "hui") {
+        return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
+      }
+      if (reading == "zi-hui") {
+        return {Unigram("字彙", -5.86892118)};
+      }
+      return {};
+    }
+
+    bool hasUnigrams(const std::string& reading) override {
+      return reading == "zi" || reading == "hui" || reading == "zi-hui";
+    }
+  };
+
+  ReadingGrid grid(std::make_shared<TestLM>());
+  ASSERT_TRUE(grid.insertReading("zi"));
+  ASSERT_TRUE(grid.insertReading("hui"));
+
+  ReadingGrid::WalkResult result = grid.walk();
+  ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"字彙"}));
+}
+
+TEST(ReadingGridTest, StandalonePhraseDoesNotBoostPrefixInLongerInput) {
+  class TestLM : public LanguageModel {
+   public:
+    std::vector<Unigram> getUnigrams(const std::string& reading) override {
+      if (reading == "zi") {
+        return {Unigram("自", -2.75471392), Unigram("字", -3.40268807)};
+      }
+      if (reading == "hui") {
+        return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
+      }
+      if (reading == "zai") {
+        return {Unigram("在", -1.0)};
+      }
+      if (reading == "zi-hui") {
+        return {Unigram("字彙", -5.86892118)};
+      }
+      return {};
+    }
+
+    bool hasUnigrams(const std::string& reading) override {
+      return reading == "zi" || reading == "hui" || reading == "zai" ||
+             reading == "zi-hui";
+    }
+  };
+
+  ReadingGrid grid(std::make_shared<TestLM>());
+  ASSERT_TRUE(grid.insertReading("zi"));
+  ASSERT_TRUE(grid.insertReading("hui"));
+  ASSERT_TRUE(grid.insertReading("zai"));
+
+  ReadingGrid::WalkResult result = grid.walk();
+  ASSERT_EQ(result.valuesAsStrings(),
+            (std::vector<std::string>{"自", "會", "在"}));
+}
+
 TEST(ReadingGridTest, InvalidOperations) {
   class TestLM : public LanguageModel {
    public:

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -280,7 +280,7 @@ TEST(ReadingGridTest, PreferExactPhraseMatchForFullInput) {
         return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
       }
       if (reading == "zi-hui") {
-        return {Unigram("字彙", -5.86892118)};
+        return {Unigram("字彙", -5.86913810)};
       }
       return {};
     }
@@ -310,7 +310,7 @@ TEST(ReadingGridTest, PreferExactPhraseMatchForFullInputCanBeDisabled) {
         return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
       }
       if (reading == "zi-hui") {
-        return {Unigram("字彙", -5.86892118)};
+        return {Unigram("字彙", -5.86913810)};
       }
       return {};
     }
@@ -343,7 +343,7 @@ TEST(ReadingGridTest, ExactPhraseMatchDoesNotBoostPrefixInLongerInput) {
         return {Unigram("在", -1.0)};
       }
       if (reading == "zi-hui") {
-        return {Unigram("字彙", -5.86892118)};
+        return {Unigram("字彙", -5.86913810)};
       }
       return {};
     }
@@ -363,6 +363,40 @@ TEST(ReadingGridTest, ExactPhraseMatchDoesNotBoostPrefixInLongerInput) {
   ReadingGrid::WalkResult result = grid.walk();
   ASSERT_EQ(result.valuesAsStrings(),
             (std::vector<std::string>{"自", "會", "在"}));
+}
+
+TEST(ReadingGridTest, PreferExactPhraseMatchForFullInputRespectsOverride) {
+  class TestLM : public LanguageModel {
+   public:
+    std::vector<Unigram> getUnigrams(const std::string& reading) override {
+      if (reading == "zi") {
+        return {Unigram("自", -2.75471392), Unigram("字", -3.40268807)};
+      }
+      if (reading == "hui") {
+        return {Unigram("會", -2.42504751), Unigram("彙", -4.69631935)};
+      }
+      if (reading == "zi-hui") {
+        return {Unigram("字彙", -5.86913810),
+                Unigram("自會", -6.48892685)};
+      }
+      return {};
+    }
+
+    bool hasUnigrams(const std::string& reading) override {
+      return reading == "zi" || reading == "hui" || reading == "zi-hui";
+    }
+  };
+
+  ReadingGrid grid(std::make_shared<TestLM>());
+  grid.setPreferExactPhraseMatchForFullInput(true);
+  ASSERT_TRUE(grid.insertReading("zi"));
+  ASSERT_TRUE(grid.insertReading("hui"));
+  ASSERT_TRUE(grid.overrideCandidate(
+      0, ReadingGrid::Candidate("zi-hui", "自會"),
+      ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram));
+
+  ReadingGrid::WalkResult result = grid.walk();
+  ASSERT_EQ(result.valuesAsStrings(), (std::vector<std::string>{"自", "會"}));
 }
 
 TEST(ReadingGridTest, InvalidOperations) {

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -525,15 +525,45 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         }
 
         _grid->insertReading(reading);
-        [self _walk];
 
-        // get user override model suggestion
-        if (_inputMode != InputModePlainBopomofo) {
-            McBopomofo::UserOverrideModel::Suggestion suggestion = _userOverrideModel->suggest(_latestWalk, self.actualCandidateCursorIndex, [NSDate date].timeIntervalSince1970);
+        BOOL shouldCheckUserOverrideModel = _inputMode != InputModePlainBopomofo;
+        BOOL shouldUseExactPhraseMatchForFullInput = Preferences.preferExactPhraseMatchForFullInput;
+        if (shouldCheckUserOverrideModel && shouldUseExactPhraseMatchForFullInput) {
+            _grid->setPreferExactPhraseMatchForFullInput(true);
+            Formosa::Gramambular2::ReadingGrid::WalkResult exactMatchWalk = _grid->walk();
+
+            _grid->setPreferExactPhraseMatchForFullInput(false);
+            Formosa::Gramambular2::ReadingGrid::WalkResult viterbiWalk = _grid->walk();
+
+            double timestamp = [NSDate date].timeIntervalSince1970;
+            // Try the exact path first for same-reading phrase replacements,
+            // then fall back to the Viterbi path for split-word corrections.
+            McBopomofo::UserOverrideModel::Suggestion suggestion =
+                _userOverrideModel->suggest(exactMatchWalk, self.actualCandidateCursorIndex, timestamp);
+            BOOL suggestionFromExactMatchWalk = !suggestion.empty();
+            if (suggestion.empty()) {
+                suggestion = _userOverrideModel->suggest(viterbiWalk, self.actualCandidateCursorIndex, timestamp);
+            }
+
             if (!suggestion.empty()) {
-                Formosa::Gramambular2::ReadingGrid::Node::OverrideType type = suggestion.forceHighScoreOverride ? Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore : Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram;
+                // An exact-path suggestion disables the exact shortcut once it
+                // becomes an override, so it needs to survive Viterbi scoring.
+                BOOL shouldForceHighScoreOverride = suggestion.forceHighScoreOverride || suggestionFromExactMatchWalk;
+                Formosa::Gramambular2::ReadingGrid::Node::OverrideType type = shouldForceHighScoreOverride ? Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore : Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram;
                 _grid->overrideCandidate(self.actualCandidateCursorIndex, suggestion.candidate, type);
-                [self _walk];
+            }
+            [self _walk];
+        } else {
+            [self _walk];
+
+            // get user override model suggestion
+            if (shouldCheckUserOverrideModel) {
+                McBopomofo::UserOverrideModel::Suggestion suggestion = _userOverrideModel->suggest(_latestWalk, self.actualCandidateCursorIndex, [NSDate date].timeIntervalSince1970);
+                if (!suggestion.empty()) {
+                    Formosa::Gramambular2::ReadingGrid::Node::OverrideType type = suggestion.forceHighScoreOverride ? Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithHighScore : Formosa::Gramambular2::ReadingGrid::Node::OverrideType::kOverrideValueWithScoreFromTopUnigram;
+                    _grid->overrideCandidate(self.actualCandidateCursorIndex, suggestion.candidate, type);
+                    [self _walk];
+                }
             }
         }
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -2484,7 +2484,8 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
 - (void)_walk
 {
-    _grid->setPreferExactPhraseMatchForFullInput(Preferences.preferExactPhraseMatchForFullInput);
+    _grid->setPreferExactPhraseMatchForFullInput(
+        Preferences.preferExactPhraseMatchForFullInput);
     _latestWalk = _grid->walk();
 }
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -2484,7 +2484,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
 - (void)_walk
 {
-    _grid->setStandalonePhraseBoundaryEnabled(Preferences.standalonePhraseBoundaryEnabled);
+    _grid->setPreferExactPhraseMatchForFullInput(Preferences.preferExactPhraseMatchForFullInput);
     _latestWalk = _grid->walk();
 }
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -2484,6 +2484,7 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
 
 - (void)_walk
 {
+    _grid->setStandalonePhraseBoundaryEnabled(Preferences.standalonePhraseBoundaryEnabled);
     _latestWalk = _grid->walk();
 }
 

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -49,6 +49,7 @@ private let kAllowMovingCursorWhenChoosingCandidates = "AllowMovingCursorWhenCho
 private let kPhraseReplacementEnabledKey = "PhraseReplacementEnabled"
 private let kChineseConversionStyleKey = "ChineseConversionStyle"
 private let kAssociatedPhrasesEnabledKey = "AssociatedPhrasesEnabled"
+private let kStandalonePhraseBoundaryEnabledKey = "StandalonePhraseBoundaryEnabled"
 private let kLetterBehaviorKey = "LetterBehavior"
 private let kControlEnterOutputKey = "ControlEnterOutput"
 private let kShiftEnterEnabledKey = "ShiftEnterEnabled"
@@ -230,6 +231,7 @@ class Preferences: NSObject {
             kPhraseReplacementEnabledKey,
             kChineseConversionStyleKey,
             kAssociatedPhrasesEnabledKey,
+            kStandalonePhraseBoundaryEnabledKey,
             kControlEnterOutputKey,
             kShiftEnterEnabledKey,
             kRepeatedPunctuationToSelectCandidateEnabledKey,
@@ -255,6 +257,7 @@ class Preferences: NSObject {
         Preferences.chineseConversionStyle = Preferences.chineseConversionStyle
         Preferences.phraseReplacementEnabled = Preferences.phraseReplacementEnabled
         Preferences.associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
+        Preferences.standalonePhraseBoundaryEnabled = Preferences.standalonePhraseBoundaryEnabled
         Preferences.letterBehavior = Preferences.letterBehavior
         Preferences.controlEnterOutput = Preferences.controlEnterOutput
         Preferences.shiftEnterEnabled = Preferences.shiftEnterEnabled
@@ -443,6 +446,9 @@ extension Preferences {
 
     @UserDefault(key: kAssociatedPhrasesEnabledKey, defaultValue: false)
     @objc static var associatedPhrasesEnabled: Bool
+
+    @UserDefault(key: kStandalonePhraseBoundaryEnabledKey, defaultValue: false)
+    @objc static var standalonePhraseBoundaryEnabled: Bool
 
     @objc static func toggleAssociatedPhrasesEnabled() -> Bool {
         associatedPhrasesEnabled = !associatedPhrasesEnabled
@@ -645,6 +651,9 @@ extension Preferences {
         )
         lines.append(
             "  - Associated Phrases (McBopomofo): \(Preferences.associatedPhrasesEnabled ? "Enabled" : "Disabled")"
+        )
+        lines.append(
+            "  - Standalone Phrase Boundary: \(Preferences.standalonePhraseBoundaryEnabled ? "Enabled" : "Disabled")"
         )
         lines.append(
             "  - Associated Phrases (Plain Bopomofo): \(Preferences.enableUserPhrasesInPlainBopomofo ? "Enabled" : "Disabled")"

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -49,7 +49,7 @@ private let kAllowMovingCursorWhenChoosingCandidates = "AllowMovingCursorWhenCho
 private let kPhraseReplacementEnabledKey = "PhraseReplacementEnabled"
 private let kChineseConversionStyleKey = "ChineseConversionStyle"
 private let kAssociatedPhrasesEnabledKey = "AssociatedPhrasesEnabled"
-private let kStandalonePhraseBoundaryEnabledKey = "StandalonePhraseBoundaryEnabled"
+private let kPreferExactPhraseMatchForFullInputKey = "PreferExactPhraseMatchForFullInput"
 private let kLetterBehaviorKey = "LetterBehavior"
 private let kControlEnterOutputKey = "ControlEnterOutput"
 private let kShiftEnterEnabledKey = "ShiftEnterEnabled"
@@ -231,7 +231,7 @@ class Preferences: NSObject {
             kPhraseReplacementEnabledKey,
             kChineseConversionStyleKey,
             kAssociatedPhrasesEnabledKey,
-            kStandalonePhraseBoundaryEnabledKey,
+            kPreferExactPhraseMatchForFullInputKey,
             kControlEnterOutputKey,
             kShiftEnterEnabledKey,
             kRepeatedPunctuationToSelectCandidateEnabledKey,
@@ -257,7 +257,7 @@ class Preferences: NSObject {
         Preferences.chineseConversionStyle = Preferences.chineseConversionStyle
         Preferences.phraseReplacementEnabled = Preferences.phraseReplacementEnabled
         Preferences.associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
-        Preferences.standalonePhraseBoundaryEnabled = Preferences.standalonePhraseBoundaryEnabled
+        Preferences.preferExactPhraseMatchForFullInput = Preferences.preferExactPhraseMatchForFullInput
         Preferences.letterBehavior = Preferences.letterBehavior
         Preferences.controlEnterOutput = Preferences.controlEnterOutput
         Preferences.shiftEnterEnabled = Preferences.shiftEnterEnabled
@@ -447,8 +447,8 @@ extension Preferences {
     @UserDefault(key: kAssociatedPhrasesEnabledKey, defaultValue: false)
     @objc static var associatedPhrasesEnabled: Bool
 
-    @UserDefault(key: kStandalonePhraseBoundaryEnabledKey, defaultValue: false)
-    @objc static var standalonePhraseBoundaryEnabled: Bool
+    @UserDefault(key: kPreferExactPhraseMatchForFullInputKey, defaultValue: false)
+    @objc static var preferExactPhraseMatchForFullInput: Bool
 
     @objc static func toggleAssociatedPhrasesEnabled() -> Bool {
         associatedPhrasesEnabled = !associatedPhrasesEnabled
@@ -653,7 +653,7 @@ extension Preferences {
             "  - Associated Phrases (McBopomofo): \(Preferences.associatedPhrasesEnabled ? "Enabled" : "Disabled")"
         )
         lines.append(
-            "  - Standalone Phrase Boundary: \(Preferences.standalonePhraseBoundaryEnabled ? "Enabled" : "Disabled")"
+            "  - Prefer Exact Phrase Match for Full Input: \(Preferences.preferExactPhraseMatchForFullInput ? "Enabled" : "Disabled")"
         )
         lines.append(
             "  - Associated Phrases (Plain Bopomofo): \(Preferences.enableUserPhrasesInPlainBopomofo ? "Enabled" : "Disabled")"

--- a/Source/ServiceProviderInputHelper.mm
+++ b/Source/ServiceProviderInputHelper.mm
@@ -71,6 +71,8 @@
 
 - (NSString * _Nonnull)serviceProviderDidRequestCommitting:(ServiceProvider * _Nonnull)provider 
 {
+    _grid->setPreferExactPhraseMatchForFullInput(
+        Preferences.preferExactPhraseMatchForFullInput);
     Formosa::Gramambular2::ReadingGrid::WalkResult _latestWalk = _grid->walk();
     std::string output;
     for (const auto& node : _latestWalk.nodes) {

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,7 +28,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="489" y="334" width="433" height="575"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1050"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1129"/>
             <view key="contentView" id="2">
                 <rect key="frame" x="0.0" y="0.0" width="433" height="575"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -98,7 +98,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-hI-9WY">
-                    <rect key="frame" x="65" y="205" width="105" height="16"/>
+                    <rect key="frame" x="65" y="181" width="105" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="選字窗文字大小：" id="Rqe-kZ-F9v">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -131,7 +131,7 @@
                     </connections>
                 </matrix>
                 <popUpButton verticalHuggingPriority="751" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YF3-dA-BAc">
-                    <rect key="frame" x="181" y="197" width="107" height="25"/>
+                    <rect key="frame" x="181" y="172" width="107" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="18" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="18" imageScaling="proportionallyDown" inset="2" selectedItem="lvY-bs-FFU" id="EI9-WJ-zQC">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -187,7 +187,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KOq-SU-0dw">
-                    <rect key="frame" x="184" y="93" width="210" height="16"/>
+                    <rect key="frame" x="184" y="70" width="210" height="16"/>
                     <buttonCell key="cell" type="check" title="按下 ESC 會清除整個輸入緩衝區" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lGd-Af-8ly">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -205,14 +205,14 @@
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="pjw-8M-CEh">
-                    <rect key="frame" x="20" y="230" width="396" height="5"/>
+                    <rect key="frame" x="20" y="206" width="396" height="5"/>
                 </box>
                 <box horizontalHuggingPriority="249" verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uuQ-a9-JKn">
-                    <rect key="frame" x="20" y="445" width="256" height="5"/>
+                    <rect key="frame" x="20" y="445" width="396" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qLt-o2-oPl">
-                    <rect key="frame" x="191" y="317" width="177" height="16"/>
-                    <buttonCell key="cell" type="check" title="選字之後自動移動游標位置" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jlf-jk-hJY">
+                    <rect key="frame" x="184" y="317" width="177" height="16"/>
+                    <buttonCell key="cell" type="check" title="選字之後自動移動游標位置" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="jlf-jk-hJY">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -221,7 +221,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sMU-k1-QG3">
-                    <rect key="frame" x="73" y="168" width="96" height="16"/>
+                    <rect key="frame" x="73" y="144" width="96" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + 字母鍵：" id="v98-LJ-zGS">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -229,7 +229,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IxA-64-q7d">
-                    <rect key="frame" x="114" y="94" width="56" height="16"/>
+                    <rect key="frame" x="114" y="70" width="56" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="ESC 鍵：" id="q86-sV-OE5">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -261,8 +261,16 @@
                         <binding destination="32" name="selectedTag" keyPath="values.UseHorizontalCandidateList" id="IRV-VT-5Ou"/>
                     </connections>
                 </matrix>
+                <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rgP-HS-mVQ">
+                    <rect key="frame" x="104" y="217" width="66" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="組字偏好：" id="pxv-kA-c2c">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="oya-hD-nIE">
-                    <rect key="frame" x="184" y="56" width="151" height="16"/>
+                    <rect key="frame" x="184" y="48" width="151" height="16"/>
                     <buttonCell key="cell" type="check" title="輸入錯誤時發出警示聲" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="N4o-lx-RYS">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -271,8 +279,18 @@
                         <binding destination="32" name="value" keyPath="values.BeepUponInputError" id="8RI-ft-Hgg"/>
                     </connections>
                 </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="m5q-92-0BV">
+                    <rect key="frame" x="184" y="217" width="229" height="16"/>
+                    <buttonCell key="cell" type="check" title="輸入完整符合已知詞時優先顯示該詞" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="9aK-hg-E2J">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="32" name="value" keyPath="values.StandalonePhraseBoundaryEnabled" id="Pdx-tH-DyY"/>
+                    </connections>
+                </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hvF-32-Zw1">
-                    <rect key="frame" x="184" y="34" width="139" height="16"/>
+                    <rect key="frame" x="184" y="26" width="139" height="16"/>
                     <buttonCell key="cell" type="check" title="定期檢查是否有新版" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="k9r-ii-fdD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -282,7 +300,7 @@
                     </connections>
                 </button>
                 <matrix verticalHuggingPriority="750" tag="1" allowsEmptySelection="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bc3-oU-EWC">
-                    <rect key="frame" x="184" y="146" width="199" height="38"/>
+                    <rect key="frame" x="184" y="122" width="199" height="38"/>
                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     <size key="cellSize" width="199" height="18"/>
                     <size key="intercellSpacing" width="4" height="2"/>
@@ -307,8 +325,8 @@
                     </connections>
                 </matrix>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tDv-b3-Mrm">
-                    <rect key="frame" x="186" y="121" width="113" height="16"/>
-                    <buttonCell key="cell" type="check" title="使用聯想詞功能" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jXH-Sv-SCM">
+                    <rect key="frame" x="184" y="97" width="113" height="16"/>
+                    <buttonCell key="cell" type="check" title="使用聯想詞功能" bezelStyle="regularSquare" imagePosition="left" alignment="left" state="on" inset="2" id="jXH-Sv-SCM">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -320,7 +338,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DoZ-iC-eqs">
-                    <rect key="frame" x="63" y="122" width="106" height="16"/>
+                    <rect key="frame" x="63" y="98" width="106" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Shift + Enter 鍵：" id="Nl4-BO-gM9">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -339,7 +357,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IHs-uV-EyH">
-                    <rect key="frame" x="184" y="283" width="176" height="24"/>
+                    <rect key="frame" x="184" y="283" width="175" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="不使用" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="eGy-zp-bhw" id="8kw-Sg-bV9">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -365,8 +383,8 @@
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="42V-Bi-KIT"/>
                 <constraint firstItem="sMU-k1-QG3" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="75" id="4Gd-VR-LGd"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KRC-Qj-X94" secondAttribute="trailing" constant="20" symbolic="YES" id="4In-SP-Pd3"/>
-                <constraint firstItem="KOq-SU-0dw" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="417" id="6Ru-Ut-7B2"/>
-                <constraint firstItem="Bc3-oU-EWC" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="342" id="74r-s5-xtV"/>
+                <constraint firstItem="KOq-SU-0dw" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="440" id="6Ru-Ut-7B2"/>
+                <constraint firstItem="Bc3-oU-EWC" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="366" id="74r-s5-xtV"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="KRC-Qj-X94" secondAttribute="trailing" constant="-1" id="9Ic-Y6-yXH"/>
                 <constraint firstItem="YWl-mS-2Wx" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="43" id="Cg1-Dw-Abj"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YF3-dA-BAc" secondAttribute="trailing" constant="20" symbolic="YES" id="Ct2-om-mnr"/>
@@ -374,31 +392,32 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qLt-o2-oPl" secondAttribute="trailing" constant="20" symbolic="YES" id="EEe-W9-qXU"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="0tK-14-8hw" secondAttribute="trailing" constant="-1" id="Fxu-L4-1tn"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oya-hD-nIE" secondAttribute="trailing" constant="20" symbolic="YES" id="G6F-dh-syY"/>
-                <constraint firstAttribute="trailing" secondItem="qLt-o2-oPl" secondAttribute="trailing" constant="68" id="GTh-kw-ZeN"/>
+                <constraint firstItem="qLt-o2-oPl" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="GTh-kw-ZeN"/>
                 <constraint firstItem="0tK-14-8hw" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="147" id="HJ5-yO-O4E"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0tK-14-8hw" secondAttribute="trailing" constant="20" symbolic="YES" id="HLI-RV-711"/>
                 <constraint firstItem="ovb-PR-Z2o" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="147" id="I5T-1A-LXi"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="IxA-64-q7d" secondAttribute="trailing" constant="-1" id="JEd-SA-eaY"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="80" id="KR1-CB-ioR"/>
                 <constraint firstItem="IHs-uV-EyH" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="LjA-Eo-HeM"/>
-                <constraint firstItem="pjw-8M-CEh" firstAttribute="top" secondItem="eKe-P1-HOz" secondAttribute="bottom" constant="8" symbolic="YES" id="Mrl-iC-L3h"/>
+                <constraint firstItem="pjw-8M-CEh" firstAttribute="top" secondItem="m5q-92-0BV" secondAttribute="bottom" constant="8" symbolic="YES" id="Mrl-iC-L3h"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IxA-64-q7d" secondAttribute="trailing" constant="20" symbolic="YES" id="OXv-HY-nwn"/>
+                <constraint firstItem="m5q-92-0BV" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="293" id="OZW-S9-WWt"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="trailing" secondItem="gtY-jT-2F6" secondAttribute="trailing" id="Oa7-Lh-Mmw"/>
                 <constraint firstItem="8MO-3w-gC1" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="119" id="OeG-jx-jYq"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="c1b-KP-F28" secondAttribute="trailing" constant="-1" id="P1F-Cz-xzC"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hlp-hI-9WY" secondAttribute="trailing" constant="20" symbolic="YES" id="PC9-FD-dLO"/>
                 <constraint firstItem="qLt-o2-oPl" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="193" id="PED-Ua-UGI"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="top" secondItem="uuQ-a9-JKn" secondAttribute="bottom" constant="16" id="PFa-Gi-quM"/>
-                <constraint firstItem="IxA-64-q7d" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="416" id="Pyv-gs-CHi"/>
+                <constraint firstItem="IxA-64-q7d" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="440" id="Pyv-gs-CHi"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="trailing" secondItem="BSi-pH-F8f" secondAttribute="trailing" id="QvH-f8-u1o"/>
                 <constraint firstItem="c1b-KP-F28" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="50" id="SnW-f7-cgz"/>
-                <constraint firstItem="oya-hD-nIE" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="454" id="StP-0w-gxo"/>
-                <constraint firstItem="qLt-o2-oPl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="20" symbolic="YES" id="T2D-4J-jWY"/>
+                <constraint firstItem="oya-hD-nIE" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="462" id="StP-0w-gxo"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qLt-o2-oPl" secondAttribute="trailing" constant="20" symbolic="YES" id="T2D-4J-jWY"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hvF-32-Zw1" secondAttribute="trailing" constant="20" symbolic="YES" id="TCY-t3-hPS"/>
-                <constraint firstItem="tDv-b3-Mrm" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="DoZ-iC-eqs" secondAttribute="trailing" constant="8" symbolic="YES" id="TYc-JO-4rD"/>
+                <constraint firstItem="tDv-b3-Mrm" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="TYc-JO-4rD"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8MO-3w-gC1" secondAttribute="trailing" constant="20" symbolic="YES" id="U9v-8G-T8K"/>
                 <constraint firstItem="KMh-qe-ZAb" firstAttribute="top" secondItem="YWl-mS-2Wx" secondAttribute="bottom" constant="9" id="UGy-4h-9eR"/>
-                <constraint firstAttribute="trailing" secondItem="tDv-b3-Mrm" secondAttribute="trailing" constant="137" id="USg-iD-9aF"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tDv-b3-Mrm" secondAttribute="trailing" constant="20" symbolic="YES" id="USg-iD-9aF"/>
                 <constraint firstItem="KRC-Qj-X94" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="20" symbolic="YES" id="Vcd-VH-A59"/>
                 <constraint firstItem="2Nx-PK-HCb" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="VkM-rY-Yrp"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IHs-uV-EyH" secondAttribute="trailing" constant="20" symbolic="YES" id="XV9-im-EHc"/>
@@ -411,34 +430,39 @@
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="centerX" secondItem="hlp-hI-9WY" secondAttribute="centerX" constant="-1" id="dqa-vM-3jZ"/>
                 <constraint firstItem="YF3-dA-BAc" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="e5G-Du-eTU"/>
                 <constraint firstItem="oya-hD-nIE" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="eCx-8M-T6p"/>
+                <constraint firstItem="rgP-HS-mVQ" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="293" id="eKV-jz-Os1"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6eT-rC-gVz" secondAttribute="trailing" id="eor-Aj-Jk9"/>
                 <constraint firstItem="IxA-64-q7d" firstAttribute="top" secondItem="DoZ-iC-eqs" secondAttribute="bottom" constant="12" id="fxn-7m-Tax"/>
+                <constraint firstItem="m5q-92-0BV" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="glH-Hv-1AB"/>
                 <constraint firstItem="IHs-uV-EyH" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="219" id="hlG-T4-jOY"/>
                 <constraint firstItem="IxA-64-q7d" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="116" id="ihq-6K-4O0"/>
                 <constraint firstItem="2Nx-PK-HCb" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="123" id="iss-rc-oRY"/>
                 <constraint firstItem="c1b-KP-F28" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="67" id="jEX-fy-dEL"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KMh-qe-ZAb" secondAttribute="trailing" constant="20" symbolic="YES" id="jdc-7t-e0K"/>
-                <constraint firstItem="sMU-k1-QG3" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="342" id="kM7-ga-J0L"/>
-                <constraint firstItem="YF3-dA-BAc" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="305" id="lYD-Sh-ToB"/>
+                <constraint firstItem="sMU-k1-QG3" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="366" id="kM7-ga-J0L"/>
+                <constraint firstItem="YF3-dA-BAc" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="329" id="lYD-Sh-ToB"/>
                 <constraint firstItem="DoZ-iC-eqs" firstAttribute="trailing" secondItem="8MO-3w-gC1" secondAttribute="trailing" constant="-1" id="nee-7w-xPo"/>
                 <constraint firstAttribute="trailing" secondItem="pjw-8M-CEh" secondAttribute="trailing" constant="20" symbolic="YES" id="nmI-LZ-kdZ"/>
-                <constraint firstItem="hvF-32-Zw1" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="476" id="nz6-rf-rCd"/>
+                <constraint firstItem="hvF-32-Zw1" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="484" id="nz6-rf-rCd"/>
                 <constraint firstAttribute="trailing" secondItem="6eT-rC-gVz" secondAttribute="trailing" constant="38" id="oNu-3J-5fh"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YWl-mS-2Wx" secondAttribute="trailing" constant="20" symbolic="YES" id="oY6-bi-K9l"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="m5q-92-0BV" secondAttribute="trailing" constant="20" symbolic="YES" id="p0b-eX-5tt"/>
                 <constraint firstItem="KOq-SU-0dw" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="pGP-cf-yJD"/>
                 <constraint firstItem="gtY-jT-2F6" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="95" id="pNV-tW-L84"/>
                 <constraint firstItem="BSi-pH-F8f" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="20" symbolic="YES" id="sDa-gA-chB"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rgP-HS-mVQ" secondAttribute="trailing" constant="20" symbolic="YES" id="sUw-vg-Bzv"/>
                 <constraint firstItem="Bc3-oU-EWC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sMU-k1-QG3" secondAttribute="trailing" constant="8" symbolic="YES" id="tmk-dQ-WZU"/>
-                <constraint firstItem="hlp-hI-9WY" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="305" id="txe-bY-Wgs"/>
+                <constraint firstItem="hlp-hI-9WY" firstAttribute="top" secondItem="eWf-pC-0Bt" secondAttribute="top" constant="329" id="txe-bY-Wgs"/>
                 <constraint firstItem="6eT-rC-gVz" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="uCf-qg-C2Y"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2Nx-PK-HCb" secondAttribute="trailing" constant="20" symbolic="YES" id="uFU-GE-Wqn"/>
                 <constraint firstItem="pjw-8M-CEh" firstAttribute="leading" secondItem="uuQ-a9-JKn" secondAttribute="leading" id="uOd-ta-Qxh"/>
+                <constraint firstItem="rgP-HS-mVQ" firstAttribute="trailing" secondItem="KMh-qe-ZAb" secondAttribute="trailing" id="vV7-GC-RMR"/>
                 <constraint firstItem="tDv-b3-Mrm" firstAttribute="top" secondItem="Bc3-oU-EWC" secondAttribute="bottom" constant="9" id="wcQ-7E-4RP"/>
                 <constraint firstItem="0tK-14-8hw" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="29" id="xYa-P6-Eyo"/>
                 <constraint firstItem="hvF-32-Zw1" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="184" id="ycn-h5-f2z"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KOq-SU-0dw" secondAttribute="trailing" constant="20" symbolic="YES" id="z2V-7t-ODc"/>
                 <constraint firstItem="BSi-pH-F8f" firstAttribute="leading" secondItem="eWf-pC-0Bt" secondAttribute="leading" constant="186" id="zDN-jC-jgL"/>
-                <constraint firstItem="gtY-jT-2F6" firstAttribute="trailing" secondItem="uuQ-a9-JKn" secondAttribute="trailing" constant="122" id="zks-Pk-AKU"/>
+                <constraint firstAttribute="trailing" secondItem="uuQ-a9-JKn" secondAttribute="trailing" constant="20" symbolic="YES" id="zks-Pk-AKU"/>
             </constraints>
             <point key="canvasLocation" x="168" y="-350"/>
         </view>
@@ -496,7 +520,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Toh-FQ-MTf">
-                    <rect key="frame" x="181" y="219" width="219" height="25"/>
+                    <rect key="frame" x="182" y="219" width="218" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="關閉" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="4VD-Kh-SxN" id="Gcx-5r-kDK">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -591,7 +615,7 @@
                     <rect key="frame" x="20" y="89" width="396" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="k5j-ZT-zUm">
-                    <rect key="frame" x="184" y="56" width="128" height="24"/>
+                    <rect key="frame" x="185" y="56" width="127" height="24"/>
                     <buttonCell key="cell" type="push" title="產生系統資訊報告" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Z6Q-r5-E9H">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -662,7 +686,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="107" translatesAutoresizingMaskIntoConstraints="NO" id="uPv-37-dOi">
-                    <rect key="frame" x="6" y="298" width="105" height="16"/>
+                    <rect key="frame" x="7" y="298" width="105" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="使用者詞彙位置：" id="ulY-l0-tqg">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -670,7 +694,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b15-I3-wDL">
-                    <rect key="frame" x="8" y="258" width="74" height="24"/>
+                    <rect key="frame" x="9" y="258" width="73" height="24"/>
                     <popUpButtonCell key="cell" type="push" title="標準" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="WPo-X9-YuK" id="zEZ-0A-2Df">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>

--- a/Source/zh-Hant.lproj/preferences.xib
+++ b/Source/zh-Hant.lproj/preferences.xib
@@ -286,7 +286,7 @@
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="32" name="value" keyPath="values.StandalonePhraseBoundaryEnabled" id="Pdx-tH-DyY"/>
+                        <binding destination="32" name="value" keyPath="values.PreferExactPhraseMatchForFullInput" id="Pdx-tH-DyY"/>
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="hvF-32-Zw1">


### PR DESCRIPTION
## Summary

This PR adds an optional composition preference that prefers an exact phrase match when the full input exactly matches a known phrase.

When enabled, if the entire composing buffer is a known phrase, the engine presents that phrase before a higher-scoring segmentation made from shorter words. This only applies to the full input and does not boost the same phrase when it is merely a prefix of a longer input.

## Motivation

Some known phrases can currently lose to a segmentation made from high-frequency single-character words, even when the user has entered the full reading of the intended phrase.

Examples:

| Input | Intended phrase | Previous result | Why this is surprising |
|---|---|---|---|
| ㄗˋ ㄏㄨㄟˋ | 字彙 | 自會 | The full input matches 字彙, but higher-frequency single-character words can be selected instead. |
| ㄧ ㄗㄞˋ | 一再 | 一在 | The full input matches 一再, but it can be split into two single-character words. |
| ㄕˋ ㄕˋ | 試試 | 是是 | The high-frequency 是 can outweigh the known phrase 試試. |
| ㄍㄜˋ ㄕˋ | 各式 | 個是 | Common single-character words can produce a higher score despite an unnatural phrase. |
| ㄉㄜ˙ ㄔㄨ | 得出 | 的出 | The high-frequency 的 can cause an unintended split. |
| ㄧ ㄐㄧㄡˋ | 依舊 | 一就 | The known phrase exists, but the split result can score higher. |
| ㄓㄨㄥ ㄧ | 中醫 | 中一 | A complete domain phrase can lose to a split result. |
| ㄅㄨˋ ㄧˇ | 不已 | 不以 | The phrase has a clear meaning, but the split can rank higher. |
| ㄅㄨˋ ㄉㄠˋ | 步道 | 不到 | If the user intends 步道, the previous behavior can conflict with that intent. |
| ㄕˋ ㄧㄝˇ | 視野 | 是也 | High-frequency single-character words can outweigh the phrase. |
| ㄧㄡˇ ㄕˋ | 有事 | 有是 | A natural phrase can lose to scoring from shorter words. |
| ㄇㄧㄢˋ ㄕˋ | 面試 | 面是 | A common phrase can lose because 是 is scored as a high-frequency single-character word. |
| ㄗㄨㄛˋ ㄕˋ | 做事 | 作是 | A natural verb-object phrase can be split into less natural single-character words. |
| ㄏㄠˇ ㄕˋ | 好事 | 好是 | The intended phrase is common, but the split result may still score higher. |
| ㄕˋ ㄏㄡˋ | 事後 | 是後 | The phrase has a clear meaning, but the split can rank higher. |
| ㄒㄧㄣ ㄕˋ | 心事 | 心是 | A natural phrase can be split into a less natural result. |
| ㄧㄠˋ ㄕ˙ | 鑰匙 | 要時 | A known everyday word can lose to a higher-scoring split result. |

## Behavior

This preference is disabled by default.

When enabled:

- Full-input exact phrase matches are preferred.
- User overrides still take precedence.
- Prefix matches inside longer input are not boosted.
- Normal lattice scoring continues to apply when there is no full-input phrase match.

## Notes

This is intended to handle cases where the user's full input strongly indicates a known phrase, while keeping the existing scoring behavior as the default.

The exact-match shortcut now checks for overridden nodes in the grid before returning a full-input phrase. If any override exists, the engine falls back to the normal Viterbi flow instead of replacing the result afterward. This avoids bypassing user-selected or user-override-model-selected candidates.

When the exact-match preference is enabled, user override suggestions are checked against both paths:

- The exact-match path is checked first, preserving same-reading phrase replacements, such as 字彙 -> 自會.
- If no suggestion is found, the normal Viterbi path is checked as a fallback, preserving corrections from split words to phrases, such as 好顯 -> 好險.

Suggestions found from the exact-match path are applied as high-score overrides so they remain selected after the override disables the exact-match shortcut for the final walk.