### PR TITLE
Fix Hsu and ETen26 out-of-order sequence handling

### DIFF
--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -302,6 +302,15 @@ class BopomofoKeyboardLayout {
           syllable += head;
         } else if (syllable.maskType() < follow.maskType()) {
           syllable += follow;
+        } else if ((syllable.maskType() == follow.maskType()) &&
+                   syllable.maskType() == BPMF::VowelMask) {
+          // if the existing syllable contains only a vowel, and the
+          // current character has 2+ possibilities, and the second (follow)
+          // choice is also a vowel, we run into the case where the user
+          // may have typed the consonant-vowel sequence in the wrong
+          // order, and so the first (head) choice, which is always a
+          // consonant, must be taken.
+          syllable += head;
         } else {
           syllable += ending;
         }

--- a/Source/Engine/Mandarin/MandarinTest.cpp
+++ b/Source/Engine/Mandarin/MandarinTest.cpp
@@ -101,12 +101,55 @@ TEST(MandarinTest, ETen26Layout) {
   ASSERT_EQ(buf.composedString(), "ㄗㄢˋ");
 }
 
+TEST(MandarinTest, ETen26LayoutOutOfOrderEquivalentSequence) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::ETen26Layout());
+  buf.combineKey('q');
+  buf.combineKey('a');
+  ASSERT_EQ(buf.composedString(), "ㄗㄚ");
+
+  buf.clear();
+  buf.combineKey('a');  // ㄚ first
+  buf.combineKey('q');  // even if q can be ㄟ, a vowel is already in place
+  ASSERT_EQ(buf.composedString(), "ㄗㄚ");
+
+  buf.clear();
+  buf.combineKey('q');
+  buf.combineKey('i');
+  ASSERT_EQ(buf.composedString(), "ㄗㄞ");
+
+  buf.clear();
+  buf.combineKey('i');
+  buf.combineKey('q');
+  ASSERT_EQ(buf.composedString(), "ㄗㄞ");
+}
 TEST(MandarinTest, HsuLayout) {
   BopomofoReadingBuffer buf(BopomofoKeyboardLayout::HsuLayout());
   buf.combineKey('f');
   buf.combineKey('a');  // EI when in the vowel state
   buf.combineKey('f');  // Tone 3 when in the tone state
   ASSERT_EQ(buf.composedString(), "ㄈㄟˇ");
+}
+
+TEST(MandarinTest, HsuLayoutOutOfOrderEquivalentSequence) {
+  BopomofoReadingBuffer buf(BopomofoKeyboardLayout::HsuLayout());
+  buf.combineKey('a');
+  buf.combineKey('i');
+  ASSERT_EQ(buf.composedString(), "ㄘㄞ");
+
+  buf.clear();
+  buf.combineKey('i');  // ㄞ first
+  buf.combineKey('a');  // even if a can be ㄟ, a vowel is already in place
+  ASSERT_EQ(buf.composedString(), "ㄘㄞ");
+
+  buf.clear();
+  buf.combineKey('a');
+  buf.combineKey('y');
+  ASSERT_EQ(buf.composedString(), "ㄘㄚ");
+
+  buf.clear();
+  buf.combineKey('y');
+  buf.combineKey('a');
+  ASSERT_EQ(buf.composedString(), "ㄘㄚ");
 }
 
 TEST(MandarinTest, IBMLayout) {


### PR DESCRIPTION
Certain sequences should have the equivalent output, such as ai/ia with Hsu (both should yield ㄘㄞ). While "ia" might be a mistake on the user's part, since it is the equivalent of "ai", the layout code still should honor it.

This issue was discovered via #870.
