### PR TITLE
Fix pinyin mode persisting after switching to another layout

### DIFF
--- a/Source/Engine/Mandarin/Mandarin.h
+++ b/Source/Engine/Mandarin/Mandarin.h
@@ -381,9 +381,9 @@ class BopomofoReadingBuffer {
 
   void setKeyboardLayout(const BopomofoKeyboardLayout* layout) {
     layout_ = layout;
+    pinyin_mode_ = layout == BopomofoKeyboardLayout::HanyuPinyinLayout();
 
-    if (layout == BopomofoKeyboardLayout::HanyuPinyinLayout()) {
-      pinyin_mode_ = true;
+    if (pinyin_mode_) {
       pinyin_sequence_ = "";
     }
   }


### PR DESCRIPTION
This PR fixes an issue where switching from the Hanyu Pinyin keyboard layout to another layout would leave the input method in Pinyin mode.

https://github.com/user-attachments/assets/79d7b415-3f24-4cb1-a59f-c8a38cdd8404

---

On an unrelated note, the labels and controls in the Preferences window are pretty badly misaligned, and I suck at laying things out in XIB 🥲 If anyone’s willing to help, that’d be awesome! Or maybe it’s finally time to migrate to SwiftUI XDD

<img width="500" src="https://github.com/user-attachments/assets/aca93ea2-b5fd-4e34-942a-28d466877e14" />