### PR TITLE
Avoid repeated negative unigram lookups

### DIFF
--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -54,14 +54,18 @@ bool ReadingGrid::insertReading(const std::string& reading) {
     return false;
   }
 
-  if (!lm_.hasUnigrams(reading)) {
+  std::string insertedReading = reading;
+  auto unigrams = lm_.getUnigrams(insertedReading);
+  if (unigrams.empty()) {
     return false;
   }
 
   readings_.insert(readings_.begin() + static_cast<ptrdiff_t>(cursor_),
-                   reading);
+                   std::move(insertedReading));
   expandGridAt(cursor_);
-  update();
+  insert(cursor_,
+         std::make_shared<Node>(readings_[cursor_], 1, std::move(unigrams)));
+  update(cursor_, EditType::kInsertion);
 
   // Cursor must only move after update().
   ++cursor_;
@@ -78,7 +82,7 @@ bool ReadingGrid::deleteReadingBeforeCursor() {
   // Cursor must decrement for grid-shrinking and update to work.
   --cursor_;
   shrinkGridAt(cursor_);
-  update();
+  update(cursor_, EditType::kDeletion);
   return true;
 }
 
@@ -90,7 +94,7 @@ bool ReadingGrid::deleteReadingAfterCursor() {
   readings_.erase(readings_.begin() + static_cast<ptrdiff_t>(cursor_),
                   readings_.begin() + static_cast<ptrdiff_t>(cursor_ + 1));
   shrinkGridAt(cursor_);
-  update();
+  update(cursor_, EditType::kDeletion);
   return true;
 }
 
@@ -291,7 +295,7 @@ void ReadingGrid::removeAffectedNodes(size_t loc) {
   //                XXXXX
   //            XXXXXXXXX
   //
-  if (spans_.empty()) {
+  if (spans_.empty() || loc == 0) {
     return;
   }
   size_t affectedLength = kMaximumSpanLength - 1;
@@ -323,7 +327,7 @@ std::string ReadingGrid::combineReading(
 
 bool ReadingGrid::hasNodeAt(size_t loc, size_t readingLen,
                             const std::string& reading) {
-  if (loc > spans_.size()) {
+  if (loc >= spans_.size()) {
     return false;
   }
   const NodePtr& n = spans_[loc].nodeOf(readingLen);
@@ -333,14 +337,20 @@ bool ReadingGrid::hasNodeAt(size_t loc, size_t readingLen,
   return reading == n->reading();
 }
 
-void ReadingGrid::update() {
-  size_t begin =
-      (cursor_ <= kMaximumSpanLength) ? 0 : cursor_ - kMaximumSpanLength;
-  size_t end = cursor_ + kMaximumSpanLength;
+void ReadingGrid::update(size_t loc, EditType editType) {
+  // Spans that do not cross the edit retain their previous lookup result. A
+  // node means that the lookup succeeded, while a null slot means that the
+  // same reading was already looked up and did not exist. Only spans that
+  // include an insertion or cross a deletion boundary need to be queried.
+  size_t affectedLength = kMaximumSpanLength - 1;
+  size_t begin = loc <= affectedLength ? 0 : loc - affectedLength;
+  size_t end = editType == EditType::kInsertion ? loc + 1 : loc;
   end = std::min(end, readings_.size());
 
   for (size_t pos = begin; pos < end; pos++) {
-    for (size_t len = 1; len <= kMaximumSpanLength && pos + len <= end; len++) {
+    size_t minimumLength = loc - pos + 1;
+    size_t maximumLength = std::min(kMaximumSpanLength, readings_.size() - pos);
+    for (size_t len = minimumLength; len <= maximumLength; len++) {
       std::string combinedReading =
           combineReading(readings_.begin() + static_cast<ptrdiff_t>(pos),
                          readings_.begin() + static_cast<ptrdiff_t>(pos + len));
@@ -351,7 +361,8 @@ void ReadingGrid::update() {
           continue;
         }
 
-        insert(pos, std::make_shared<Node>(combinedReading, len, unigrams));
+        insert(pos, std::make_shared<Node>(std::move(combinedReading), len,
+                                           std::move(unigrams)));
       }
     }
   }

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -253,6 +253,11 @@ class ReadingGrid {
 
   // Internal methods for maintaining the grid.
 
+  enum class EditType {
+    kInsertion,
+    kDeletion,
+  };
+
   void expandGridAt(size_t loc);
   void shrinkGridAt(size_t loc);
   void removeAffectedNodes(size_t loc);
@@ -260,7 +265,7 @@ class ReadingGrid {
   std::string combineReading(std::vector<std::string>::const_iterator begin,
                              std::vector<std::string>::const_iterator end);
   bool hasNodeAt(size_t loc, size_t readingLen, const std::string& reading);
-  void update();
+  void update(size_t loc, EditType editType);
 
   // Internal implementation of overrideCandidate, with an optional reading.
   bool overrideCandidate(size_t loc, const std::string* reading,

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -166,6 +166,37 @@ class MockLM : public LanguageModel {
   bool hasUnigrams(const std::string&) override { return true; }
 };
 
+class SingleReadingCountingLM : public LanguageModel {
+ public:
+  std::vector<Unigram> getUnigrams(const std::string& reading) override {
+    ++getUnigramsCount_;
+    ++getUnigramsCounts_[reading];
+    if (reading.find(ReadingGrid::kDefaultSeparator) != std::string::npos) {
+      return {};
+    }
+    return std::vector<Unigram>{Unigram(reading, -1)};
+  }
+
+  bool hasUnigrams(const std::string& reading) override {
+    ++hasUnigramsCount_;
+    return reading.find(ReadingGrid::kDefaultSeparator) == std::string::npos;
+  }
+
+  [[nodiscard]] size_t getUnigramsCount() const { return getUnigramsCount_; }
+
+  [[nodiscard]] size_t getUnigramsCount(const std::string& reading) const {
+    auto iter = getUnigramsCounts_.find(reading);
+    return iter == getUnigramsCounts_.end() ? 0 : iter->second;
+  }
+
+  [[nodiscard]] size_t hasUnigramsCount() const { return hasUnigramsCount_; }
+
+ private:
+  std::map<std::string, size_t> getUnigramsCounts_;
+  size_t getUnigramsCount_ = 0;
+  size_t hasUnigramsCount_ = 0;
+};
+
 static bool Contains(const std::vector<ReadingGrid::Candidate>& candidates,
                      const std::string& str) {
   return std::any_of(candidates.cbegin(), candidates.cend(),
@@ -267,6 +298,94 @@ TEST(ReadingGridTest, BasicOperations) {
   ASSERT_EQ(grid.cursor(), 0);
   ASSERT_EQ(grid.length(), 0);
   ASSERT_EQ(grid.spans().size(), 0);
+}
+
+TEST(ReadingGridTest, InsertReadingQueriesEachCombinationOnce) {
+  auto lm = std::make_shared<SingleReadingCountingLM>();
+  ReadingGrid grid(lm);
+
+  for (const char* reading : {"a", "b", "c", "d", "e", "f"}) {
+    ASSERT_TRUE(grid.insertReading(reading));
+  }
+
+  EXPECT_EQ(lm->getUnigramsCount(), 21);
+  EXPECT_EQ(lm->hasUnigramsCount(), 0);
+  EXPECT_EQ(lm->getUnigramsCount("a-b"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-b-c-d-e-f"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("e-f"), 1);
+}
+
+TEST(ReadingGridTest, InsertionOnlyQueriesSpansContainingTheEdit) {
+  auto lm = std::make_shared<SingleReadingCountingLM>();
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("a"));
+  ASSERT_TRUE(grid.insertReading("b"));
+  ASSERT_TRUE(grid.insertReading("c"));
+
+  grid.setCursor(1);
+  ASSERT_TRUE(grid.insertReading("x"));
+
+  EXPECT_EQ(lm->getUnigramsCount(), 12);
+  EXPECT_EQ(lm->getUnigramsCount("b-c"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-x"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-x-b-c"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("x-b-c"), 1);
+}
+
+TEST(ReadingGridTest, InsertionAtBeginningPreservesExistingLookupResults) {
+  auto lm = std::make_shared<SingleReadingCountingLM>();
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("b"));
+  ASSERT_TRUE(grid.insertReading("c"));
+
+  grid.setCursor(0);
+  ASSERT_TRUE(grid.insertReading("a"));
+
+  EXPECT_EQ(lm->getUnigramsCount(), 6);
+  EXPECT_EQ(lm->getUnigramsCount("b-c"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-b"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-b-c"), 1);
+}
+
+TEST(ReadingGridTest, DeletionOnlyQueriesSpansCrossingTheEdit) {
+  auto lm = std::make_shared<SingleReadingCountingLM>();
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("a"));
+  ASSERT_TRUE(grid.insertReading("b"));
+  ASSERT_TRUE(grid.insertReading("c"));
+  ASSERT_TRUE(grid.insertReading("d"));
+
+  grid.setCursor(2);
+  ASSERT_TRUE(grid.deleteReadingBeforeCursor());
+
+  EXPECT_EQ(lm->getUnigramsCount(), 12);
+  EXPECT_EQ(lm->getUnigramsCount("a-c"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("a-c-d"), 1);
+  EXPECT_EQ(lm->getUnigramsCount("c-d"), 1);
+
+  grid.setCursor(0);
+  ASSERT_TRUE(grid.deleteReadingAfterCursor());
+  EXPECT_EQ(lm->getUnigramsCount(), 12);
+  ASSERT_EQ(grid.readings(), (std::vector<std::string>{"c", "d"}));
+  ASSERT_NE(grid.spans()[0].nodeOf(1), nullptr);
+  EXPECT_EQ(grid.spans()[0].nodeOf(1)->reading(), "c");
+
+  grid.setCursor(2);
+  ASSERT_TRUE(grid.deleteReadingBeforeCursor());
+  EXPECT_EQ(lm->getUnigramsCount(), 12);
+  ASSERT_EQ(grid.readings(), (std::vector<std::string>{"c"}));
+  ASSERT_NE(grid.spans()[0].nodeOf(1), nullptr);
+  EXPECT_EQ(grid.spans()[0].nodeOf(1)->reading(), "c");
+}
+
+TEST(ReadingGridTest, InsertReadingAcceptsReadingOwnedByGrid) {
+  ReadingGrid grid(std::make_shared<MockLM>());
+  ASSERT_TRUE(grid.insertReading("a"));
+
+  const std::string& aliasedReading = grid.readings()[0];
+  ASSERT_TRUE(grid.insertReading(aliasedReading));
+  ASSERT_EQ(grid.readings(), (std::vector<std::string>{"a", "a"}));
+  ASSERT_EQ(grid.spans()[1].nodeOf(1)->reading(), "a");
 }
 
 TEST(ReadingGridTest, InvalidOperations) {


### PR DESCRIPTION
Description copied from [#883](https://github.com/openvanilla/McBopomofo/pull/883#issuecomment-5013779351)

---

For caching, I tried keeping an array in each span to record missing keys. I also tried using an `unordered_map` to remember which keys had already been looked up. I know 新酷音 uses a trie, but that feels too heavy for this. None of these approaches felt elegant enough to me.

In the end, this is the version I am happy with and wanted to share. It does not add any new data structure. The core change is just the loops in `ReadingGrid::update()`.

```cpp
void ReadingGrid::update(size_t loc, EditType editType) {
  // Spans that do not cross the edit retain their previous lookup result. A
  // node means that the lookup succeeded, while a null slot means that the
  // same reading was already looked up and did not exist. Only spans that
  // include an insertion or cross a deletion boundary need to be queried.
  size_t affectedLength = kMaximumSpanLength - 1;
  size_t begin = loc <= affectedLength ? 0 : loc - affectedLength;
  size_t end = editType == EditType::kInsertion ? loc + 1 : loc;
  end = std::min(end, readings_.size());

  for (size_t pos = begin; pos < end; pos++) {
    size_t minimumLength = loc - pos + 1;
    size_t maximumLength = std::min(kMaximumSpanLength, readings_.size() - pos);
    for (size_t len = minimumLength; len <= maximumLength; len++) {
      std::string combinedReading =
          combineReading(readings_.begin() + static_cast<ptrdiff_t>(pos),
                         readings_.begin() + static_cast<ptrdiff_t>(pos + len));

      if (!hasNodeAt(pos, len, combinedReading)) {
        auto unigrams = lm_.getUnigrams(combinedReading);
        if (unigrams.empty()) {
          continue;
        }

        insert(pos, std::make_shared<Node>(std::move(combinedReading), len,
                                           std::move(unigrams)));
      }
    }
  }
}
```

Let's do some simple math XDD, we only want `update()` to visit combinations that can reach the edit location:

```cpp
size_t affectedLength = kMaximumSpanLength - 1;
size_t begin = loc <= affectedLength ? 0 : loc - affectedLength;
```

`kMaximumSpanLength` is 8, so if there are fewer than 7 readings on the left, we start at position 0. Otherwise, we start at `loc - 7`.

The end position depends on whether this is an insertion or deletion:

```cpp
size_t end = editType == EditType::kInsertion ? loc + 1 : loc;
```

For an insertion, `end` is `loc + 1`. The outer loop is:

```cpp
for (size_t pos = begin; pos < end; pos++)
```

Since the condition is `pos < end`, `end` must be `loc + 1` if we want to include `pos == loc`.

Suppose we insert `n` between `a` and `b`:

```text
a b c
```

After the insertion:

```text
a n b c
  ↑
 loc
```

The affected combinations starting before `n` are:

```text
a n
a n b
a n b c
```

The affected combinations starting at `n` are:

```text
n
n b
n b c
```

All of them contain the inserted reading. Existing combinations such as `b c` do not contain the edit, so they can keep their previous lookup result.

For a deletion, `end` is just `loc`.

After deletion, `loc` is the first surviving reading on the right. For example:

```text
a b c
```

After deleting `b`:

```text
a | c
    loc = 1
```

Only spans starting to the left of `loc` can cross this new boundary. So deletion uses `pos < loc` and does not include `pos == loc`.

Then we calculate the minimum length:

```cpp
size_t minimumLength = loc - pos + 1;
```

This is the minimum length needed for a span starting at `pos` to reach `loc`.

The maximum length is:

```cpp
size_t maximumLength =
    std::min(kMaximumSpanLength, readings_.size() - pos);
```

This is the number of readings left between `pos` and the end of the vector, capped by `kMaximumSpanLength`.

That's all!! We've covered all the cases without adding a trie, a cache, or any other long-lived data structure.
My changes are available in https://github.com/ChiahongHong/McBopomofo/tree/reduce-binary-search

### Without NEON

| Stage  | short_iterations | medium_iterations | long_iterations |
|--------|-----------------:|------------------:|----------------:|
| Before |          771,129 |           116,411 |          30,573 |
| After  |          892,077 |           148,430 |          43,351 |

### With NEON

| Stage  | short_iterations | medium_iterations | long_iterations |
|--------|-----------------:|------------------:|----------------:|
| Before |          898,449 |           148,747 |          43,103 |
| After  |          952,787 |           174,237 |          66,322 |
