### PR TITLE
Fix pronunciation for 眶

### DIFF
--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -7296,6 +7296,7 @@
 礦 ㄎㄨㄤˋ kuang4 dj;4 big5
 曠 ㄎㄨㄤˋ kuang4 dj;4 big5
 框 ㄎㄨㄤˋ kuang4 dj;4 big5
+眶 ㄎㄨㄤˋ kuang4 dj;4 big5
 鄺 ㄎㄨㄤˋ kuang4 dj;4 big5
 貺 ㄎㄨㄤˋ kuang4 dj;4 big5
 壙 ㄎㄨㄤˋ kuang4 dj;4 big5

--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -7295,7 +7295,7 @@
 礦 ㄎㄨㄤˋ kuang4 dj;4 big5
 曠 ㄎㄨㄤˋ kuang4 dj;4 big5
 框 ㄎㄨㄤˋ kuang4 dj;4 big5
-眶 ㄎㄨㄤˋ kuang4 dj;4 big5
+眶 ㄎㄨㄤ kuang dj; big5
 鄺 ㄎㄨㄤˋ kuang4 dj;4 big5
 貺 ㄎㄨㄤˋ kuang4 dj;4 big5
 壙 ㄎㄨㄤˋ kuang4 dj;4 big5

--- a/Source/Data/BPMFBase.txt
+++ b/Source/Data/BPMFBase.txt
@@ -7289,13 +7289,13 @@
 軭 ㄎㄨㄤ kuang dj; utf8
 邼 ㄎㄨㄤ kuang dj; utf8
 𨀕 ㄎㄨㄤ kuang dj; utf8
+眶 ㄎㄨㄤ kuang dj; big5
 俇 ㄎㄨㄤˇ kuang3 dj;3 big5
 兤 ㄎㄨㄤˇ kuang3 dj;3 utf8
 況 ㄎㄨㄤˋ kuang4 dj;4 big5
 礦 ㄎㄨㄤˋ kuang4 dj;4 big5
 曠 ㄎㄨㄤˋ kuang4 dj;4 big5
 框 ㄎㄨㄤˋ kuang4 dj;4 big5
-眶 ㄎㄨㄤ kuang dj; big5
 鄺 ㄎㄨㄤˋ kuang4 dj;4 big5
 貺 ㄎㄨㄤˋ kuang4 dj;4 big5
 壙 ㄎㄨㄤˋ kuang4 dj;4 big5


### PR DESCRIPTION
Per Taiwan MOE dictionaries, 眶 is dark level tone instead of departing tone.  Its departing tone is only present in 中華新韻 and modern dictionaries mostly in China and Hong Kong that inherit the former, and is likely a mistake since this character was level tone or dark level tone all along in previous dictionaries, or is the pronunciation in some Mandarin dialects.