### PR TITLE
Bump version to 3.1-dev for built-from-source uses

### DIFF
--- a/Source/Installer/Installer-Info.plist
+++ b/Source/Installer/Installer-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1</string>
+	<string>3.1-dev</string>
 	<key>CFBundleSignature</key>
 	<string>MBIN</string>
 	<key>CFBundleVersion</key>
-	<string>2496</string>
+	<string>2498</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSHasLocalizedDisplayName</key>

--- a/Source/McBopomofo-Info.plist
+++ b/Source/McBopomofo-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1</string>
+	<string>3.1-dev</string>
 	<key>CFBundleSignature</key>
 	<string>BPMF</string>
 	<key>CFBundleVersion</key>
-	<string>2496</string>
+	<string>2498</string>
 	<key>ComponentInputModeDict</key>
 	<dict>
 		<key>tsInputModeListKey</key>


### PR DESCRIPTION
This is to distinguish users who build from source from those who use the public releases.
