### PR TITLE
fix(input): refresh candidates after user phrase changes

### DIFF
--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -98,25 +98,55 @@ bool ReadingGrid::deleteReadingAfterCursor() {
   return true;
 }
 
-bool ReadingGrid::refresh() {
-  std::vector<Span> refreshedSpans(readings_.size());
+bool ReadingGrid::refreshNodesForReading(const std::string& reading) {
+  if (reading.empty()) {
+    return false;
+  }
+
+  struct MatchingSpan {
+    size_t position;
+    size_t length;
+  };
+  std::vector<MatchingSpan> matchingSpans;
   for (size_t pos = 0; pos < readings_.size(); ++pos) {
     size_t maximumLength = std::min(kMaximumSpanLength, readings_.size() - pos);
     for (size_t len = 1; len <= maximumLength; ++len) {
       std::string combinedReading =
           combineReading(readings_.begin() + static_cast<ptrdiff_t>(pos),
                          readings_.begin() + static_cast<ptrdiff_t>(pos + len));
-      auto unigrams = lm_.getUnigrams(combinedReading);
-      if (!unigrams.empty()) {
-        refreshedSpans[pos].add(std::make_shared<Node>(
-            std::move(combinedReading), len, std::move(unigrams)));
+      if (combinedReading == reading) {
+        matchingSpans.push_back({pos, len});
       }
     }
-    if (refreshedSpans[pos].nodeOf(1) == nullptr) {
-      return false;
-    }
   }
-  spans_ = std::move(refreshedSpans);
+
+  if (matchingSpans.empty()) {
+    return false;
+  }
+
+  auto unigrams = lm_.getUnigrams(reading);
+  bool wouldRemoveSingleReadingNode =
+      std::any_of(matchingSpans.cbegin(), matchingSpans.cend(),
+                  [](const MatchingSpan& span) { return span.length == 1; });
+  if (unigrams.empty() && wouldRemoveSingleReadingNode) {
+    return false;
+  }
+
+  for (const MatchingSpan& matchingSpan : matchingSpans) {
+    const NodePtr existingNode =
+        spans_[matchingSpan.position].nodeOf(matchingSpan.length);
+    if (unigrams.empty()) {
+      spans_[matchingSpan.position].removeNodeOfLength(matchingSpan.length);
+      continue;
+    }
+
+    auto refreshedNode =
+        std::make_shared<Node>(reading, matchingSpan.length, unigrams);
+    if (existingNode != nullptr) {
+      refreshedNode->restoreOverrideFrom(*existingNode);
+    }
+    spans_[matchingSpan.position].add(std::move(refreshedNode));
+  }
   return true;
 }
 
@@ -514,6 +544,13 @@ bool ReadingGrid::Node::selectOverrideUnigram(
   return false;
 }
 
+bool ReadingGrid::Node::restoreOverrideFrom(const Node& node) {
+  if (!node.isOverridden()) {
+    return false;
+  }
+  return selectOverrideUnigram(node.value(), node.overrideType_);
+}
+
 std::vector<ReadingGrid::NodePtr>::const_iterator
 ReadingGrid::WalkResult::findNodeAt(size_t cursor,
                                     size_t* outCursorPastNode) const {
@@ -583,6 +620,17 @@ void ReadingGrid::Span::add(const ReadingGrid::NodePtr& node) {
          node->spanningLength() <= kMaximumSpanLength);
   nodes_[node->spanningLength() - 1] = node;
   maxLength_ = std::max(maxLength_, node->spanningLength());
+}
+
+void ReadingGrid::Span::removeNodeOfLength(size_t length) {
+  assert(length > 0 && length <= kMaximumSpanLength);
+  nodes_[length - 1] = nullptr;
+  if (maxLength_ != length) {
+    return;
+  }
+  while (maxLength_ > 0 && nodes_[maxLength_ - 1] == nullptr) {
+    --maxLength_;
+  }
 }
 
 void ReadingGrid::Span::removeNodesOfOrLongerThan(size_t length) {

--- a/Source/Engine/gramambular2/reading_grid.cpp
+++ b/Source/Engine/gramambular2/reading_grid.cpp
@@ -98,6 +98,28 @@ bool ReadingGrid::deleteReadingAfterCursor() {
   return true;
 }
 
+bool ReadingGrid::refresh() {
+  std::vector<Span> refreshedSpans(readings_.size());
+  for (size_t pos = 0; pos < readings_.size(); ++pos) {
+    size_t maximumLength = std::min(kMaximumSpanLength, readings_.size() - pos);
+    for (size_t len = 1; len <= maximumLength; ++len) {
+      std::string combinedReading =
+          combineReading(readings_.begin() + static_cast<ptrdiff_t>(pos),
+                         readings_.begin() + static_cast<ptrdiff_t>(pos + len));
+      auto unigrams = lm_.getUnigrams(combinedReading);
+      if (!unigrams.empty()) {
+        refreshedSpans[pos].add(std::make_shared<Node>(
+            std::move(combinedReading), len, std::move(unigrams)));
+      }
+    }
+    if (refreshedSpans[pos].nodeOf(1) == nullptr) {
+      return false;
+    }
+  }
+  spans_ = std::move(refreshedSpans);
+  return true;
+}
+
 std::optional<ReadingGrid::NodePtr> ReadingGrid::findInSpan(
     size_t cursor, const std::function<bool(const NodePtr&)>& predicate) const {
   assert(cursor <= readings_.size());

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -75,9 +75,10 @@ class ReadingGrid {
   // Delete the reading after the cursor, like Del. Cursor is unmoved.
   bool deleteReadingAfterCursor();
 
-  // Rebuild all nodes using the current language model while preserving the
-  // readings and cursor.
-  bool refresh();
+  // Adds, replaces, or removes nodes in every span whose combined reading
+  // matches the given reading using the current language model. Other nodes,
+  // readings, and the cursor are preserved.
+  bool refreshNodesForReading(const std::string& reading);
 
   static constexpr size_t kMaximumSpanLength = 8;
   static constexpr char kDefaultSeparator[] = "-";
@@ -146,6 +147,9 @@ class ReadingGrid {
     void reset();
 
     bool selectOverrideUnigram(const std::string& value, OverrideType type);
+
+    // Restores another node's override if the same unigram still exists.
+    bool restoreOverrideFrom(const Node& node);
 
     // A sufficiently high score to cause the walk to go through an overriding
     // node. Although this can be 0, setting it to a positive value has the
@@ -248,6 +252,7 @@ class ReadingGrid {
    public:
     void clear();
     void add(const NodePtr& node);
+    void removeNodeOfLength(size_t length);
     void removeNodesOfOrLongerThan(size_t length);
     [[nodiscard]] const NodePtr& nodeOf(size_t length) const;
     [[nodiscard]] size_t maxLength() const { return maxLength_; }

--- a/Source/Engine/gramambular2/reading_grid.h
+++ b/Source/Engine/gramambular2/reading_grid.h
@@ -75,6 +75,10 @@ class ReadingGrid {
   // Delete the reading after the cursor, like Del. Cursor is unmoved.
   bool deleteReadingAfterCursor();
 
+  // Rebuild all nodes using the current language model while preserving the
+  // readings and cursor.
+  bool refresh();
+
   static constexpr size_t kMaximumSpanLength = 8;
   static constexpr char kDefaultSeparator[] = "-";
 

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -384,26 +384,226 @@ TEST(ReadingGridTest, DeletionOnlyQueriesSpansCrossingTheEdit) {
   EXPECT_EQ(grid.spans()[0].nodeOf(1)->reading(), "c");
 }
 
-TEST(ReadingGridTest, RefreshAfterLanguageModelChange) {
-  auto lm = std::make_shared<SimpleLM>(kSampleData);
+TEST(ReadingGridTest, RefreshNodesForReadingAddsAndRemovesMatchingNodes) {
+  constexpr char kData[] = R"(
+ㄍㄠ 高 -1
+ㄎㄜ 科 -1
+)";
+  auto lm = std::make_shared<SimpleLM>(kData);
   ReadingGrid grid(lm);
-  grid.setReadingSeparator("");
   ASSERT_TRUE(grid.insertReading("ㄍㄠ"));
   ASSERT_TRUE(grid.insertReading("ㄎㄜ"));
-  ASSERT_EQ(grid.cursor(), 2);
-  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
+  ASSERT_TRUE(grid.insertReading("ㄍㄠ"));
+  ASSERT_TRUE(grid.insertReading("ㄎㄜ"));
+  ASSERT_EQ(grid.cursor(), 4);
+  EXPECT_FALSE(Contains(grid.candidatesAt(0), "高科"));
+  EXPECT_FALSE(Contains(grid.candidatesAt(2), "高科"));
+  auto displayedWalk = grid.walk();
 
-  lm->setUnigrams("ㄍㄠㄎㄜ", {LanguageModel::Unigram("高科", 0)});
-  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
-  ASSERT_TRUE(grid.refresh());
-  EXPECT_TRUE(Contains(grid.candidatesAt(1), "高科"));
-  EXPECT_EQ(grid.cursor(), 2);
+  lm->setUnigrams("ㄍㄠ-ㄎㄜ", {LanguageModel::Unigram("高科", 0)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄍㄠ-ㄎㄜ"));
+  EXPECT_TRUE(Contains(grid.candidatesAt(0), "高科"));
+  EXPECT_TRUE(Contains(grid.candidatesAt(2), "高科"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"高", "科", "高", "科"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"高科", "高科"}));
+  EXPECT_EQ(grid.cursor(), 4);
 
-  lm->removeUnigrams("ㄍㄠㄎㄜ");
-  EXPECT_TRUE(Contains(grid.candidatesAt(1), "高科"));
-  ASSERT_TRUE(grid.refresh());
-  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
-  EXPECT_EQ(grid.cursor(), 2);
+  lm->removeUnigrams("ㄍㄠ-ㄎㄜ");
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄍㄠ-ㄎㄜ"));
+  EXPECT_FALSE(Contains(grid.candidatesAt(0), "高科"));
+  EXPECT_FALSE(Contains(grid.candidatesAt(2), "高科"));
+  EXPECT_EQ(grid.cursor(), 4);
+}
+
+TEST(ReadingGridTest, RefreshNodesForReadingDoesNotRemoveSingleReadingNode) {
+  constexpr char kData[] = R"(
+ㄕˋ 是 -1
+)";
+  auto lm = std::make_shared<SimpleLM>(kData);
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  const auto originalNode = grid.spans()[0].nodeOf(1);
+  ASSERT_NE(originalNode, nullptr);
+
+  lm->removeUnigrams("ㄕˋ");
+  EXPECT_FALSE(grid.refreshNodesForReading("ㄕˋ"));
+  EXPECT_EQ(grid.spans()[0].nodeOf(1), originalNode);
+  EXPECT_EQ(grid.walk().valuesAsStrings(), (std::vector<std::string>{"是"}));
+}
+
+TEST(ReadingGridTest,
+     RefreshRepeatedReadingPreservesExistingWalkWithCandidateOverride) {
+  constexpr char kData[] = R"(
+ㄕˋ 是 -1
+ㄕˋ 事 -2
+ㄐㄧㄡˋ 就 -1
+ㄕˋ-ㄕˋ 試試 -1
+ㄕˋ-ㄕˋ 逝世 -2
+)";
+  auto lm = std::make_shared<SimpleLM>(kData);
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄐㄧㄡˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  // This is a transient ReadingGrid candidate override, not an observation in
+  // UserOverrideModel.
+  ASSERT_TRUE(grid.overrideCandidate(0, "逝世"));
+  ASSERT_TRUE(grid.overrideCandidate(3, "是"));
+  ASSERT_TRUE(grid.overrideCandidate(4, "事"));
+  const auto originalFirstCharacterNode = grid.spans()[3].nodeOf(1);
+  const auto originalSecondCharacterNode = grid.spans()[4].nodeOf(1);
+  ASSERT_NE(originalFirstCharacterNode, nullptr);
+  ASSERT_NE(originalSecondCharacterNode, nullptr);
+  ASSERT_TRUE(originalFirstCharacterNode->isOverridden());
+  ASSERT_TRUE(originalSecondCharacterNode->isOverridden());
+  EXPECT_EQ(originalFirstCharacterNode->value(), "是");
+  EXPECT_EQ(originalSecondCharacterNode->value(), "事");
+  auto displayedWalk = grid.walk();
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "是", "事"}));
+  const auto originalFrontNode = grid.spans()[0].nodeOf(2);
+  const auto originalBackNode = grid.spans()[3].nodeOf(2);
+  ASSERT_NE(originalFrontNode, nullptr);
+  ASSERT_NE(originalBackNode, nullptr);
+
+  // Model 是事 being added after its two characters were selected separately
+  // at the second ㄕˋ-ㄕˋ occurrence. Both matching phrase nodes are refreshed,
+  // while the existing walk keeps its original nodes.
+  lm->setUnigrams("ㄕˋ-ㄕˋ", {LanguageModel::Unigram("是事", 0),
+                              LanguageModel::Unigram("試試", -1),
+                              LanguageModel::Unigram("逝世", -2)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  const auto addedFrontNode = grid.spans()[0].nodeOf(2);
+  const auto addedBackNode = grid.spans()[3].nodeOf(2);
+  ASSERT_NE(addedFrontNode, nullptr);
+  ASSERT_NE(addedBackNode, nullptr);
+  EXPECT_NE(addedFrontNode, originalFrontNode);
+  EXPECT_NE(addedBackNode, originalBackNode);
+  EXPECT_TRUE(addedFrontNode->isOverridden());
+  EXPECT_EQ(addedFrontNode->value(), "逝世");
+  EXPECT_EQ(grid.spans()[3].nodeOf(1), originalFirstCharacterNode);
+  EXPECT_EQ(grid.spans()[4].nodeOf(1), originalSecondCharacterNode);
+  EXPECT_TRUE(Contains(grid.candidatesAt(0), "是事"));
+  EXPECT_TRUE(Contains(grid.candidatesAt(3), "是事"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "是", "事"}));
+
+  // Model the language model state after boosting 逝世 and excluding 試試.
+  lm->setUnigrams("ㄕˋ-ㄕˋ", {LanguageModel::Unigram("逝世", 0),
+                              LanguageModel::Unigram("是事", 0)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  const auto replacedFrontNode = grid.spans()[0].nodeOf(2);
+  const auto replacedBackNode = grid.spans()[3].nodeOf(2);
+  ASSERT_NE(replacedFrontNode, nullptr);
+  ASSERT_NE(replacedBackNode, nullptr);
+  EXPECT_NE(replacedFrontNode, addedFrontNode);
+  EXPECT_NE(replacedBackNode, addedBackNode);
+  EXPECT_TRUE(replacedFrontNode->isOverridden());
+  EXPECT_EQ(replacedFrontNode->value(), "逝世");
+  EXPECT_FALSE(Contains(grid.candidatesAt(3), "試試"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "是", "事"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "是", "事"}));
+
+  // Model all phrases for ㄕˋ-ㄕˋ being removed.
+  lm->removeUnigrams("ㄕˋ-ㄕˋ");
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  EXPECT_EQ(grid.spans()[0].nodeOf(2), nullptr);
+  EXPECT_EQ(grid.spans()[3].nodeOf(2), nullptr);
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "是", "事"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"是", "是", "就", "是", "事"}));
+}
+
+TEST(ReadingGridTest,
+     RefreshRepeatedReadingPreservesExistingWalkWithoutCandidateOverride) {
+  constexpr char kData[] = R"(
+ㄕˋ 是 -1
+ㄕˋ 事 -2
+ㄐㄧㄡˋ 就 -1
+ㄕˋ-ㄕˋ 試試 -1
+ㄕˋ-ㄕˋ 逝世 -2
+)";
+  auto lm = std::make_shared<SimpleLM>(kData);
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄐㄧㄡˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  auto displayedWalk = grid.walk();
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"試試", "就", "試試"}));
+
+  lm->setUnigrams("ㄕˋ-ㄕˋ", {LanguageModel::Unigram("世事", 0),
+                              LanguageModel::Unigram("試試", -1),
+                              LanguageModel::Unigram("逝世", -2)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"試試", "就", "試試"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"世事", "就", "世事"}));
+
+  lm->setUnigrams("ㄕˋ-ㄕˋ", {LanguageModel::Unigram("逝世", 0)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"試試", "就", "試試"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "逝世"}));
+
+  lm->removeUnigrams("ㄕˋ-ㄕˋ");
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  EXPECT_EQ(grid.spans()[0].nodeOf(2), nullptr);
+  EXPECT_EQ(grid.spans()[3].nodeOf(2), nullptr);
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"試試", "就", "試試"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"是", "是", "就", "是", "是"}));
+}
+
+TEST(ReadingGridTest,
+     RefreshRepeatedReadingDoesNotRestoreMissingCandidateOverride) {
+  constexpr char kData[] = R"(
+ㄕˋ 是 -1
+ㄕˋ 事 -2
+ㄐㄧㄡˋ 就 -1
+ㄕˋ-ㄕˋ 試試 -1
+ㄕˋ-ㄕˋ 逝世 -2
+)";
+  auto lm = std::make_shared<SimpleLM>(kData);
+  ReadingGrid grid(lm);
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄐㄧㄡˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.insertReading("ㄕˋ"));
+  ASSERT_TRUE(grid.overrideCandidate(0, "逝世"));
+  auto displayedWalk = grid.walk();
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "試試"}));
+
+  // Model the language model state after 逝世 is excluded. The refreshed
+  // nodes cannot restore that candidate override, while the existing walk
+  // continues to hold its original nodes.
+  lm->setUnigrams("ㄕˋ-ㄕˋ", {LanguageModel::Unigram("試試", -1)});
+  ASSERT_TRUE(grid.refreshNodesForReading("ㄕˋ-ㄕˋ"));
+  const auto refreshedFrontNode = grid.spans()[0].nodeOf(2);
+  const auto refreshedBackNode = grid.spans()[3].nodeOf(2);
+  ASSERT_NE(refreshedFrontNode, nullptr);
+  ASSERT_NE(refreshedBackNode, nullptr);
+  EXPECT_FALSE(refreshedFrontNode->isOverridden());
+  EXPECT_FALSE(Contains(grid.candidatesAt(0), "逝世"));
+  EXPECT_FALSE(Contains(grid.candidatesAt(3), "逝世"));
+  EXPECT_EQ(displayedWalk.valuesAsStrings(),
+            (std::vector<std::string>{"逝世", "就", "試試"}));
+  EXPECT_EQ(grid.walk().valuesAsStrings(),
+            (std::vector<std::string>{"試試", "就", "試試"}));
 }
 
 TEST(ReadingGridTest, InsertReadingAcceptsReadingOwnedByGrid) {

--- a/Source/Engine/gramambular2/reading_grid_test.cpp
+++ b/Source/Engine/gramambular2/reading_grid_test.cpp
@@ -154,6 +154,12 @@ class SimpleLM : public LanguageModel {
     return db_.find(key) != db_.end();
   }
 
+  void setUnigrams(const std::string& key, std::vector<Unigram> unigrams) {
+    db_[key] = std::move(unigrams);
+  }
+
+  void removeUnigrams(const std::string& key) { db_.erase(key); }
+
  protected:
   std::map<std::string, std::vector<Unigram>> db_;
 };
@@ -376,6 +382,28 @@ TEST(ReadingGridTest, DeletionOnlyQueriesSpansCrossingTheEdit) {
   ASSERT_EQ(grid.readings(), (std::vector<std::string>{"c"}));
   ASSERT_NE(grid.spans()[0].nodeOf(1), nullptr);
   EXPECT_EQ(grid.spans()[0].nodeOf(1)->reading(), "c");
+}
+
+TEST(ReadingGridTest, RefreshAfterLanguageModelChange) {
+  auto lm = std::make_shared<SimpleLM>(kSampleData);
+  ReadingGrid grid(lm);
+  grid.setReadingSeparator("");
+  ASSERT_TRUE(grid.insertReading("ㄍㄠ"));
+  ASSERT_TRUE(grid.insertReading("ㄎㄜ"));
+  ASSERT_EQ(grid.cursor(), 2);
+  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
+
+  lm->setUnigrams("ㄍㄠㄎㄜ", {LanguageModel::Unigram("高科", 0)});
+  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
+  ASSERT_TRUE(grid.refresh());
+  EXPECT_TRUE(Contains(grid.candidatesAt(1), "高科"));
+  EXPECT_EQ(grid.cursor(), 2);
+
+  lm->removeUnigrams("ㄍㄠㄎㄜ");
+  EXPECT_TRUE(Contains(grid.candidatesAt(1), "高科"));
+  ASSERT_TRUE(grid.refresh());
+  EXPECT_FALSE(Contains(grid.candidatesAt(1), "高科"));
+  EXPECT_EQ(grid.cursor(), 2);
 }
 
 TEST(ReadingGridTest, InsertReadingAcceptsReadingOwnedByGrid) {

--- a/Source/InputMethodController+KeyHandlerDelegate.swift
+++ b/Source/InputMethodController+KeyHandlerDelegate.swift
@@ -92,9 +92,11 @@ extension McBopomofoInputMethodController: KeyHandlerDelegate {
         if !state.validToWrite {
             return false
         }
-        LanguageModelManager.writeUserPhrase(state.userPhrase)
-        runUserPhraseHookIfEnabled(text: state.selectedText)
-        return true
+        let result = LanguageModelManager.writeUserPhrase(state.userPhrase)
+        if result {
+            runUserPhraseHookIfEnabled(text: state.selectedText)
+        }
+        return result
     }
 
     func keyHandler(

--- a/Source/InputState.swift
+++ b/Source/InputState.swift
@@ -388,14 +388,8 @@ class InputState: NSObject {
                 return false
             }
 
-            let (exactBegin, _) = (composingBuffer as NSString).characterIndex(
-                from: markedRange.location)
-            let (exactEnd, _) = (composingBuffer as NSString).characterIndex(
-                from: markedRange.location + markedRange.length)
-            let selectedReadings = readings[exactBegin..<exactEnd]
-
-            let joined = selectedReadings.joined(separator: "-")
-            let exist = LanguageModelManager.checkIfExist(userPhrase: text, key: joined)
+            let exist = LanguageModelManager.checkIfExist(
+                userPhrase: text, key: selectedReading)
             if exist {
                 tooltip = String(
                     format: NSLocalizedString(
@@ -475,15 +469,17 @@ class InputState: NSObject {
             (composingBuffer as NSString).substring(with: markedRange)
         }
 
-        @objc var userPhrase: String {
-            let text = (composingBuffer as NSString).substring(with: markedRange)
+        @objc var selectedReading: String {
             let (exactBegin, _) = (composingBuffer as NSString).characterIndex(
                 from: markedRange.location)
             let (exactEnd, _) = (composingBuffer as NSString).characterIndex(
                 from: markedRange.location + markedRange.length)
             let selectedReadings = readings[exactBegin..<exactEnd]
-            let joined = selectedReadings.joined(separator: "-")
-            return "\(text) \(joined)"
+            return selectedReadings.joined(separator: "-")
+        }
+
+        @objc var userPhrase: String {
+            "\(selectedText) \(selectedReading)"
         }
     }
 

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1327,13 +1327,13 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             errorCallback();
             return YES;
         }
-        if (![self.delegate keyHandlerDidRequestReloadLanguageModel:self] || !_grid->refresh()) {
+        if (![self.delegate keyHandlerDidRequestReloadLanguageModel:self] ||
+            !_grid->refreshNodesForReading(state.selectedReading.UTF8String)) {
             errorCallback();
             stateCallback(state);
             return YES;
         }
-        [self _walk];
-        InputStateInputting *inputting = (InputStateInputting *)[self buildInputtingState];
+        InputStateInputting *inputting = [state convertToInputting];
         stateCallback(inputting);
         return YES;
     }
@@ -1564,12 +1564,11 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     }
                     if (![strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading] ||
                         ![strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf] ||
-                        !strongSelf->_grid->refresh()) {
+                        !strongSelf->_grid->refreshNodesForReading(reading.UTF8String)) {
                         errorCallback();
                         stateCallback(currentState);
                         return;
                     }
-                    [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
                 };
@@ -1584,12 +1583,11 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     }
                     if (![strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading] ||
                         ![strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf] ||
-                        !strongSelf->_grid->refresh()) {
+                        !strongSelf->_grid->refreshNodesForReading(reading.UTF8String)) {
                         errorCallback();
                         stateCallback(currentState);
                         return;
                     }
-                    [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
                 };

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -1327,6 +1327,12 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
             errorCallback();
             return YES;
         }
+        if (![self.delegate keyHandlerDidRequestReloadLanguageModel:self] || !_grid->refresh()) {
+            errorCallback();
+            stateCallback(state);
+            return YES;
+        }
+        [self _walk];
         InputStateInputting *inputting = (InputStateInputting *)[self buildInputtingState];
         stateCallback(inputting);
         return YES;
@@ -1556,8 +1562,13 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     if (!strongSelf) {
                         return;
                     }
-                    [strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading];
-                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    if (![strongSelf.delegate keyHandler:strongSelf didRequestBoostScoreForPhrase:candidate.value reading:reading] ||
+                        ![strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf] ||
+                        !strongSelf->_grid->refresh()) {
+                        errorCallback();
+                        stateCallback(currentState);
+                        return;
+                    }
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);
@@ -1571,8 +1582,13 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
                     if (!strongSelf) {
                         return;
                     }
-                    [strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading];
-                    [strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf];
+                    if (![strongSelf.delegate keyHandler:strongSelf didRequestExcludePhrase:candidate.value reading:reading] ||
+                        ![strongSelf.delegate keyHandlerDidRequestReloadLanguageModel:strongSelf] ||
+                        !strongSelf->_grid->refresh()) {
+                        errorCallback();
+                        stateCallback(currentState);
+                        return;
+                    }
                     [strongSelf _walk];
                     InputStateInputting *inputting = (InputStateInputting *)[strongSelf buildInputtingState];
                     stateCallback(inputting);


### PR DESCRIPTION
## Summary

This PR refreshes candidates after a user phrase is added, boosted, or excluded.

## Motivation

After adding `高科` as a user phrase, the language model was reloaded, but the existing `ReadingGrid` nodes still contained the old candidates. As a result, `高科` did not immediately appear in the candidate list.

Similarly, removing `高科` did not immediately remove it from the candidate list.

## Behavior

After the language model is reloaded:

- Nodes matching the changed reading are added, replaced, or removed.
- Every occurrence of the same reading in the grid is refreshed.
- Other nodes, readings, and the cursor remain unchanged.
- The current composition remains unchanged until a later normal walk.
- Valid candidate overrides are preserved.

## Notes

`ReadingGrid::walk()` only selects a path from the nodes already in the grid. It does not query the language model again.

This change refreshes only the nodes matching the updated reading instead of rebuilding the entire grid.

## Testing

Added tests covering:

- Adding and removing `高科` candidates.
- Refreshing repeated readings.
- Preserving the current walk and valid candidate overrides.
- Removing an excluded candidate override.
- Preserving required single-reading nodes.

All 32 `ReadingGridTest` tests pass.