### PR TITLE
feat(input): add Option-key direct input

### DIFF
--- a/McBopomofoTests/KeyHandlerBopomofoTests.swift
+++ b/McBopomofoTests/KeyHandlerBopomofoTests.swift
@@ -22,6 +22,7 @@
 // OTHER DEALINGS IN THE SOFTWARE.
 
 import CandidateUI
+import Carbon.HIToolbox
 import XCTest
 
 @testable import McBopomofo
@@ -537,6 +538,217 @@ class KeyHandlerBopomofoTests: XCTestCase {
         XCTAssertTrue(state is InputState.Inputting, "\(state)")
         if let state = state as? InputState.Inputting {
             XCTAssertEqual(state.composingBuffer, "一a")
+        }
+    }
+
+    func testOptionKeyDirectInputDoesNotHandleWhenDisabled() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = false
+
+        let input = KeyHandlerInput(
+            inputText: "å", keyCode: 0, charCode: charCode("å"), flags: .option,
+            isVerticalMode: false, inputTextIgnoringModifiers: "å", directInputText: "a")
+        var state: InputState = InputState.Empty()
+
+        let result = handler.handle(input: input, state: state) { newState in
+            state = newState
+        } errorCallback: {
+        }
+
+        XCTAssertFalse(result)
+        XCTAssertTrue(state is InputState.Empty, "\(state)")
+    }
+
+    func testOptionKeyDirectInputAcceptsValidDirectInputText() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        let texts = Array(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890-=[]\\;',./`éß€"
+        ).map(String.init) + ["e\u{301}", "ss"]
+
+        for text in texts {
+            let input = KeyHandlerInput(
+                inputText: "modified", keyCode: 0, charCode: 0, flags: .option,
+                isVerticalMode: false, inputTextIgnoringModifiers: "modified",
+                directInputText: text)
+            var state: InputState = InputState.Empty()
+            var committedText: String?
+
+            let result = handler.handle(input: input, state: state) { newState in
+                state = newState
+                if let committing = newState as? InputState.Committing {
+                    committedText = committing.poppedText
+                }
+            } errorCallback: {
+            }
+
+            XCTAssertTrue(input.isValidDirectInputText, "Expected \(text) to be valid")
+            XCTAssertTrue(result, "Expected Option + \(text) to be handled")
+            XCTAssertEqual(committedText, text)
+            XCTAssertTrue(state is InputState.Empty, "\(state)")
+        }
+    }
+
+    func testOptionKeyDirectInputRejectsInvalidDirectInputText() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        let texts: [String?] = [nil, "", " ", "a b", "\n", "\u{F700}"]
+
+        for text in texts {
+            let input = KeyHandlerInput(
+                inputText: "modified", keyCode: 0, charCode: 0, flags: .option,
+                isVerticalMode: false, inputTextIgnoringModifiers: "modified",
+                directInputText: text)
+            var state: InputState = InputState.Empty()
+
+            XCTAssertFalse(input.isValidDirectInputText, "Expected \(String(describing: text)) to be invalid")
+            let result = handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+
+            XCTAssertFalse(result)
+            XCTAssertTrue(state is InputState.Empty, "\(state)")
+        }
+    }
+
+    func testOptionKeyDirectInputUsesTranslatedTextInsteadOfPhysicalKeyCode() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        let input = KeyHandlerInput(
+            inputText: "", keyCode: UInt16(kVK_ANSI_Q), charCode: 0, flags: .option,
+            isVerticalMode: false, inputTextIgnoringModifiers: "'", directInputText: "'")
+        var state: InputState = InputState.Empty()
+        var committedText = ""
+
+        let result = handler.handle(input: input, state: state) { newState in
+            state = newState
+            if let committing = newState as? InputState.Committing {
+                committedText += committing.poppedText
+            }
+        } errorCallback: {
+        }
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(committedText, "'")
+        XCTAssertTrue(state is InputState.Empty, "\(state)")
+    }
+
+    func testOptionKeyDirectInputTranslatesDeadKeysToBaseCharacters() throws {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        let inputs: [(keyCode: Int, accent: String, expected: String)] = [
+            (kVK_ANSI_E, "´", "e"),
+            (kVK_ANSI_U, "¨", "u"),
+            (kVK_ANSI_I, "ˆ", "i"),
+            (kVK_ANSI_N, "˜", "n"),
+        ]
+
+        for (keyCode, accent, expected) in inputs {
+            let event = try XCTUnwrap(
+                NSEvent.keyEvent(
+                    with: .keyDown, location: .zero, modifierFlags: .option, timestamp: 0,
+                    windowNumber: 0, context: nil, characters: accent,
+                    charactersIgnoringModifiers: accent, isARepeat: false,
+                    keyCode: UInt16(keyCode)))
+            let input = KeyHandlerInput(event: event, isVerticalMode: false)
+            var state: InputState = InputState.Empty()
+            var committedText: String?
+
+            XCTAssertEqual(input.directInputText, expected)
+            let result = handler.handle(input: input, state: state) { newState in
+                state = newState
+                if let committing = newState as? InputState.Committing {
+                    committedText = committing.poppedText
+                }
+            } errorCallback: {
+            }
+
+            XCTAssertTrue(result)
+            XCTAssertEqual(committedText, expected)
+            XCTAssertTrue(state is InputState.Empty, "\(state)")
+        }
+    }
+
+    func testOptionKeyDirectInputCommitsExistingCompositionFirst() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        var state: InputState = InputState.Empty()
+        for key in ["u", "6"] {
+            let input = KeyHandlerInput(
+                inputText: key, keyCode: 0, charCode: charCode(key), flags: [],
+                isVerticalMode: false)
+            handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+        }
+
+        var committedTexts: [String] = []
+        let input = KeyHandlerInput(
+            inputText: "´", keyCode: 0, charCode: charCode("´"), flags: .option,
+            isVerticalMode: false, inputTextIgnoringModifiers: "´", directInputText: "e")
+        let result = handler.handle(input: input, state: state) { newState in
+            state = newState
+            if let committing = newState as? InputState.Committing {
+                committedTexts.append(committing.poppedText)
+            }
+        } errorCallback: {
+        }
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(committedTexts, ["一", "e"])
+        XCTAssertTrue(state is InputState.Empty, "\(state)")
+    }
+
+    func testOptionKeyDirectInputPreservesOtherModifierCombinations() {
+        let current = Preferences.optionKeyDirectInputEnabled
+        addTeardownBlock {
+            Preferences.optionKeyDirectInputEnabled = current
+        }
+        Preferences.optionKeyDirectInputEnabled = true
+
+        let modifierCombinations: [NSEvent.ModifierFlags] = [
+            [.option, .shift], [.option, .command], [.option, .control],
+        ]
+
+        for flags in modifierCombinations {
+            let input = KeyHandlerInput(
+                inputText: "modified", keyCode: 0, charCode: 0, flags: flags,
+                isVerticalMode: false, inputTextIgnoringModifiers: "modified",
+                directInputText: "a")
+            var state: InputState = InputState.Empty()
+
+            let result = handler.handle(input: input, state: state) { newState in
+                state = newState
+            } errorCallback: {
+            }
+
+            XCTAssertFalse(result, "Expected \(flags) to preserve the existing behavior")
+            XCTAssertTrue(state is InputState.Empty, "\(state)")
         }
     }
 

--- a/McBopomofoTests/PreferencesTests.swift
+++ b/McBopomofoTests/PreferencesTests.swift
@@ -82,6 +82,14 @@ final class PreferencesTests {
         #expect(Preferences.basisKeyboardLayout == "com.apple.keylayout.ABC")
     }
 
+    @Test("Test Option key direct input setting")
+    func testOptionKeyDirectInputEnabled() {
+        #expect(Preferences.optionKeyDirectInputEnabled == false)
+        Preferences.optionKeyDirectInputEnabled = true
+        #expect(Preferences.optionKeyDirectInputEnabled == true)
+        #expect(UserDefaults.standard.bool(forKey: "OptionKeyDirectInputEnabled"))
+    }
+
     @Test("Test function keyboard layout setting")
     func testFunctionKeyboardLayout() {
         #expect(Preferences.functionKeyboardLayout == "com.apple.keylayout.US")

--- a/Source/Base.lproj/Localizable.strings
+++ b/Source/Base.lproj/Localizable.strings
@@ -212,6 +212,8 @@
 "Shift + Letter Keys:" = "Shift + Letter Keys:";
 "Input uppercase letters directly" = "Input uppercase letters directly";
 "Input lowercased letters to buffer" = "Input lowercased letters to buffer";
+"Option + Key:" = "Option + Key:";
+"Input letters, numbers, punctuation, and symbols directly" = "Input letters, numbers, punctuation, and symbols directly";
 "ESC Key:" = "ESC Key:";
 "Beep upon input error" = "Beep upon input error";
 "Trigger associated phrases" = "Trigger associated phrases";

--- a/Source/KeyHandler.mm
+++ b/Source/KeyHandler.mm
@@ -367,6 +367,18 @@ InputMode InputModePlainBopomofo = @"org.openvanilla.inputmethod.McBopomofo.Plai
         return YES;
     }
 
+    if (Preferences.optionKeyDirectInputEnabled && input.isOptionHold &&
+        !input.isShiftHold && !input.isCommandHold && !input.isControlHold) {
+        NSString *directText = input.directInputText;
+        if (input.isValidDirectInputText) {
+            [self handleForceCommitWithStateCallback:stateCallback];
+            InputStateCommitting *committingState = [[InputStateCommitting alloc] initWithPoppedText:directText];
+            stateCallback(committingState);
+            stateCallback([[InputStateEmpty alloc] init]);
+            return YES;
+        }
+    }
+
     // if the inputText is empty, it's a function key combination, we ignore it
     if (!input.inputText.length) {
         return NO;

--- a/Source/KeyHandlerInput.swift
+++ b/Source/KeyHandlerInput.swift
@@ -39,9 +39,15 @@ enum KeyCode: UInt16 {
 }
 
 class KeyHandlerInput: NSObject {
+    private static let allowedDirectInputCharacterSet = CharacterSet.alphanumerics
+        .union(.punctuationCharacters)
+        .union(.symbols)
+        .union(.nonBaseCharacters)
+
     @objc private(set) var useVerticalMode: Bool
     @objc private(set) var inputText: String?
     @objc private(set) var inputTextIgnoringModifiers: String?
+    @objc private(set) var directInputText: String?
     @objc private(set) var charCode: UInt16
     @objc private(set) var keyCode: UInt16
     private var flags: NSEvent.ModifierFlags
@@ -52,9 +58,10 @@ class KeyHandlerInput: NSObject {
     private var verticalModeOnlyChooseCandidateKey: KeyCode
     @objc private(set) var emacsKey: McBopomofoEmacsKey
 
-    @objc init(inputText: String?, keyCode: UInt16, charCode: UInt16, flags: NSEvent.ModifierFlags, isVerticalMode: Bool, inputTextIgnoringModifiers: String? = nil) {
+    @objc init(inputText: String?, keyCode: UInt16, charCode: UInt16, flags: NSEvent.ModifierFlags, isVerticalMode: Bool, inputTextIgnoringModifiers: String? = nil, directInputText: String? = nil) {
         self.inputText = inputText
         self.inputTextIgnoringModifiers = inputTextIgnoringModifiers ?? inputText
+        self.directInputText = directInputText
         self.keyCode = keyCode
         self.charCode = charCode
         self.flags = flags
@@ -71,6 +78,7 @@ class KeyHandlerInput: NSObject {
     @objc init(event: NSEvent, isVerticalMode: Bool) {
         inputText = event.characters
         inputTextIgnoringModifiers = event.charactersIgnoringModifiers
+        directInputText = event.characters(byApplyingModifiers: [])
         keyCode = event.keyCode
         flags = event.modifierFlags
         useVerticalMode = isVerticalMode
@@ -92,7 +100,7 @@ class KeyHandlerInput: NSObject {
     }
 
     override var description: String {
-        return "<\(super.description) inputText:\(String(describing: inputText)), inputTextIgnoringModifiers:\(String(describing: inputTextIgnoringModifiers)) charCode:\(charCode), keyCode:\(keyCode), flags:\(flags), cursorForwardKey:\(cursorForwardKey), cursorBackwardKey:\(cursorBackwardKey), extraChooseCandidateKey:\(extraChooseCandidateKey), absorbedArrowKey:\(absorbedArrowKey),  verticalModeOnlyChooseCandidateKey:\(verticalModeOnlyChooseCandidateKey), emacsKey:\(emacsKey), useVerticalMode:\(useVerticalMode)>"
+        return "<\(super.description) inputText:\(String(describing: inputText)), inputTextIgnoringModifiers:\(String(describing: inputTextIgnoringModifiers)), directInputText:\(String(describing: directInputText)) charCode:\(charCode), keyCode:\(keyCode), flags:\(flags), cursorForwardKey:\(cursorForwardKey), cursorBackwardKey:\(cursorBackwardKey), extraChooseCandidateKey:\(extraChooseCandidateKey), absorbedArrowKey:\(absorbedArrowKey),  verticalModeOnlyChooseCandidateKey:\(verticalModeOnlyChooseCandidateKey), emacsKey:\(emacsKey), useVerticalMode:\(useVerticalMode)>"
     }
 
     @objc var isShiftHold: Bool {
@@ -121,6 +129,15 @@ class KeyHandlerInput: NSObject {
 
     @objc var isNumericPad: Bool {
         flags.contains([.numericPad])
+    }
+
+    @objc var isValidDirectInputText: Bool {
+        guard let directInputText, !directInputText.isEmpty else {
+            return false
+        }
+        return directInputText.unicodeScalars.allSatisfy {
+            Self.allowedDirectInputCharacterSet.contains($0)
+        }
     }
 
     @objc var isReservedKey: Bool {

--- a/Source/Preferences.swift
+++ b/Source/Preferences.swift
@@ -50,6 +50,7 @@ private let kPhraseReplacementEnabledKey = "PhraseReplacementEnabled"
 private let kChineseConversionStyleKey = "ChineseConversionStyle"
 private let kAssociatedPhrasesEnabledKey = "AssociatedPhrasesEnabled"
 private let kLetterBehaviorKey = "LetterBehavior"
+private let kOptionKeyDirectInputEnabledKey = "OptionKeyDirectInputEnabled"
 private let kControlEnterOutputKey = "ControlEnterOutput"
 private let kShiftEnterEnabledKey = "ShiftEnterEnabled"
 private let kRepeatedPunctuationToSelectCandidateEnabledKey =
@@ -230,6 +231,8 @@ class Preferences: NSObject {
             kPhraseReplacementEnabledKey,
             kChineseConversionStyleKey,
             kAssociatedPhrasesEnabledKey,
+            kLetterBehaviorKey,
+            kOptionKeyDirectInputEnabledKey,
             kControlEnterOutputKey,
             kShiftEnterEnabledKey,
             kRepeatedPunctuationToSelectCandidateEnabledKey,
@@ -256,6 +259,7 @@ class Preferences: NSObject {
         Preferences.phraseReplacementEnabled = Preferences.phraseReplacementEnabled
         Preferences.associatedPhrasesEnabled = Preferences.associatedPhrasesEnabled
         Preferences.letterBehavior = Preferences.letterBehavior
+        Preferences.optionKeyDirectInputEnabled = Preferences.optionKeyDirectInputEnabled
         Preferences.controlEnterOutput = Preferences.controlEnterOutput
         Preferences.shiftEnterEnabled = Preferences.shiftEnterEnabled
         Preferences.repeatedPunctuationToSelectCandidateEnabled =
@@ -486,6 +490,10 @@ extension Preferences {
     @UserDefault(key: kLetterBehaviorKey, defaultValue: 0)
     @objc static var letterBehavior: Int
 
+    /// Whether Option + a text key directly inputs letters, numbers, punctuation, and symbols.
+    @UserDefault(key: kOptionKeyDirectInputEnabledKey, defaultValue: false)
+    @objc static var optionKeyDirectInputEnabled: Bool
+
     /// The behavior of pressing Ctrl + Enter.
     ///
     /// - 0: Disabled.
@@ -651,6 +659,9 @@ extension Preferences {
         )
 
         lines.append("  - Letter Keys: \(Preferences.letterBehavior)")
+        lines.append(
+            "  - Option Key Direct Input: \(Preferences.optionKeyDirectInputEnabled ? "Enabled" : "Disabled")"
+        )
         lines.append("  - Ctrl + Enter Key: \(Preferences.controlEnterOutput.name)")
         lines.append(
             "  - Shift + Enter Key For Associated Phrases: \(Preferences.shiftEnterEnabled ? "Enabled" : "Disabled")"

--- a/Source/PreferencesUI/PreferencesModel.swift
+++ b/Source/PreferencesUI/PreferencesModel.swift
@@ -146,6 +146,14 @@ final class PreferencesViewModel: NSObject, ObservableObject {
         }
     }
 
+    var optionKeyDirectInputEnabled: Bool {
+        get { Preferences.optionKeyDirectInputEnabled }
+        set {
+            objectWillChange.send()
+            Preferences.optionKeyDirectInputEnabled = newValue
+        }
+    }
+
     var shiftEnterEnabled: Bool {
         get { Preferences.shiftEnterEnabled }
         set {

--- a/Source/PreferencesUI/PreferencesView.swift
+++ b/Source/PreferencesUI/PreferencesView.swift
@@ -499,6 +499,12 @@ private struct BasicPreferencesView: View {
                 .fixedSize()
             }
 
+            PreferenceRow(localized("Option + Key:")) {
+                Toggle(
+                    localized("Input letters, numbers, punctuation, and symbols directly"),
+                    isOn: $preferences.optionKeyDirectInputEnabled)
+            }
+
             PreferenceRow(localized("Shift + Enter Key:")) {
                 Toggle(
                     localized("Trigger associated phrases"), isOn: $preferences.shiftEnterEnabled)

--- a/Source/en.lproj/Localizable.strings
+++ b/Source/en.lproj/Localizable.strings
@@ -214,6 +214,8 @@
 "Shift + Letter Keys:" = "Shift + Letter Keys:";
 "Input uppercase letters directly" = "Input uppercase letters directly";
 "Input lowercased letters to buffer" = "Input lowercased letters to buffer";
+"Option + Key:" = "Option + Key:";
+"Input letters, numbers, punctuation, and symbols directly" = "Input letters, numbers, punctuation, and symbols directly";
 "ESC Key:" = "ESC Key:";
 "Beep upon input error" = "Beep upon input error";
 "Trigger associated phrases" = "Trigger associated phrases";

--- a/Source/zh-Hant.lproj/Localizable.strings
+++ b/Source/zh-Hant.lproj/Localizable.strings
@@ -212,6 +212,8 @@
 "Shift + Letter Keys:" = "Shift + 字母鍵：";
 "Input uppercase letters directly" = "直接輸入大寫字母";
 "Input lowercased letters to buffer" = "在輸入緩衝區中輸入小寫字母";
+"Option + Key:" = "Option + 按鍵：";
+"Input letters, numbers, punctuation, and symbols directly" = "直接輸入字母、數字、標點與符號";
 "ESC Key:" = "ESC 鍵：";
 "Beep upon input error" = "輸入錯誤時發出警示聲";
 "Trigger associated phrases" = "使用聯想詞功能";


### PR DESCRIPTION
## Summary

This PR adds an opt-in preference for directly entering letters, numbers, punctuation, and symbols with Option while using McBopomofo.

The preference is disabled by default to preserve existing behavior.

## Motivation

When typing Chinese, users often need to temporarily enter a few half-width letters, numbers, punctuation marks, or symbols, such as identifiers, URLs, commands, or inline code. Switching to a Latin input source and then switching back interrupts the typing flow for these brief inputs.

This option allows users to hold Option and enter the base keyboard-layout output directly while remaining in McBopomofo. It makes mixed Chinese and English input more convenient without introducing a persistent English mode or changing the default behavior.

## Behavior

When the preference is enabled:

- Option with a valid text key directly commits the key's base keyboard-layout output.
- An existing composition is committed before the direct input.
- Option-Shift, Option-Command, and Option-Control combinations retain their existing behavior.
- Spaces, newlines, function-key characters, and other unsupported text are not intercepted.

## Implementation

- Add `optionKeyDirectInputEnabled` to `Preferences`, defaults, snapshots, and diagnostic output.
- Add the preference to the Basic preferences UI with English, Base, and Traditional Chinese localizations.
- Derive `directInputText` with `NSEvent.characters(byApplyingModifiers: [])`.
- Validate the complete translated string as alphanumeric, punctuation, symbol, or non-base Unicode text.
- Use the translated text instead of deriving output from a physical key code.
- Force-commit an existing composition before committing the direct-input text.

## Testing

Added coverage for:

- Disabled preference behavior.
- Valid single-character, multi-scalar, and multi-character text.
- Empty, whitespace-containing, control, and function-key text.
- Keyboard-layout-translated output instead of physical key labels.
- Option dead keys for E, U, I, and N.
- Existing composition commit order.
- Preservation of Option-Shift, Option-Command, and Option-Control combinations.
- Preference defaults and `UserDefaults` persistence.

Focused KeyHandler and Preferences tests pass, and `git diff --check` reports no whitespace errors.